### PR TITLE
Rename webhook so it doesn't override eks webhook

### DIFF
--- a/helm-charts/stable/amazon-eks-pod-identity-webhook/Chart.yaml
+++ b/helm-charts/stable/amazon-eks-pod-identity-webhook/Chart.yaml
@@ -29,7 +29,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.0
+version: 1.0.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm-charts/stable/amazon-eks-pod-identity-webhook/config/job.sh
+++ b/helm-charts/stable/amazon-eks-pod-identity-webhook/config/job.sh
@@ -29,10 +29,10 @@ cat /config/mutatingwebhook.yaml | sed -e "s|\${CA_BUNDLE}|${CA_BUNDLE}|g" | sed
 kubectl apply -f mutatingwebhook.yaml
 
 # Loop for a total of 50 seconds to give time for webhook to create CertificateSigningRequest
-for i in {1..10}; do
+for i in {1..20}; do
     # Make sure to have the NAMESPACE and WEBHOOK_NAME env var defined
-    for c in $(kubectl get csr -o json | jq -r '.items[] | select(.spec.username=="system:serviceaccount:$NAMESPACE:$WEBHOOK_NAME" and .status=={}).metadata.name'); do
+    for c in $(kubectl get csr -o json | jq -r ".items[] | select(.spec.username==\"system:serviceaccount:$NAMESPACE:$WEBHOOK_NAME\" and .status=={}).metadata.name"); do
         kubectl certificate approve $c
     done
-    sleep 5
+    sleep 30
 done

--- a/helm-charts/stable/amazon-eks-pod-identity-webhook/values.yaml
+++ b/helm-charts/stable/amazon-eks-pod-identity-webhook/values.yaml
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-nameOverride: "pod-identity-webhook"
-fullnameOverride: "pod-identity-webhook"
+nameOverride: "0500-eks-distro-pod-identity-webhook"
+fullnameOverride: "0500-eks-distro-pod-identity-webhook"
 
 # Make sure to pass in the image for the webhook here or as a parameter to the helm installation
 image: placeholder-webhook:fake
@@ -38,4 +38,4 @@ service:
 
 replicaCount: 1
 
-jobName: "pod-identity-webhook-cert-approver"
+jobName: "0500-eks-distro-pod-identity-webhook-cert-approver"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Rename pod identity webhook to avoid replacing configuration by eks. Also fixed quotes in job script to be able to use the env var in the string, and increased sleep and loop count.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
