### PR TITLE
Add bash 4.3 to builder base to support kubernetes make test

### DIFF
--- a/builder-base/Dockerfile
+++ b/builder-base/Dockerfile
@@ -17,6 +17,7 @@ FROM ${BASE_IMAGE}
 
 COPY golang-checksum /golang-checksum
 COPY buildkit-checksum /buildkit-checksum
+COPY bash-checksum /bash-checksum
 COPY install.sh /opt/install.sh
 RUN bash /opt/install.sh
 

--- a/builder-base/bash-checksum
+++ b/builder-base/bash-checksum
@@ -1,0 +1,1 @@
+afc687a28e0e24dc21b988fa159ff9dbcf6b7caa92ade8645cc6d5605cd024d4  bash-4.3.tar.gz

--- a/builder-base/install.sh
+++ b/builder-base/install.sh
@@ -66,5 +66,19 @@ sha256sum -c $BASE_DIR/buildkit-checksum
 tar -C /usr -xzf buildkit-$BUILDKIT_VERSION.linux-amd64.tar.gz
 rm -rf buildkit-$BUILDKIT_VERSION.linux-amd64.tar.gz
 
+# Bash 4.3 is required to run kubernetes make test
+OVERRIDE_BASH_VERSION="${OVERRIDE_BASH_VERSION:-4.3}"
+wget http://ftp.gnu.org/gnu/bash/bash-$OVERRIDE_BASH_VERSION.tar.gz 
+tar -xf bash-$OVERRIDE_BASH_VERSION.tar.gz
+sha256sum -c $BASE_DIR/bash-checksum
+
+cd bash-$OVERRIDE_BASH_VERSION
+./configure --prefix=/usr --without-bash-malloc
+make 
+make install 
+cd ..
+rm -f bash-$OVERRIDE_BASH_VERSION.tar.gz
+rm -rf bash-$OVERRIDE_BASH_VERSION
+
 # directory setup
 mkdir -p /go/src /go/bin /go/pkg /go/src/github.com/aws/eks-distro


### PR DESCRIPTION
Running make test from the upstream kubernetes source requires bash version of 4.3 or higher.  Amazon linux ships with 4.2 and there doesn't seem to be a way to get it without building it from source.

I have built this docker image locally and built kubernetes and run the unit tests with it.

light reading:
https://github.com/kubernetes/kubernetes/issues/82605
https://github.com/kubernetes/kubernetes/issues/78702

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
