### PR TITLE
Add support for empty repositories list in CP values

### DIFF
--- a/helm-charts/stable/prow-control-plane/Chart.yaml
+++ b/helm-charts/stable/prow-control-plane/Chart.yaml
@@ -29,7 +29,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.5
+version: 1.0.6
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm-charts/stable/prow-control-plane/templates/config-ConfigMap.yaml
+++ b/helm-charts/stable/prow-control-plane/templates/config-ConfigMap.yaml
@@ -83,7 +83,6 @@ data:
             entrypoint: {{ .Values.utility_images.entrypoint }}
             initupload: {{ .Values.utility_images.initupload }}
             sidecar: {{ .Values.utility_images.sidecar }}
-
     tide:
       queries:
       - labels:
@@ -94,12 +93,15 @@ data:
         - do-not-merge/hold
         - do-not-merge/work-in-progress
         - do-not-merge/invalid-owners-file
-        repos:
-        {{-  range $repo := .Values.repositories }}
-          - {{ $repo.org }}/{{ $repo.name }}
-        {{- end }}
+        repos: 
+        {{- if eq (len .Values.repositories) 0 }} []
+        {{- else }}
+          {{-  range $repo := .Values.repositories }}
+        - {{ $repo.org }}/{{ $repo.name }}
+          {{- end }}
       merge_method:
-      {{-  range $repo := .Values.repositories }}
+        {{-  range $repo := .Values.repositories }}
         {{ $repo.org }}/{{ $repo.name }}: squash
-      {{- end }}
+        {{- end }}
+        {{- end }}
     decorate_all_jobs: true

--- a/helm-charts/stable/prow-control-plane/templates/plugins-ConfigMap.yaml
+++ b/helm-charts/stable/prow-control-plane/templates/plugins-ConfigMap.yaml
@@ -18,7 +18,9 @@ metadata:
   name: plugins
 data:
   plugins.yaml: |
-    plugins:
+    plugins: 
+    {{- if eq (len .Values.repositories) 0 }} []
+    {{- else }}
       {{- range $repo := .Values.repositories }}
       {{ $repo.org }}/{{ $repo.name }}:
       - approve
@@ -39,6 +41,7 @@ data:
       - {{ $extra }}
       {{- end }}
       {{- end }}
+    {{- end }}
     config_updater:
       maps:
 {{ toYaml .Values.plugins.configUpdaterMaps | indent 8 }}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Add support for empty repositories list in CP values. 
Currently, if we pass in empty repositories to prow-control-plane helm chart, it will create invalid ConfigMaps. This PR solves that issue.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
