### PR TITLE
Improve the conditional construct for periodic job target

### DIFF
--- a/eks-distro-base/Makefile
+++ b/eks-distro-base/Makefile
@@ -96,12 +96,12 @@ build: local-images
 release: images
 
 .PHONY: update
-update: 
+update:
 	# Sleeping until buildkit daemon is running on the other container
 	sleep 10
 	$(eval RETURN_MESSAGE="$(shell ./check_update.sh $(IMAGE_REPO) $(IMAGE_NAME) $(IMAGE_TAG))")
 	if [ $(RETURN_MESSAGE) = "Updates required" ]; then \
-		$(MAKE) images \
+		$(MAKE) images; \
 	elif [ $(RETURN_MESSAGE) = "Error" ]; then \
 		exit 1; \
 	fi

--- a/eks-distro-base/check_update.sh
+++ b/eks-distro-base/check_update.sh
@@ -50,6 +50,8 @@ fi
 RETURN_STATUS=$(cat /tmp/${IMAGE_TAG}/return_value)
 if [ $RETURN_STATUS -eq 100 ]; then
     echo "Updates required"
+elif [ $RETURN_STATUS -eq 0 ]; then
+    echo "No updates required"
 elif [ $RETURN_STATUS -eq 1 ]; then
     echo "Error"
 fi


### PR DESCRIPTION
Qualifying the conditional for the `update` target invoked by the EKS Distro base periodic job with an additional check. Adding missing semicolon.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
