### PR TITLE
Skip image tag update for Kubernetes project

### DIFF
--- a/eks-distro-base/update_base_image.sh
+++ b/eks-distro-base/update_base_image.sh
@@ -18,9 +18,9 @@ set -e
 set -o pipefail
 set -x
 
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 IMAGE_TAG=$1
 DRY_RUN_FLAG=$2
-REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 
 ${REPO_ROOT}/../pr-scripts/install_gh.sh
 ${REPO_ROOT}/../pr-scripts/create_pr.sh eks-distro-build-tooling '.*' $IMAGE_TAG TAG_FILE $DRY_RUN_FLAG

--- a/pr-scripts/create_pr.sh
+++ b/pr-scripts/create_pr.sh
@@ -71,7 +71,9 @@ git rebase upstream/main
 
 for FILE in $(find ./ -type f -name $FILEPATH); do
     if [ $REPO = "eks-distro" ]; then
-        if [ $(dirname $FILE) = "." ]; then
+        if [ $(dirname $FILE) = "./projects/kubernetes/kubernetes" ]; then
+            continue
+        elif [ $(dirname $FILE) = "." ]; then
             OLD_TAG="^BASE_IMAGE?=\(.*\):.*"
             NEW_TAG="BASE_IMAGE?=\1:${IMAGE_TAG}"
         else


### PR DESCRIPTION
Kubernetes/Kubernetes project does not use the EKS Distro base image and hence we should skip tag update in that Makefile.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
