### PR TITLE
Use PR branch ref SHA for presubmits instead of base ref

### DIFF
--- a/builder-base/update_base_image.sh
+++ b/builder-base/update_base_image.sh
@@ -21,5 +21,11 @@ set -x
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 DRY_RUN_FLAG=$1
 
+if [ $DRY_RUN_FLAG = "--dry-run" ]; then
+    NEW_TAG=$PULL_PULL_SHA
+else
+    NEW_TAG=$PULL_BASE_SHA
+fi
+
 ${REPO_ROOT}/../pr-scripts/install_gh.sh
-${REPO_ROOT}/../pr-scripts/create_pr.sh eks-distro-prow-jobs 'builder:.*' 'builder:'"$PULL_BASE_SHA" *.yaml $DRY_RUN_FLAG
+${REPO_ROOT}/../pr-scripts/create_pr.sh eks-distro-prow-jobs 'builder:.*' 'builder:'"$NEW_TAG" *.yaml $DRY_RUN_FLAG


### PR DESCRIPTION
Using the PULL_BASE_SHA environment variable for simulating the changes in the presubmit jobs could cause issued since it would essentially be trying to replace the existing tag with the same new tag value. This causes `git add` to not add any files, hence `git commit` fails with exit code 1 since there are no files to commit.

Hence for presubmits, we could use `PULL_PULL_SHA`, a job environment variable from the presubmit CI environment which refers to the SHA of the head commit of the PR against which the job runs.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
