### PR TITLE
Qualify README, improve consistency of Makefiles

### DIFF
--- a/builder-base/Makefile
+++ b/builder-base/Makefile
@@ -16,7 +16,6 @@ endif
 
 .PHONY: local-images
 local-images:
-	mkdir -p /tmp/builder-base
 	# Sleeping until buildkit daemon is running on the other container
 	sleep 10
 	buildctl \
@@ -26,7 +25,7 @@ local-images:
 		--opt build-arg:BASE_IMAGE=$(BASE_IMAGE) \
 		--local dockerfile=./ \
 		--local context=. \
-		--output type=tar,dest=/tmp/builder-base/output.tar
+		--output type=tar,dest=/tmp/builder-base.tar
 	./update_base_image.sh --dry-run
 
 .PHONY: images

--- a/builder-base/README.md
+++ b/builder-base/README.md
@@ -2,3 +2,4 @@
 
 This image is used to build other jobs. It is a base image for prow jobs.
 
+New builds of this image will automatically raise a PR to update the image tags in the prowjobs in the aws/eks-distro-prow-jobs repo

--- a/eks-distro-base/Makefile
+++ b/eks-distro-base/Makefile
@@ -100,9 +100,9 @@ release: images
 update: 
 	# Sleeping until buildkit daemon is running on the other container
 	sleep 10
-	$(eval RETURN_VALUE="$(shell ./check_update.sh $(IMAGE_REPO) $(IMAGE_NAME) $(IMAGE_TAG))")
-	if [ $(RETURN_VALUE) = "Updates required" ]; then \
+	$(eval RETURN_MESSAGE="$(shell ./check_update.sh $(IMAGE_REPO) $(IMAGE_NAME) $(IMAGE_TAG))")
+	if [ $(RETURN_MESSAGE) = "Updates required" ]; then \
 		$(MAKE) images \
-	elif [ $(RETURN_VALUE) = "Error" ]; then \
+	elif [ $(RETURN_MESSAGE) = "Error" ]; then \
 		exit 1; \
 	fi

--- a/eks-distro-base/README.md
+++ b/eks-distro-base/README.md
@@ -1,3 +1,5 @@
 # eks-distro/base container image
 
 This image is used as the base image for building images of our deliverable projects such as coredns, metrics-server, etc.
+
+New builds of this image will automatically raise a PR to update the image tags in the TAG_FILE in this repo and the Makefiles in the aws/eks-distro repo.


### PR DESCRIPTION
Adding PR creation info to README's, remove unnecessary steps from builder-base Makefile, fix varnames in eks-distro-base Makefile.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
