### PR TITLE
Add default aws region to pod-identity-webhook

### DIFF
--- a/helm-charts/stable/amazon-eks-pod-identity-webhook/Chart.yaml
+++ b/helm-charts/stable/amazon-eks-pod-identity-webhook/Chart.yaml
@@ -29,7 +29,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.3
+version: 1.0.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm-charts/stable/amazon-eks-pod-identity-webhook/templates/Deployment.yaml
+++ b/helm-charts/stable/amazon-eks-pod-identity-webhook/templates/Deployment.yaml
@@ -51,6 +51,7 @@ spec:
         - --annotation-prefix=eks.amazonaws.com
         - --token-audience=sts.amazonaws.com
         - --token-expiration={{ .Values.webhook.tokenExpiration }}
+        - --aws-default-region={{ .Values.webhook.defaultRegion }}
         - --sts-regional-endpoint={{ .Values.webhook.stsRegionalEndpoint }}
         - --metrics-port={{ .Values.webhook.metricsPort }}
         - --port={{ .Values.webhook.port }}

--- a/helm-charts/stable/amazon-eks-pod-identity-webhook/values.yaml
+++ b/helm-charts/stable/amazon-eks-pod-identity-webhook/values.yaml
@@ -32,6 +32,7 @@ fargate: false
 # Parameters to webhook are defined here: https://github.com/aws/amazon-eks-pod-identity-webhook#usage
 webhook:
   tokenExpiration: 3600
+  defaultRegion: us-west-2
   stsRegionalEndpoint: true
   port: 443
   metricsPort: 9999


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Adding default region flag so that the webhook can append `AWS_REGION` and `AWS_DEFAULT_REGION` environment variables to the pod to be able to make use of the regional STS endpoints. This link mentions that the region needs to be set as well in order to make use of regional endpoints, and I noticed in our pods that the region wasn't being set: https://docs.aws.amazon.com/credref/latest/refdocs/setting-global-sts_regional_endpoints.html

The region field is configurable so that it can set in our infrastructure when deploying the helm chart. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
