### PR TITLE
Prevent script from failing due to non-zero exit code

### DIFF
--- a/builder-base/Makefile
+++ b/builder-base/Makefile
@@ -2,10 +2,7 @@ DEVELOPMENT?=true
 AWS_ACCOUNT_ID?=$(shell aws sts get-caller-identity --query Account --output text)
 AWS_REGION?=us-west-2
 
-BASE_REPO?=137112412989.dkr.ecr.$(AWS_REGION).amazonaws.com
-BASE_IMAGE_NAME?=amazonlinux
-BASE_TAG?=2
-BASE_IMAGE?=$(BASE_REPO)/$(BASE_IMAGE_NAME):$(BASE_TAG)
+BASE_IMAGE?=public.ecr.aws/amazonlinux/amazonlinux:2
 
 IMAGE_REPO?=$(AWS_ACCOUNT_ID).dkr.ecr.$(AWS_REGION).amazonaws.com
 IMAGE_NAME?=eks-distro/builder

--- a/eks-distro-base/Makefile
+++ b/eks-distro-base/Makefile
@@ -2,9 +2,7 @@ DEVELOPMENT?=true
 AWS_ACCOUNT_ID?=$(shell aws sts get-caller-identity --query Account --output text)
 AWS_REGION?=us-west-2
 
-BASE_IMAGE_NAME?=amazonlinux
-BASE_TAG?=2
-BASE_IMAGE?=$(BASE_IMAGE_NAME):$(BASE_TAG)
+BASE_IMAGE?=public.ecr.aws/amazonlinux/amazonlinux:2
 
 IMAGE_REPO?=$(AWS_ACCOUNT_ID).dkr.ecr.$(AWS_REGION).amazonaws.com
 IMAGE_NAME?=eks-distro/base

--- a/eks-distro-base/check_update.sh
+++ b/eks-distro-base/check_update.sh
@@ -25,7 +25,7 @@ mkdir eks-distro-base/check-update
 cat << EOF >> eks-distro-base/check-update/Dockerfile
 FROM $BASE_IMAGE AS base_image
 
-RUN yum check-update --security
+RUN (yum check-update --security) && true
 RUN echo $? > ./return_value
 
 FROM scratch
@@ -45,4 +45,6 @@ RETURN_STATUS=$(cat /tmp/status/return_value)
 
 if [ $RETURN_STATUS -eq 100 ]; then
     bash ./eks-distro-base/update_base_image.sh
+elif [ $RETURN_STATUS -eq 1 ]; then
+    exit 1
 fi


### PR DESCRIPTION
Script fails when a command has a non-zero exit code, due to `set -e` option. Added a hack to work around this. This construct still preserves the non-zero code but does not exit the script abruptly.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
