### PR TITLE
Install AWSCLIv2 on builder-base image

### DIFF
--- a/builder-base/install.sh
+++ b/builder-base/install.sh
@@ -30,7 +30,6 @@ yum update -y
 
 amazon-linux-extras enable docker
 yum install -y \
-    awscli \
     amazon-ecr-credential-helper \
     curl \
     gcc \
@@ -43,9 +42,15 @@ yum install -y \
     python3-pip \
     rsync \
     tar \
+    unzip \
     vim \
     wget \
     which
+
+curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+unzip awscliv2.zip
+./aws/install
+aws --version
 
 GOLANG_VERSION="${GOLANG_VERSION:-1.15.6}"
 wget \


### PR DESCRIPTION
Though AWS CLI version 2 is generally available, the builder-base image still uses version 1 of the CLI since it is downloaded via `yum` and the latest available version in the `yum` repositories is `1.18.147`. Hence we should install version 2 using [these instructions](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2-linux.html#cliv2-linux-install).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
