### PR TITLE
Remove minor version from our paths for golang

### DIFF
--- a/builder-base/install.sh
+++ b/builder-base/install.sh
@@ -87,9 +87,16 @@ mkdir -p /go/src /go/bin /go/pkg /go/src/github.com/aws/eks-distro
 export GOPATH=/go
 export PATH=${GOPATH}/bin/:$PATH
 
-for version in "${GOLANG113_VERSION:-1.13.15}" "${GOLANG114_VERSION:-1.14.13}" "${GOLANG115_VERSION:-1.15.6}"; do
+setupgo() {
+    local -r version=$1
     go get golang.org/dl/go${version}
     go${version} download
-    mkdir -p ${GOPATH}/go${version}/bin
-    cp ${GOPATH}/bin/go${version} ${GOPATH}/go${version}/bin/go
-done
+    # Removing the last number as we only care about the major version of golang
+    local -r majorversion=${version%.*}
+    mkdir -p ${GOPATH}/go${majorversion}/bin
+    cp ${GOPATH}/bin/go${version} ${GOPATH}/go${majorversion}/bin/go
+}
+
+setupgo "${GOLANG113_VERSION:-1.13.15}"
+setupgo "${GOLANG114_VERSION:-1.14.13}"
+setupgo "${GOLANG115_VERSION:-1.15.6}"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This is a continuation of https://github.com/aws/eks-distro-build-tooling/pull/86 and related to https://github.com/aws/eks-distro/pull/114

Since we don't need to know the minor version and only will use golang binaries based on the major version, such as "1.15", I am modifying the path that we are storing them in so for the related PR, we won't have to hardcode the versions in our script.

Also modified to just using a function instead so I can make use of local variables, and after some discussions on functions vs loops earlier.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
