### PR TITLE
Add amazon-eks-pod-identity-webhook to Helm charts

### DIFF
--- a/helm-charts/stable/amazon-eks-pod-identity-webhook/.helmignore
+++ b/helm-charts/stable/amazon-eks-pod-identity-webhook/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/helm-charts/stable/amazon-eks-pod-identity-webhook/Chart.yaml
+++ b/helm-charts/stable/amazon-eks-pod-identity-webhook/Chart.yaml
@@ -1,0 +1,37 @@
+# Copyright 2020 Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v2
+name: amazon-eks-pod-identity-webhook
+description: Custom amazon-eks-pod-identity-webhook installation Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 1.0.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+appVersion: 1.0.0

--- a/helm-charts/stable/amazon-eks-pod-identity-webhook/README.md
+++ b/helm-charts/stable/amazon-eks-pod-identity-webhook/README.md
@@ -1,0 +1,12 @@
+## Helm chart for custom amazon-eks-pod-identity-webhook installation
+
+This deploys [amazon-eks-pod-identity-webhook](https://github.com/aws/amazon-eks-pod-identity-webhook)
+and the related job resources to automate the `cluster-up` target in the upstream repository.
+
+Make sure to specify the image name with deploying this Helm chart.
+
+All the resources are defined in `templates/` except for the `MutatingWebhookConfiguration`,
+which gets applied as part of the `Job` during `post-install,post-upgrade`. The resources in
+`template/` related to the job have a `job-` prefix. There is also a `CronJob` that executes
+the same script as the `Job` to also be able to detect for newer `CertificateSigningRequests`
+in case the webhook detects that the certifcate in the secret is about to expire.

--- a/helm-charts/stable/amazon-eks-pod-identity-webhook/config/job.sh
+++ b/helm-charts/stable/amazon-eks-pod-identity-webhook/config/job.sh
@@ -1,0 +1,38 @@
+# Copyright 2020 Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+set -o pipefail
+set -x
+
+echo "Running job.sh in $(pwd)"
+
+yum install -y jq
+
+KUBECTL_VERSION=v1.18.9
+curl -sSL "https://distro.eks.amazonaws.com/kubernetes-1-18/releases/1/artifacts/kubernetes/${KUBECTL_VERSION}/bin/linux/amd64/kubectl" -o /bin/kubectl
+chmod +x /bin/kubectl
+
+CA_BUNDLE=$(cat /var/run/secrets/kubernetes.io/serviceaccount/ca.crt | base64 -w 0)
+cat /config/mutatingwebhook.yaml | sed -e "s|\${CA_BUNDLE}|${CA_BUNDLE}|g" | sed -e "s|\${WEBHOOK_NAME}|${WEBHOOK_NAME}|g" | sed -e "s|\${NAMESPACE}|${NAMESPACE}|g" > mutatingwebhook.yaml
+kubectl apply -f mutatingwebhook.yaml
+
+# Loop for a total of 50 seconds to give time for webhook to create CertificateSigningRequest
+for i in {1..10}; do
+    # Make sure to have the NAMESPACE and WEBHOOK_NAME env var defined
+    for c in $(kubectl get csr -o json | jq -r '.items[] | select(.spec.username=="system:serviceaccount:$NAMESPACE:$WEBHOOK_NAME" and .status=={}).metadata.name'); do
+        kubectl certificate approve $c
+    done
+    sleep 5
+done

--- a/helm-charts/stable/amazon-eks-pod-identity-webhook/config/mutatingwebhook.yaml
+++ b/helm-charts/stable/amazon-eks-pod-identity-webhook/config/mutatingwebhook.yaml
@@ -12,13 +12,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: distro.eks.amazonaws.com/v1alpha1
-kind: ReleaseChannel
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: MutatingWebhookConfiguration
 metadata:
-  creationTimestamp: null
-  name: 1-18
-spec:
-  snsTopicARN: "arn:aws:sns:us-east-1:379412251201:eks-distro-updates"
-status:
-  active: true
-  latestRelease: 1
+  name: ${WEBHOOK_NAME}
+  namespace: ${NAMESPACE}
+webhooks:
+- name: ${WEBHOOK_NAME}.amazonaws.com
+  failurePolicy: Ignore
+  sideEffects: None
+  clientConfig:
+    service:
+      name: ${WEBHOOK_NAME}
+      namespace: ${NAMESPACE}
+      path: "/mutate"
+    caBundle: ${CA_BUNDLE}
+  rules:
+  - operations: [ "CREATE" ]
+    apiGroups: [""]
+    apiVersions: ["v1"]
+    resources: ["pods"]

--- a/helm-charts/stable/amazon-eks-pod-identity-webhook/templates/ClusterRole.yaml
+++ b/helm-charts/stable/amazon-eks-pod-identity-webhook/templates/ClusterRole.yaml
@@ -12,13 +12,25 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: distro.eks.amazonaws.com/v1alpha1
-kind: ReleaseChannel
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
 metadata:
-  creationTimestamp: null
-  name: 1-18
-spec:
-  snsTopicARN: "arn:aws:sns:us-east-1:379412251201:eks-distro-updates"
-status:
-  active: true
-  latestRelease: 1
+  name: {{ include "amazon-eks-pod-identity-webhook.fullname" . }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  verbs:
+  - get
+  - watch
+  - list
+- apiGroups:
+  - certificates.k8s.io
+  resources:
+  - certificatesigningrequests
+  verbs:
+  - create
+  - get
+  - list
+  - watch

--- a/helm-charts/stable/amazon-eks-pod-identity-webhook/templates/ClusterRoleBinding.yaml
+++ b/helm-charts/stable/amazon-eks-pod-identity-webhook/templates/ClusterRoleBinding.yaml
@@ -12,13 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: distro.eks.amazonaws.com/v1alpha1
-kind: ReleaseChannel
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
 metadata:
-  creationTimestamp: null
-  name: 1-18
-spec:
-  snsTopicARN: "arn:aws:sns:us-east-1:379412251201:eks-distro-updates"
-status:
-  active: true
-  latestRelease: 1
+  name: {{ include "amazon-eks-pod-identity-webhook.fullname" . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "amazon-eks-pod-identity-webhook.fullname" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "amazon-eks-pod-identity-webhook.fullname" . }}
+  namespace: {{ .Release.Namespace }}

--- a/helm-charts/stable/amazon-eks-pod-identity-webhook/templates/Deployment.yaml
+++ b/helm-charts/stable/amazon-eks-pod-identity-webhook/templates/Deployment.yaml
@@ -1,0 +1,62 @@
+# Copyright 2020 Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "amazon-eks-pod-identity-webhook.fullname" . }}
+  labels:
+    {{- include "amazon-eks-pod-identity-webhook.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "amazon-eks-pod-identity-webhook.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "amazon-eks-pod-identity-webhook.selectorLabels" . | nindent 8 }}
+    spec:
+      serviceAccountName: {{ include "amazon-eks-pod-identity-webhook.fullname" . }}
+      {{- if .Values.fargate }}
+      initContainers:
+      - name: sleep
+        image: {{ .Values.baseImage }}
+        imagePullPolicy: Always
+        command:
+        - sleep
+        - {{ .Values.sleep | quote }}
+      {{- end }}
+      containers:
+      - name: webhook
+        image: {{ .Values.image }}
+        imagePullPolicy: Always
+        command:
+        - /webhook
+        - --in-cluster
+        - --namespace={{ .Release.Namespace }}
+        - --service-name={{ include "amazon-eks-pod-identity-webhook.fullname" . }}
+        - --tls-secret={{ include "amazon-eks-pod-identity-webhook.fullname" . }}
+        - --annotation-prefix=eks.amazonaws.com
+        - --token-audience=sts.amazonaws.com
+        - --metrics-port={{ .Values.service.metricsPort }}
+        - --port={{ .Values.service.port }}
+        - --logtostderr
+        volumeMounts:
+        - name: webhook-certs
+          mountPath: /var/run/app/certs
+          readOnly: false
+      volumes:
+      - name: webhook-certs
+        emptyDir: {}

--- a/helm-charts/stable/amazon-eks-pod-identity-webhook/templates/NOTES.txt
+++ b/helm-charts/stable/amazon-eks-pod-identity-webhook/templates/NOTES.txt
@@ -1,0 +1,5 @@
+Thank you for installing {{ .Chart.Name }}.
+
+Your release is named {{ .Release.Name }} and deployed to the {{ .Release.Namespace }} namespace.
+
+For more information about this application, visit https://github.com/aws/amazon-eks-pod-identity-webhook

--- a/helm-charts/stable/amazon-eks-pod-identity-webhook/templates/Role.yaml
+++ b/helm-charts/stable/amazon-eks-pod-identity-webhook/templates/Role.yaml
@@ -12,13 +12,24 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: distro.eks.amazonaws.com/v1alpha1
-kind: ReleaseChannel
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
 metadata:
-  creationTimestamp: null
-  name: 1-18
-spec:
-  snsTopicARN: "arn:aws:sns:us-east-1:379412251201:eks-distro-updates"
-status:
-  active: true
-  latestRelease: 1
+  name: {{ include "amazon-eks-pod-identity-webhook.fullname" . }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - update
+  - patch
+  resourceNames:
+  - {{ include "amazon-eks-pod-identity-webhook.fullname" . }}

--- a/helm-charts/stable/amazon-eks-pod-identity-webhook/templates/RoleBinding.yaml
+++ b/helm-charts/stable/amazon-eks-pod-identity-webhook/templates/RoleBinding.yaml
@@ -12,13 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: distro.eks.amazonaws.com/v1alpha1
-kind: ReleaseChannel
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
 metadata:
-  creationTimestamp: null
-  name: 1-18
-spec:
-  snsTopicARN: "arn:aws:sns:us-east-1:379412251201:eks-distro-updates"
-status:
-  active: true
-  latestRelease: 1
+  name: {{ include "amazon-eks-pod-identity-webhook.fullname" . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "amazon-eks-pod-identity-webhook.fullname" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "amazon-eks-pod-identity-webhook.fullname" . }}
+  namespace: {{ .Release.Namespace }}

--- a/helm-charts/stable/amazon-eks-pod-identity-webhook/templates/Service.yaml
+++ b/helm-charts/stable/amazon-eks-pod-identity-webhook/templates/Service.yaml
@@ -12,13 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: distro.eks.amazonaws.com/v1alpha1
-kind: ReleaseChannel
+apiVersion: v1
+kind: Service
 metadata:
-  creationTimestamp: null
-  name: 1-18
+  name: {{ include "amazon-eks-pod-identity-webhook.fullname" . }}
+  labels:
+    {{- include "amazon-eks-pod-identity-webhook.labels" . | nindent 4 }}
+  annotations:
+    prometheus.io/port: {{ .Values.service.metricsPort | quote }}
+    prometheus.io/scheme: "https"
+    prometheus.io/scrape: "true"
 spec:
-  snsTopicARN: "arn:aws:sns:us-east-1:379412251201:eks-distro-updates"
-status:
-  active: true
-  latestRelease: 1
+  ports:
+  - port: {{ .Values.service.port }}
+    targetPort: {{ .Values.service.port }}
+  selector:
+    {{- include "amazon-eks-pod-identity-webhook.selectorLabels" . | nindent 4 }}

--- a/helm-charts/stable/amazon-eks-pod-identity-webhook/templates/ServiceAccount.yaml
+++ b/helm-charts/stable/amazon-eks-pod-identity-webhook/templates/ServiceAccount.yaml
@@ -12,13 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: distro.eks.amazonaws.com/v1alpha1
-kind: ReleaseChannel
+apiVersion: v1
+kind: ServiceAccount
 metadata:
-  creationTimestamp: null
-  name: 1-18
-spec:
-  snsTopicARN: "arn:aws:sns:us-east-1:379412251201:eks-distro-updates"
-status:
-  active: true
-  latestRelease: 1
+  name: {{ include "amazon-eks-pod-identity-webhook.name" . }}
+  labels:
+    {{- include "amazon-eks-pod-identity-webhook.labels" . | nindent 4 }}

--- a/helm-charts/stable/amazon-eks-pod-identity-webhook/templates/_helpers.tpl
+++ b/helm-charts/stable/amazon-eks-pod-identity-webhook/templates/_helpers.tpl
@@ -1,0 +1,51 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "amazon-eks-pod-identity-webhook.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "amazon-eks-pod-identity-webhook.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "amazon-eks-pod-identity-webhook.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "amazon-eks-pod-identity-webhook.labels" -}}
+helm.sh/chart: {{ include "amazon-eks-pod-identity-webhook.chart" . }}
+{{ include "amazon-eks-pod-identity-webhook.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "amazon-eks-pod-identity-webhook.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "amazon-eks-pod-identity-webhook.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/helm-charts/stable/amazon-eks-pod-identity-webhook/templates/job-ClusterRole.yaml
+++ b/helm-charts/stable/amazon-eks-pod-identity-webhook/templates/job-ClusterRole.yaml
@@ -12,13 +12,36 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: distro.eks.amazonaws.com/v1alpha1
-kind: ReleaseChannel
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
 metadata:
-  creationTimestamp: null
-  name: 1-18
-spec:
-  snsTopicARN: "arn:aws:sns:us-east-1:379412251201:eks-distro-updates"
-status:
-  active: true
-  latestRelease: 1
+  name: {{ .Values.jobName }}
+rules:
+- apiGroups:
+  - admissionregistration.k8s.io
+  resources:
+  - mutatingwebhookconfigurations
+  verbs:
+  - get
+  - patch
+  resourceNames:
+  - {{ include "amazon-eks-pod-identity-webhook.fullname" . }}
+- apiGroups:
+  - admissionregistration.k8s.io
+  resources:
+  - mutatingwebhookconfigurations
+  verbs:
+  - create
+- apiGroups:
+  - certificates.k8s.io
+  resources:
+  - certificatesigningrequests
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - certificates.k8s.io
+  resources:
+  - certificatesigningrequests/approval
+  verbs:
+  - update

--- a/helm-charts/stable/amazon-eks-pod-identity-webhook/templates/job-ClusterRoleBinding.yaml
+++ b/helm-charts/stable/amazon-eks-pod-identity-webhook/templates/job-ClusterRoleBinding.yaml
@@ -12,13 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: distro.eks.amazonaws.com/v1alpha1
-kind: ReleaseChannel
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
 metadata:
-  creationTimestamp: null
-  name: 1-18
-spec:
-  snsTopicARN: "arn:aws:sns:us-east-1:379412251201:eks-distro-updates"
-status:
-  active: true
-  latestRelease: 1
+  name: {{ .Values.jobName }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ .Values.jobName }}
+subjects:
+- kind: ServiceAccount
+  name: {{ .Values.jobName }}
+  namespace: {{ .Release.Namespace }}

--- a/helm-charts/stable/amazon-eks-pod-identity-webhook/templates/job-ConfigMap.yaml
+++ b/helm-charts/stable/amazon-eks-pod-identity-webhook/templates/job-ConfigMap.yaml
@@ -12,13 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: distro.eks.amazonaws.com/v1alpha1
-kind: ReleaseChannel
+apiVersion: v1
+kind: ConfigMap
 metadata:
-  creationTimestamp: null
-  name: 1-18
-spec:
-  snsTopicARN: "arn:aws:sns:us-east-1:379412251201:eks-distro-updates"
-status:
-  active: true
-  latestRelease: 1
+  name: {{ .Values.jobName }}-configmap
+data:
+  {{- $files := .Files }}
+  {{- range tuple "mutatingwebhook.yaml" "job.sh" }}
+  {{ . }}: |-
+{{ $files.Get (printf "config/%s" .) | indent 4 }}
+  {{- end }}

--- a/helm-charts/stable/amazon-eks-pod-identity-webhook/templates/job-CronJob.yaml
+++ b/helm-charts/stable/amazon-eks-pod-identity-webhook/templates/job-CronJob.yaml
@@ -1,0 +1,47 @@
+# Copyright 2020 Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: {{ .Values.jobName }}
+spec:
+  schedule: "@weekly"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          serviceAccountName: {{ .Values.jobName }}
+          containers:
+          - name: job
+            image: {{ .Values.baseImage }}
+            imagePullPolicy: Always
+            env:
+            - name: WEBHOOK_NAME
+              value: {{ include "amazon-eks-pod-identity-webhook.fullname" . }}
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            command:
+            - bash
+            - config/job.sh
+            volumeMounts:
+            - name: config
+              mountPath: /config
+          volumes:
+          - name: config
+            configMap:
+              name: {{ .Values.jobName }}-configmap
+          restartPolicy: OnFailure

--- a/helm-charts/stable/amazon-eks-pod-identity-webhook/templates/job-Job.yaml
+++ b/helm-charts/stable/amazon-eks-pod-identity-webhook/templates/job-Job.yaml
@@ -1,0 +1,56 @@
+# Copyright 2020 Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ .Values.jobName }}
+  annotations:
+    helm.sh/hook: post-install,post-upgrade
+    helm.sh/hook-weight: "0"
+spec:
+  template:
+    spec:
+      serviceAccountName: {{ .Values.jobName }}
+      {{- if .Values.fargate }}
+      initContainers:
+      - name: sleep
+        image: {{ .Values.baseImage }}
+        imagePullPolicy: Always
+        command:
+        - sleep
+        - {{ .Values.sleep | quote }}
+      {{- end }}
+      containers:
+      - name: job
+        image: {{ .Values.baseImage }}
+        imagePullPolicy: Always
+        env:
+        - name: WEBHOOK_NAME
+          value: {{ include "amazon-eks-pod-identity-webhook.fullname" . }}
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        command:
+        - bash
+        - config/job.sh
+        volumeMounts:
+        - name: config
+          mountPath: /config
+      volumes:
+      - name: config
+        configMap:
+          name: {{ .Values.jobName }}-configmap
+      restartPolicy: OnFailure

--- a/helm-charts/stable/amazon-eks-pod-identity-webhook/templates/job-ServiceAccount.yaml
+++ b/helm-charts/stable/amazon-eks-pod-identity-webhook/templates/job-ServiceAccount.yaml
@@ -12,13 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: distro.eks.amazonaws.com/v1alpha1
-kind: ReleaseChannel
+kind: ServiceAccount
+apiVersion: v1
 metadata:
-  creationTimestamp: null
-  name: 1-18
-spec:
-  snsTopicARN: "arn:aws:sns:us-east-1:379412251201:eks-distro-updates"
-status:
-  active: true
-  latestRelease: 1
+  name: {{ .Values.jobName }}

--- a/helm-charts/stable/amazon-eks-pod-identity-webhook/values.yaml
+++ b/helm-charts/stable/amazon-eks-pod-identity-webhook/values.yaml
@@ -1,0 +1,35 @@
+# Copyright 2020 Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+nameOverride: "pod-identity-webhook"
+fullnameOverride: "pod-identity-webhook"
+
+# Make sure to pass in the image for the webhook here or as a parameter to the helm installation
+image: placeholder-webhook:fake
+
+# Used for sleep containers as well as to run our job script
+baseImage: public.ecr.aws/amazonlinux/amazonlinux:2 
+
+# Adding the value for 'sleep' in seconds as a sleep to the deployment to allow for the webhook to be able to talk to kube-apiserver
+# as fargate pods take longer to bootstrap.
+sleep: 30
+fargate: false
+
+service:
+  port: 443
+  metricsPort: 9999
+
+replicaCount: 1
+
+jobName: "pod-identity-webhook-cert-approver"

--- a/release/config/crds/distro.eks.amazonaws.com_releasechannels.yaml
+++ b/release/config/crds/distro.eks.amazonaws.com_releasechannels.yaml
@@ -1,3 +1,17 @@
+# Copyright 2020 Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 
 ---
 apiVersion: apiextensions.k8s.io/v1beta1

--- a/release/config/crds/distro.eks.amazonaws.com_releases.yaml
+++ b/release/config/crds/distro.eks.amazonaws.com_releases.yaml
@@ -1,3 +1,17 @@
+# Copyright 2020 Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 
 ---
 apiVersion: apiextensions.k8s.io/v1beta1

--- a/release/config/examples/release_example.yaml
+++ b/release/config/examples/release_example.yaml
@@ -1,3 +1,17 @@
+# Copyright 2020 Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: distro.eks.amazonaws.com/v1alpha1
 kind: Release
 metadata:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This PR adds a helm chart to deploy the amazon-eks-pod-identity-webhook and automates applying the MutatingWebhookConfiguration and approving the certificate through a job in post-install/upgrade as well as a cronjob that runs to be able to look for pending requests when the certificate is about the expire. This tries to mimic the cluster-up target in the upstream Makefile: https://github.com/vivek-koppuru/amazon-eks-pod-identity-webhook/blob/master/Makefile

This PR will be followed by the CDK infra changes to add this helm chart and pass in the necessary values, such as the image of the webhook and the fargate value based on the stack.

The MutatingWebhookConfiguration is applied during the jobs to be able to retrieve the CA_Bundle from the default secret instead of having to store it and pass it in as a variable from the CDK, as well as this being a resource that is not supported as part of the ordering of the helm install/upgrade steps. This is add as a ConfigMap to mount onto the job/cronjob.

The job/cronjob script is added as a ConfigMap to run as well, which installs jq and kubectl on amazonlinux:2 that is vended by the ECR public gallery. If needed, this can be baked into our existing builder image instead.

The script also checks for any pending CSRs by the pod-identity-webhook, and runs for 10 times with a 5 second sleep in between (a total of 50 seconds), to allow time for the webhook to vend out the CSR. My understanding is that there shouldn't be any disadvantage to approving all pending ones by the webhook as the webhook will only be looking for the latest approval to then update the secret. I think this loop is necessary to be able to ensure that there is no race condition where there is an existing CSR request, but is approved after it creates a new one that the script isn't able to detect.

There is also a sleep container added for fargate to the deployment to give time to talk to the kube-apiserver. It is configured to 30 seconds as trying 5 and 10 seconds weren't enough. That same sleep container is added to the job as well to be able have it in sync a bit more.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
