### PR TITLE
Quote PR body and title in PR creation command

### DIFF
--- a/builder-base/update_base_image.sh
+++ b/builder-base/update_base_image.sh
@@ -19,6 +19,7 @@ set -o pipefail
 set -x
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+DRY_RUN_FLAG=$1
 
 ${REPO_ROOT}/../pr-scripts/install_gh.sh
-${REPO_ROOT}/../pr-scripts/create_pr.sh eks-distro-prow-jobs 'builder:.*' 'builder:'"$PULL_BASE_SHA" *.yaml $1
+${REPO_ROOT}/../pr-scripts/create_pr.sh eks-distro-prow-jobs 'builder:.*' 'builder:'"$PULL_BASE_SHA" *.yaml $DRY_RUN_FLAG

--- a/eks-distro-base/Makefile
+++ b/eks-distro-base/Makefile
@@ -6,7 +6,6 @@ BASE_IMAGE?=public.ecr.aws/amazonlinux/amazonlinux:2
 
 IMAGE_REPO?=$(AWS_ACCOUNT_ID).dkr.ecr.$(AWS_REGION).amazonaws.com
 IMAGE_NAME?=eks-distro/base
-# This tag is overwritten in the prow job to point to the commit hash
 IMAGE_TAG?=$(shell date "+%F-%s")
 IMAGE?=$(IMAGE_REPO)/$(IMAGE_NAME):$(IMAGE_TAG)
 

--- a/pr-scripts/create_pr.sh
+++ b/pr-scripts/create_pr.sh
@@ -92,5 +92,5 @@ gh auth login --with-token < /secrets/github-secrets/token
 
 PR_EXISTS=$(gh pr list | grep -c "${PR_BRANCH}" || true)
 if [ $PR_EXISTS -eq 0 ]; then
-  gh pr create --title $PR_TITLE --body $PR_BODY
+  gh pr create --title "$PR_TITLE" --body "$PR_BODY"
 fi


### PR DESCRIPTION
The `gh pr create` command expects quotes around the PR body and title strings. Changed the other files to trigger the jobs.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
