### PR TITLE
Update name of webhook

### DIFF
--- a/helm-charts/stable/amazon-eks-pod-identity-webhook/values.yaml
+++ b/helm-charts/stable/amazon-eks-pod-identity-webhook/values.yaml
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-nameOverride: "0500-eks-distro-pod-identity-webhook"
-fullnameOverride: "0500-eks-distro-pod-identity-webhook"
+nameOverride: "eks-distro-pod-identity-webhook"
+fullnameOverride: "eks-distro-pod-identity-webhook"
 
 # Make sure to pass in the image for the webhook here or as a parameter to the helm installation
 image: placeholder-webhook:fake
@@ -38,4 +38,4 @@ service:
 
 replicaCount: 1
 
-jobName: "0500-eks-distro-pod-identity-webhook-cert-approver"
+jobName: "eks-distro-pod-identity-webhook-cert-approver"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

The Service name doesn't support starting with a number, so changing the name. However, if we still want to include the number for the mutatingwebhookconfiguration resource, we can append that to the name of that resource or split up the naming in values.

Took an initial look into why the linting isn't catching the fact that this PR isn't modifying the version in Chart.yaml, but couldn't find anything. Will look more into it later.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
