### PR TITLE
Add multiple versions of go

### DIFF
--- a/builder-base/golang-checksum
+++ b/builder-base/golang-checksum
@@ -1,1 +1,1 @@
-01cc3ddf6273900eba3e2bf311238828b7168b822bb57a9ccab4d7aa2acd6028  go1.13.15.linux-amd64.tar.gz
+3918e6cc85e7eaaa6f859f1bdbaac772e7a825b0eb423c63d3ae68b21f84b844  go1.15.6.linux-amd64.tar.gz

--- a/builder-base/install.sh
+++ b/builder-base/install.sh
@@ -47,7 +47,7 @@ yum install -y \
     wget \
     which
 
-GOLANG_VERSION="${GOLANG_VERSION:-1.13.15}"
+GOLANG_VERSION="${GOLANG_VERSION:-1.15.6}"
 wget \
     --progress dot:giga \
     --max-redirect=1 \
@@ -82,3 +82,14 @@ rm -rf bash-$OVERRIDE_BASH_VERSION
 
 # directory setup
 mkdir -p /go/src /go/bin /go/pkg /go/src/github.com/aws/eks-distro
+
+# install additional versions of go
+export GOPATH=/go
+export PATH=${GOPATH}/bin/:$PATH
+
+for version in "${GOLANG113_VERSION:-1.13.15}" "${GOLANG114_VERSION:-1.14.13}" "${GOLANG115_VERSION:-1.15.6}"; do
+    go get golang.org/dl/go${version}
+    go${version} download
+    mkdir -p ${GOPATH}/go${version}/bin
+    cp ${GOPATH}/bin/go${version} ${GOPATH}/go${version}/bin/go
+done


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Changes enable installation of multiple versions of go in our builder base image so that we can choose what version of the go binary to run based on the project we are building. This takes advantage of installing specific versions of go using `go get` as explained in this link: https://golang.org/doc/manage-install. Also updated the default go binary on the image to 1.15 so we wouldn't have to worry about using an older default.

Then, for each of our projects or the kubernetes version that we are trying to build, we can add an export to our path to include the path to this binary before the default version that a customer may have. That way, since the scope of the path would only be during the duration of the script, the go build will still succeed even if there isn't an installation of this binary. 

The line that we would add for the eks-distro PR will look something like this: `export PATH=/go/go${GOLANG_VERSION}/bin:$PATH`. I will be putting that up soon as well, but this PR isn't blocked by that. Whenever we want to upgrade specific versions or add more versions, it would be as simple as modifying it in the script below, and then consuming it by updating our PATH variable. I have tried aliasing, but that doesn't work well for scripts. Symlinking is an option, but it can be more destructive as we have to make sure we don't override the go binary that the customer has, or if we do, we would need to restore it correctly. This would ensure we don't worry about that.

Once this PR is merged, our eks-distro-pr-bot will automatically create a PR to update the builder base images in all of our prow jobs.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
