### PR TITLE
Set session name on prow cp pods

### DIFF
--- a/helm-charts/stable/prow-control-plane/Chart.yaml
+++ b/helm-charts/stable/prow-control-plane/Chart.yaml
@@ -29,7 +29,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.1
+version: 1.0.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm-charts/stable/prow-control-plane/templates/crier-Deployment.yaml
+++ b/helm-charts/stable/prow-control-plane/templates/crier-Deployment.yaml
@@ -35,6 +35,10 @@ spec:
         env:
         - name: AWS_STS_REGIONAL_ENDPOINTS
           value: regional
+        - name: AWS_ROLE_SESSION_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
         image: {{ .Values.crier.image }}
         args:
         - --blob-storage-workers=10

--- a/helm-charts/stable/prow-control-plane/templates/deck-Deployment.yaml
+++ b/helm-charts/stable/prow-control-plane/templates/deck-Deployment.yaml
@@ -40,6 +40,10 @@ spec:
         env:
         - name: AWS_STS_REGIONAL_ENDPOINTS
           value: regional
+        - name: AWS_ROLE_SESSION_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
         image: {{ .Values.deck.image }}
         args:
         - --config-path=/etc/config/config.yaml

--- a/helm-charts/stable/prow-control-plane/templates/ghProxy-Deployment.yaml
+++ b/helm-charts/stable/prow-control-plane/templates/ghProxy-Deployment.yaml
@@ -36,6 +36,10 @@ spec:
         env:
         - name: AWS_STS_REGIONAL_ENDPOINTS
           value: regional
+        - name: AWS_ROLE_SESSION_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
         image: {{ .Values.ghproxy.image }}
         args:
         - --cache-dir=/cache

--- a/helm-charts/stable/prow-control-plane/templates/hook-Deployment.yaml
+++ b/helm-charts/stable/prow-control-plane/templates/hook-Deployment.yaml
@@ -40,6 +40,10 @@ spec:
         env:
         - name: AWS_STS_REGIONAL_ENDPOINTS
           value: regional
+        - name: AWS_ROLE_SESSION_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
         image: {{ .Values.hook.image }}
         imagePullPolicy: Always
         args:

--- a/helm-charts/stable/prow-control-plane/templates/horologium-Deployment.yaml
+++ b/helm-charts/stable/prow-control-plane/templates/horologium-Deployment.yaml
@@ -37,6 +37,10 @@ spec:
         env:
         - name: AWS_STS_REGIONAL_ENDPOINTS
           value: regional
+        - name: AWS_ROLE_SESSION_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
         image: {{ .Values.horologium.image }}
         args:
         - --dry-run={{ .Values.dryRun }}

--- a/helm-charts/stable/prow-control-plane/templates/kubeconfig-Secret.yaml
+++ b/helm-charts/stable/prow-control-plane/templates/kubeconfig-Secret.yaml
@@ -50,6 +50,9 @@ stringData:
           - --cluster-id
           - "{{ .Values.dataplane.postsubmits.clusterName}}"
           command: /shared-bins/aws-iam-authenticator
+          env:
+          - name: AWS_STS_REGIONAL_ENDPOINTS
+            value: regional
     - name: "{{ .Values.dataplane.presubmits.clusterArn }}"
       user:
         exec:
@@ -59,3 +62,6 @@ stringData:
           - --cluster-id
           - "{{ .Values.dataplane.presubmits.clusterName}}"
           command: /shared-bins/aws-iam-authenticator
+          env:
+          - name: AWS_STS_REGIONAL_ENDPOINTS
+            value: regional

--- a/helm-charts/stable/prow-control-plane/templates/prow-controller-manager-Deployment.yaml
+++ b/helm-charts/stable/prow-control-plane/templates/prow-controller-manager-Deployment.yaml
@@ -34,6 +34,10 @@ spec:
         env:
         - name: AWS_STS_REGIONAL_ENDPOINTS
           value: regional
+        - name: AWS_ROLE_SESSION_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
         args:
         - --dry-run={{ .Values.dryRun }}
         - --deck-url=http://deck/

--- a/helm-charts/stable/prow-control-plane/templates/sinker-Deployment.yaml
+++ b/helm-charts/stable/prow-control-plane/templates/sinker-Deployment.yaml
@@ -34,6 +34,10 @@ spec:
         env:
         - name: AWS_STS_REGIONAL_ENDPOINTS
           value: regional
+        - name: AWS_ROLE_SESSION_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
         image: {{ .Values.sinker.image }}
         args:
         - --config-path=/etc/config/config.yaml

--- a/helm-charts/stable/prow-control-plane/templates/statusreconciler-Deployment.yaml
+++ b/helm-charts/stable/prow-control-plane/templates/statusreconciler-Deployment.yaml
@@ -35,6 +35,10 @@ spec:
         env:
         - name: AWS_STS_REGIONAL_ENDPOINTS
           value: regional
+        - name: AWS_ROLE_SESSION_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
         image: {{ .Values.statusreconciler.image }}
         args:
         - --dry-run={{ .Values.dryRun }}

--- a/helm-charts/stable/prow-control-plane/templates/tide-Deployment.yaml
+++ b/helm-charts/stable/prow-control-plane/templates/tide-Deployment.yaml
@@ -36,6 +36,10 @@ spec:
         env:
         - name: AWS_STS_REGIONAL_ENDPOINTS
           value: regional
+        - name: AWS_ROLE_SESSION_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
         image: {{ .Values.tide.image }}
         args:
         - --dry-run={{ .Values.dryRun }}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

* Adds a session name to help debug which IAM role sessions are associated with which pods 
* Ensure that aws-iam-authenticator is using the regional endpiont

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
