### PR TITLE
Add GCC to install script

### DIFF
--- a/builder-base/install.sh
+++ b/builder-base/install.sh
@@ -33,6 +33,7 @@ yum install -y \
     awscli \
     amazon-ecr-credential-helper \
     curl \
+    gcc \
     git \
     jq \
     less \


### PR DESCRIPTION
Add GCC to installation script for builder-base.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
