### PR TITLE
Fix sed command for Makefile, resolve git push errors

### DIFF
--- a/builder-base/Makefile
+++ b/builder-base/Makefile
@@ -6,7 +6,8 @@ BASE_IMAGE?=public.ecr.aws/amazonlinux/amazonlinux:2
 
 IMAGE_REPO?=$(AWS_ACCOUNT_ID).dkr.ecr.$(AWS_REGION).amazonaws.com
 IMAGE_NAME?=eks-distro/builder
-# This tag is overwritten in the prow job to point to the commit hash
+# This tag is overwritten in the prow job to point to the PR branch commit hash (presubmit)
+# or the base branch commit hash (postsubmit)
 IMAGE_TAG?=latest
 IMAGE?=$(IMAGE_REPO)/$(IMAGE_NAME):$(IMAGE_TAG)
 

--- a/eks-distro-base/update_base_image.sh
+++ b/eks-distro-base/update_base_image.sh
@@ -24,4 +24,4 @@ REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 
 ${REPO_ROOT}/../pr-scripts/install_gh.sh
 ${REPO_ROOT}/../pr-scripts/create_pr.sh eks-distro-build-tooling '.*' $IMAGE_TAG TAG_FILE $DRY_RUN_FLAG
-${REPO_ROOT}/../pr-scripts/create_pr.sh eks-distro 'BASE_TAG?=.*' 'BASE_TAG?='"$IMAGE_TAG" Makefile $DRY_RUN_FLAG
+${REPO_ROOT}/../pr-scripts/create_pr.sh eks-distro 'BASE_TAG?=.*' 'BASE_TAG?='"$IMAGE_TAG" Makefile $IMAGE_TAG $DRY_RUN_FLAG


### PR DESCRIPTION
- Fixed `sed` command for main Makefile which was referencing an old variable
- Fixed `sed` command for PR body
- Fixed the push errors by configuring git


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
