### PR TITLE
Remove ssh-key from prow config and set versions to 1.0.0 for release

### DIFF
--- a/helm-charts/stable/prow-control-plane/Chart.yaml
+++ b/helm-charts/stable/prow-control-plane/Chart.yaml
@@ -29,9 +29,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.9
+version: 1.0.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 0.3.0
+appVersion: 1.0.0

--- a/helm-charts/stable/prow-control-plane/templates/config-ConfigMap.yaml
+++ b/helm-charts/stable/prow-control-plane/templates/config-ConfigMap.yaml
@@ -78,8 +78,6 @@ data:
             bucket: s3://{{ .Values.prow.presubmitsBucketName }}
             path_strategy: explicit
           s3_credentials_secret: s3-credentials
-          ssh_key_secrets:
-          - ssh-secret
           utility_images:
             clonerefs:  {{ .Values.utility_images.clonerefs }}
             entrypoint: {{ .Values.utility_images.entrypoint }}

--- a/helm-charts/stable/prow-data-plane/Chart.yaml
+++ b/helm-charts/stable/prow-data-plane/Chart.yaml
@@ -29,9 +29,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.0
+version: 1.0.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 1.16.0
+appVersion: 1.0.0


### PR DESCRIPTION
Removing ssh-key configuration for prow config as we will be making the repos public for release.

Also resetting versions to 1.0.0 for the release. The app version is not actually being used I believe so changing it from 1.16 to 1.0 in data plane won't have any consequences.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
