### PR TITLE
Use regional endpionts for authenticator

### DIFF
--- a/helm-charts/stable/prow-control-plane/Chart.yaml
+++ b/helm-charts/stable/prow-control-plane/Chart.yaml
@@ -29,7 +29,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.2
+version: 1.0.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm-charts/stable/prow-control-plane/templates/kubeconfig-Secret.yaml
+++ b/helm-charts/stable/prow-control-plane/templates/kubeconfig-Secret.yaml
@@ -49,6 +49,8 @@ stringData:
           - token
           - --cluster-id
           - "{{ .Values.dataplane.postsubmits.clusterName}}"
+          - --region
+          - "{{ .Values.region }}"
           command: /shared-bins/aws-iam-authenticator
           env:
           - name: AWS_STS_REGIONAL_ENDPOINTS
@@ -61,6 +63,8 @@ stringData:
           - token
           - --cluster-id
           - "{{ .Values.dataplane.presubmits.clusterName}}"
+          - --region
+          - "{{ .Values.region }}"
           command: /shared-bins/aws-iam-authenticator
           env:
           - name: AWS_STS_REGIONAL_ENDPOINTS


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Validated that regional endpoints are used if `--region` is passed. I don't know why the Go SDK doesn't respect `AWS_STS_REGIONAL_ENDPOINTS` when getting the initial AWS creds. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
