### PR TITLE
Decrease loop for install.sh in pod-identity-webhook helm chart

### DIFF
--- a/helm-charts/stable/amazon-eks-pod-identity-webhook/Chart.yaml
+++ b/helm-charts/stable/amazon-eks-pod-identity-webhook/Chart.yaml
@@ -29,7 +29,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.2
+version: 1.0.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

The loop for the job that deploys in our fargate cluster is too long, causing a timeout when helm is waiting for the hook to finish. I didn't encounter this issue on my devstack, but the csr's got approved within the first 2 loops, so 10 should definitely be enough for us.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
