### PR TITLE
Add SSL redirect rule to deck Ingress

### DIFF
--- a/helm-charts/stable/prow-control-plane/Chart.yaml
+++ b/helm-charts/stable/prow-control-plane/Chart.yaml
@@ -29,7 +29,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.8
+version: 0.3.9
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm-charts/stable/prow-control-plane/templates/deck-Ingress.yaml
+++ b/helm-charts/stable/prow-control-plane/templates/deck-Ingress.yaml
@@ -28,6 +28,10 @@ spec:
     http:
       paths:
       - backend:
+          serviceName: ssl-redirect
+          servicePort: use-annotation
+        path: /
+      - backend:
           serviceName: deck
           servicePort: 80
         path: /


### PR DESCRIPTION
Configure deck ingress to enable SSL redirect for HTTP.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
