### PR TITLE
Add token-expiration and sts-regional-endpoint flags

### DIFF
--- a/helm-charts/stable/amazon-eks-pod-identity-webhook/templates/Deployment.yaml
+++ b/helm-charts/stable/amazon-eks-pod-identity-webhook/templates/Deployment.yaml
@@ -50,8 +50,10 @@ spec:
         - --tls-secret={{ include "amazon-eks-pod-identity-webhook.fullname" . }}
         - --annotation-prefix=eks.amazonaws.com
         - --token-audience=sts.amazonaws.com
-        - --metrics-port={{ .Values.service.metricsPort }}
-        - --port={{ .Values.service.port }}
+        - --token-expiration={{ .Values.webhook.tokenExpiration }}
+        - --sts-regional-endpoint={{ .Values.webhook.stsRegionalEndpoint }}
+        - --metrics-port={{ .Values.webhook.metricsPort }}
+        - --port={{ .Values.webhook.port }}
         - --logtostderr
         volumeMounts:
         - name: webhook-certs

--- a/helm-charts/stable/amazon-eks-pod-identity-webhook/templates/Service.yaml
+++ b/helm-charts/stable/amazon-eks-pod-identity-webhook/templates/Service.yaml
@@ -19,12 +19,12 @@ metadata:
   labels:
     {{- include "amazon-eks-pod-identity-webhook.labels" . | nindent 4 }}
   annotations:
-    prometheus.io/port: {{ .Values.service.metricsPort | quote }}
+    prometheus.io/port: {{ .Values.webhook.metricsPort | quote }}
     prometheus.io/scheme: "https"
     prometheus.io/scrape: "true"
 spec:
   ports:
   - port: {{ .Values.service.port }}
-    targetPort: {{ .Values.service.port }}
+    targetPort: {{ .Values.webhook.port }}
   selector:
     {{- include "amazon-eks-pod-identity-webhook.selectorLabels" . | nindent 4 }}

--- a/helm-charts/stable/amazon-eks-pod-identity-webhook/values.yaml
+++ b/helm-charts/stable/amazon-eks-pod-identity-webhook/values.yaml
@@ -26,9 +26,15 @@ baseImage: public.ecr.aws/amazonlinux/amazonlinux:2
 sleep: 30
 fargate: false
 
-service:
+# Parameters to webhook are defined here: https://github.com/aws/amazon-eks-pod-identity-webhook#usage
+webhook:
+  tokenExpiration: 3600
+  stsRegionalEndpoint: true
   port: 443
   metricsPort: 9999
+
+service:
+  port: 443
 
 replicaCount: 1
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Adding parameters to webhook so that default token expiration is 3600 and sts regional endpoint is set to true.

Not modifying version as we haven't deployed this yet.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
