### PR TITLE
Add build status badge for base postsubmits

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-## My Project
+## EKS Distro Build Tooling Repository
+
+[![Build status](https://prow.eks.amazonaws.com/badge.svg?jobs=*-base-postsubmit)](https://prow.eks.amazonaws.com/?type=postsubmit)
 
 TODO: Fill this README out!
 


### PR DESCRIPTION
Used test-infra badges as an example.

Test-infra README: https://github.com/kubernetes/test-infra/blob/master/README.md
Raw: https://raw.githubusercontent.com/kubernetes/test-infra/master/README.md
Badges info: https://github.com/kubernetes/test-infra/blob/061f85d85911b229fba3d4a57025414296349214/prow/jobs.md#badges

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
