### PR TITLE
Add prow dataplane Helm charts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+.DS_store
+helm-charts/build
+*.swp
+release/bin/eks-distro-release
+release/cover.out
+.idea
+index.yaml

--- a/helm-charts/stable/prow-data-plane/.helmignore
+++ b/helm-charts/stable/prow-data-plane/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/helm-charts/stable/prow-data-plane/Chart.yaml
+++ b/helm-charts/stable/prow-data-plane/Chart.yaml
@@ -1,0 +1,23 @@
+apiVersion: v2
+name: prow-data-plane
+description: Prow data-plane Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.2.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+appVersion: 1.16.0

--- a/helm-charts/stable/prow-data-plane/README.md
+++ b/helm-charts/stable/prow-data-plane/README.md
@@ -1,0 +1,1 @@
+## Helm chart for Prow data-plane

--- a/helm-charts/stable/prow-data-plane/templates/crier-Role.yaml
+++ b/helm-charts/stable/prow-data-plane/templates/crier-Role.yaml
@@ -1,0 +1,19 @@
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: crier
+rules:
+- apiGroups:
+    - ""
+  resources:
+    - "pods"
+    - "events"
+  verbs:
+    - "get"
+    - "list"
+- apiGroups:
+    - ""
+  resources:
+    - "pods"
+  verbs:
+    - "patch"

--- a/helm-charts/stable/prow-data-plane/templates/crier-RoleBinding.yaml
+++ b/helm-charts/stable/prow-data-plane/templates/crier-RoleBinding.yaml
@@ -1,0 +1,12 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: crier
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: crier
+subjects:
+- kind: User
+  name: "crier"
+  apiGroup: rbac.authorization.k8s.io

--- a/helm-charts/stable/prow-data-plane/templates/deck-Role.yaml
+++ b/helm-charts/stable/prow-data-plane/templates/deck-Role.yaml
@@ -1,0 +1,11 @@
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: "deck"
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods/log
+    verbs:
+      - get

--- a/helm-charts/stable/prow-data-plane/templates/deck-RoleBinding.yaml
+++ b/helm-charts/stable/prow-data-plane/templates/deck-RoleBinding.yaml
@@ -1,0 +1,12 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: "deck"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: "deck"
+subjects:
+- kind: User
+  name: "deck"
+  apiGroup: rbac.authorization.k8s.io

--- a/helm-charts/stable/prow-data-plane/templates/hook-Role.yaml
+++ b/helm-charts/stable/prow-data-plane/templates/hook-Role.yaml
@@ -1,0 +1,13 @@
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: "hook"
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - create
+      - get
+      - update

--- a/helm-charts/stable/prow-data-plane/templates/hook-RoleBinding.yaml
+++ b/helm-charts/stable/prow-data-plane/templates/hook-RoleBinding.yaml
@@ -1,0 +1,12 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: "hook"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: "hook"
+subjects:
+- kind: User
+  name: "hook"
+  apiGroup: rbac.authorization.k8s.io

--- a/helm-charts/stable/prow-data-plane/templates/prow-controller-manager-Role.yaml
+++ b/helm-charts/stable/prow-data-plane/templates/prow-controller-manager-Role.yaml
@@ -1,0 +1,15 @@
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: prow-controller-manager
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - delete
+      - list
+      - watch
+      - create
+      - patch

--- a/helm-charts/stable/prow-data-plane/templates/prow-controller-manager-RoleBinding.yaml
+++ b/helm-charts/stable/prow-data-plane/templates/prow-controller-manager-RoleBinding.yaml
@@ -1,0 +1,12 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: prow-controller-manager
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: prow-controller-manager
+subjects:
+- kind: User
+  name: "prow-controller-manager"
+  apiGroup: rbac.authorization.k8s.io

--- a/helm-charts/stable/prow-data-plane/templates/s3-credentials-Secret.yaml
+++ b/helm-charts/stable/prow-data-plane/templates/s3-credentials-Secret.yaml
@@ -1,0 +1,16 @@
+{{ if .Values.s3Credentials.Secret.create }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: s3-credentials
+stringData:
+  service-account.json: |
+    {
+      "region": "{{ .Values.region }}",
+      "access_key": "",
+      "endpoint": "",
+      "insecure": false,
+      "s3_force_path_style": false,
+      "secret_key": ""
+    }
+{{ end }}

--- a/helm-charts/stable/prow-data-plane/templates/sinker-Role.yaml
+++ b/helm-charts/stable/prow-data-plane/templates/sinker-Role.yaml
@@ -1,0 +1,15 @@
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: "sinker"
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - delete
+      - list
+      - watch
+      - get
+      - patch

--- a/helm-charts/stable/prow-data-plane/templates/sinker-RoleBinding.yaml
+++ b/helm-charts/stable/prow-data-plane/templates/sinker-RoleBinding.yaml
@@ -1,0 +1,12 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: "sinker"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: "sinker"
+subjects:
+- kind: User
+  name: "sinker"
+  apiGroup: rbac.authorization.k8s.io

--- a/helm-charts/stable/prow-data-plane/values.yaml
+++ b/helm-charts/stable/prow-data-plane/values.yaml
@@ -1,0 +1,5 @@
+region: 'us-west-2'
+
+s3Credentials:
+  Secret:
+    create: true


### PR DESCRIPTION
Add Helm charts for Prow dataplane configuration.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
