### PR TITLE
Switch to artifact URLs for artifacts

### DIFF
--- a/release/api/v1alpha1/release_status.go
+++ b/release/api/v1alpha1/release_status.go
@@ -70,8 +70,8 @@ type Asset struct {
 
 type AssetArchive struct {
 	// +kubebuilder:validation:Required
-	// The path of the server at which the asset is located
-	Path string `json:"path,omitempty"`
+	// The URI where the asset is located
+	URI string `json:"uri,omitempty"`
 	// +kubebuilder:validation:Required
 	// The sha512 of the asset, only applies for 'file' store
 	SHA512 string `json:"sha512,omitempty"`

--- a/release/cmd/release.go
+++ b/release/cmd/release.go
@@ -39,10 +39,12 @@ var releaseCmd = &cobra.Command{
 		sourceDir := viper.GetString("source")
 		gitCommit := viper.GetString("git-commit")
 		imageRepository := viper.GetString("image-repository")
+		cdnURL := viper.GetString("cdn")
 		releaseNumber := viper.GetInt("release-number")
 
 		releaseConfig := &pkg.ReleaseConfig{
 			ContainerImageRepository: imageRepository,
+			ArtifactURL:              cdnURL,
 			BuildRepoSource:          sourceDir,
 			ReleaseDate:              time.Now().UTC(),
 		}
@@ -89,6 +91,7 @@ func init() {
 	// TODO: exec `git -C $SOURCE describe --always --long --abbrev=64 HEAD` instead of prompting
 	releaseCmd.Flags().String("git-commit", "", "The eks-distro git commit")
 	releaseCmd.Flags().String("image-repository", "", "The container image repository name")
+	releaseCmd.Flags().String("cdn", "https://distro.eks.amazonaws.com", "The URL base for artifacts")
 	releaseCmd.Flags().Int("release-number", 1, "The release-number to create")
 
 }

--- a/release/config/crds/distro.eks.amazonaws.com_releases.yaml
+++ b/release/config/crds/distro.eks.amazonaws.com_releases.yaml
@@ -77,10 +77,6 @@ spec:
                           type: array
                         archive:
                           properties:
-                            path:
-                              description: The path of the server at which the asset
-                                is located
-                              type: string
                             sha256:
                               description: The sha256 of the asset, only applies for
                                 'file' store
@@ -88,6 +84,9 @@ spec:
                             sha512:
                               description: The sha512 of the asset, only applies for
                                 'file' store
+                              type: string
+                            uri:
+                              description: The URI where the asset is located
                               type: string
                           type: object
                         description:

--- a/release/pkg/assets_authenticator.go
+++ b/release/pkg/assets_authenticator.go
@@ -45,6 +45,18 @@ func (r *ReleaseConfig) GetAuthenticatorComponent(spec distrov1alpha1.ReleaseSpe
 			if err != nil {
 				return nil, errors.Cause(err)
 			}
+			assetPath, err := r.GetURI(path.Join(
+				fmt.Sprintf("kubernetes-%s", spec.Channel),
+				"releases",
+				fmt.Sprintf("%d", spec.Number),
+				"artifacts",
+				"aws-iam-authenticator",
+				gitTag,
+				filename,
+			))
+			if err != nil {
+				return nil, errors.Cause(err)
+			}
 			assets = append(assets, distrov1alpha1.Asset{
 				Name:        filename,
 				Type:        "Archive",
@@ -52,15 +64,7 @@ func (r *ReleaseConfig) GetAuthenticatorComponent(spec distrov1alpha1.ReleaseSpe
 				OS:          os,
 				Arch:        []string{arch},
 				Archive: &distrov1alpha1.AssetArchive{
-					Path: path.Join(
-						fmt.Sprintf("kubernetes-%s", spec.Channel),
-						"releases",
-						fmt.Sprintf("%d", spec.Number),
-						"artifacts",
-						"aws-iam-authenticator",
-						gitTag,
-						filename,
-					),
+					URI:    assetPath,
 					SHA512: sha512,
 					SHA256: sha256,
 				},

--- a/release/pkg/assets_cni.go
+++ b/release/pkg/assets_cni.go
@@ -43,6 +43,18 @@ func (r *ReleaseConfig) GetCniComponent(spec distrov1alpha1.ReleaseSpec) (*distr
 			if err != nil {
 				return nil, errors.Cause(err)
 			}
+			assetPath, err := r.GetURI(path.Join(
+				fmt.Sprintf("kubernetes-%s", spec.Channel),
+				"releases",
+				fmt.Sprintf("%d", spec.Number),
+				"artifacts",
+				"plugins",
+				gitTag,
+				filename,
+			))
+			if err != nil {
+				return nil, errors.Cause(err)
+			}
 			assets = append(assets, distrov1alpha1.Asset{
 				Name:        filename,
 				Type:        "Archive",
@@ -50,15 +62,7 @@ func (r *ReleaseConfig) GetCniComponent(spec distrov1alpha1.ReleaseSpec) (*distr
 				OS:          os,
 				Arch:        []string{arch},
 				Archive: &distrov1alpha1.AssetArchive{
-					Path: path.Join(
-						fmt.Sprintf("kubernetes-%s", spec.Channel),
-						"releases",
-						fmt.Sprintf("%d", spec.Number),
-						"artifacts",
-						"plugins",
-						gitTag,
-						filename,
-					),
+					URI:    assetPath,
 					SHA512: sha512,
 					SHA256: sha256,
 				},

--- a/release/pkg/assets_etcd.go
+++ b/release/pkg/assets_etcd.go
@@ -43,6 +43,18 @@ func (r *ReleaseConfig) GetEtcdComponent(spec distrov1alpha1.ReleaseSpec) (*dist
 			if err != nil {
 				return nil, errors.Cause(err)
 			}
+			assetPath, err := r.GetURI(path.Join(
+				fmt.Sprintf("kubernetes-%s", spec.Channel),
+				"releases",
+				fmt.Sprintf("%d", spec.Number),
+				"artifacts",
+				"etcd",
+				gitTag,
+				filename,
+			))
+			if err != nil {
+				return nil, errors.Cause(err)
+			}
 			assets = append(assets, distrov1alpha1.Asset{
 				Name:        filename,
 				Type:        "Archive",
@@ -50,15 +62,7 @@ func (r *ReleaseConfig) GetEtcdComponent(spec distrov1alpha1.ReleaseSpec) (*dist
 				OS:          os,
 				Arch:        []string{arch},
 				Archive: &distrov1alpha1.AssetArchive{
-					Path: path.Join(
-						fmt.Sprintf("kubernetes-%s", spec.Channel),
-						"releases",
-						fmt.Sprintf("%d", spec.Number),
-						"artifacts",
-						"etcd",
-						gitTag,
-						filename,
-					),
+					URI:    assetPath,
 					SHA512: sha512,
 					SHA256: sha256,
 				},

--- a/release/pkg/assets_k8s.go
+++ b/release/pkg/assets_k8s.go
@@ -72,6 +72,18 @@ func (r *ReleaseConfig) GetKubernetesComponent(spec distrov1alpha1.ReleaseSpec) 
 				if err != nil {
 					return nil, err
 				}
+				assetPath, err := r.GetURI(path.Join(
+					fmt.Sprintf("kubernetes-%s", spec.Channel),
+					"releases",
+					fmt.Sprintf("%d", spec.Number),
+					"artifacts",
+					"kubernetes",
+					gitTag,
+					filename,
+				))
+				if err != nil {
+					return nil, err
+				}
 				binaryAssets = append(binaryAssets, distrov1alpha1.Asset{
 					Name:        filename,
 					Type:        "Archive",
@@ -79,15 +91,7 @@ func (r *ReleaseConfig) GetKubernetesComponent(spec distrov1alpha1.ReleaseSpec) 
 					OS:          os,
 					Arch:        []string{arch},
 					Archive: &distrov1alpha1.AssetArchive{
-						Path: path.Join(
-							fmt.Sprintf("kubernetes-%s", spec.Channel),
-							"releases",
-							fmt.Sprintf("%d", spec.Number),
-							"artifacts",
-							"kubernetes",
-							gitTag,
-							filename,
-						),
+						URI:    assetPath,
 						SHA512: sha512,
 						SHA256: sha256,
 					},
@@ -99,6 +103,18 @@ func (r *ReleaseConfig) GetKubernetesComponent(spec distrov1alpha1.ReleaseSpec) 
 				if err != nil {
 					return nil, err
 				}
+				assetPath, err := r.GetURI(path.Join(
+					fmt.Sprintf("kubernetes-%s", spec.Channel),
+					"releases",
+					fmt.Sprintf("%d", spec.Number),
+					"artifacts",
+					"kubernetes",
+					gitTag,
+					filename,
+				))
+				if err != nil {
+					return nil, err
+				}
 				assets = append(assets, distrov1alpha1.Asset{
 					Name:        filename,
 					Type:        "Archive",
@@ -106,15 +122,7 @@ func (r *ReleaseConfig) GetKubernetesComponent(spec distrov1alpha1.ReleaseSpec) 
 					OS:          os,
 					Arch:        []string{arch},
 					Archive: &distrov1alpha1.AssetArchive{
-						Path: path.Join(
-							fmt.Sprintf("kubernetes-%s", spec.Channel),
-							"releases",
-							fmt.Sprintf("%d", spec.Number),
-							"artifacts",
-							"kubernetes",
-							gitTag,
-							filename,
-						),
+						URI:    assetPath,
 						SHA512: sha512,
 						SHA256: sha256,
 					},
@@ -155,6 +163,18 @@ func (r *ReleaseConfig) GetKubernetesComponent(spec distrov1alpha1.ReleaseSpec) 
 				if err != nil {
 					return nil, err
 				}
+				assetPath, err := r.GetURI(path.Join(
+					fmt.Sprintf("kubernetes-%s", spec.Channel),
+					"releases",
+					fmt.Sprintf("%d", spec.Number),
+					"artifacts",
+					"kubernetes",
+					gitTag,
+					filename,
+				))
+				if err != nil {
+					return nil, err
+				}
 				imageTarAssets = append(imageTarAssets, distrov1alpha1.Asset{
 					Name:        filename,
 					Type:        "Archive",
@@ -162,15 +182,7 @@ func (r *ReleaseConfig) GetKubernetesComponent(spec distrov1alpha1.ReleaseSpec) 
 					OS:          "linux",
 					Arch:        []string{arch},
 					Archive: &distrov1alpha1.AssetArchive{
-						Path: path.Join(
-							fmt.Sprintf("kubernetes-%s", spec.Channel),
-							"releases",
-							fmt.Sprintf("%d", spec.Number),
-							"artifacts",
-							"kubernetes",
-							gitTag,
-							filename,
-						),
+						URI:    assetPath,
 						SHA512: sha512,
 						SHA256: sha256,
 					},
@@ -187,20 +199,24 @@ func (r *ReleaseConfig) GetKubernetesComponent(spec distrov1alpha1.ReleaseSpec) 
 	if err != nil {
 		return nil, err
 	}
+	assetPath, err := r.GetURI(path.Join(
+		fmt.Sprintf("kubernetes-%s", spec.Channel),
+		"releases",
+		fmt.Sprintf("%d", spec.Number),
+		"artifacts",
+		"kubernetes",
+		gitTag,
+		filename,
+	))
+	if err != nil {
+		return nil, err
+	}
 	assets = append(assets, distrov1alpha1.Asset{
 		Name:        filename,
 		Type:        "Archive",
 		Description: "Kubernetes source tarball",
 		Archive: &distrov1alpha1.AssetArchive{
-			Path: path.Join(
-				fmt.Sprintf("kubernetes-%s", spec.Channel),
-				"releases",
-				fmt.Sprintf("%d", spec.Number),
-				"artifacts",
-				"kubernetes",
-				gitTag,
-				filename,
-			),
+			URI:    assetPath,
 			SHA512: sha512,
 			SHA256: sha256,
 		},

--- a/release/pkg/generate_spec.go
+++ b/release/pkg/generate_spec.go
@@ -15,6 +15,7 @@
 package pkg
 
 import (
+	"net/url"
 	"time"
 
 	distrov1alpha1 "github.com/aws/eks-distro-build-tooling/release/api/v1alpha1"
@@ -24,6 +25,7 @@ import (
 // ReleaseConfig contains metadata fields for a release
 type ReleaseConfig struct {
 	ContainerImageRepository string
+	ArtifactURL              string
 	BuildRepoSource          string
 	ReleaseDate              time.Time
 }
@@ -59,4 +61,14 @@ func (r *ReleaseConfig) UpdateReleaseStatus(release *distrov1alpha1.Release) err
 		Components: components,
 	}
 	return nil
+}
+
+// GetURI returns an full URL for the given path
+func (r *ReleaseConfig) GetURI(path string) (string, error) {
+	uri, err := url.Parse(r.ArtifactURL)
+	if err != nil {
+		return "", err
+	}
+	uri.Path = path
+	return uri.String(), nil
 }


### PR DESCRIPTION
Update to use URI instead of Path, this requires less context for the user to add the domain

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
