### PR TITLE
Generate release CRD from artifact directory

### DIFF
--- a/release/cmd/release.go
+++ b/release/cmd/release.go
@@ -41,11 +41,13 @@ var releaseCmd = &cobra.Command{
 		imageRepository := viper.GetString("image-repository")
 		cdnURL := viper.GetString("cdn")
 		releaseNumber := viper.GetInt("release-number")
+		artifactDir := fmt.Sprintf("kubernetes-%s/releases/%d/artifacts/", releaseBranch, releaseNumber)
 
 		releaseConfig := &pkg.ReleaseConfig{
 			ContainerImageRepository: imageRepository,
 			ArtifactURL:              cdnURL,
 			BuildRepoSource:          sourceDir,
+			ArtifactDir:              artifactDir,
 			ReleaseDate:              time.Now().UTC(),
 		}
 		release := &distrov1alpha1.Release{

--- a/release/pkg/assets_attacher.go
+++ b/release/pkg/assets_attacher.go
@@ -16,7 +16,7 @@ package pkg
 
 import (
 	"fmt"
-	"path"
+	"path/filepath"
 
 	distrov1alpha1 "github.com/aws/eks-distro-build-tooling/release/api/v1alpha1"
 	"github.com/pkg/errors"
@@ -25,7 +25,7 @@ import (
 // GetAttacherComponent returns the Component for Kubernetes
 func (r *ReleaseConfig) GetAttacherComponent(spec distrov1alpha1.ReleaseSpec) (*distrov1alpha1.Component, error) {
 	projectSource := "projects/kubernetes-csi/external-attacher"
-	tagFile := path.Join(r.BuildRepoSource, projectSource, "GIT_TAG")
+	tagFile := filepath.Join(r.BuildRepoSource, projectSource, "GIT_TAG")
 	gitTag, err := readTag(tagFile)
 	if err != nil {
 		return nil, errors.Cause(err)

--- a/release/pkg/assets_authenticator.go
+++ b/release/pkg/assets_authenticator.go
@@ -16,7 +16,7 @@ package pkg
 
 import (
 	"fmt"
-	"path"
+	"path/filepath"
 
 	distrov1alpha1 "github.com/aws/eks-distro-build-tooling/release/api/v1alpha1"
 	"github.com/pkg/errors"
@@ -25,7 +25,7 @@ import (
 // GetKubernetesComponent returns the Component for Kubernetes
 func (r *ReleaseConfig) GetAuthenticatorComponent(spec distrov1alpha1.ReleaseSpec) (*distrov1alpha1.Component, error) {
 	projectSource := "projects/kubernetes-sigs/aws-iam-authenticator"
-	tagFile := path.Join(r.BuildRepoSource, projectSource, "GIT_TAG")
+	tagFile := filepath.Join(r.BuildRepoSource, projectSource, "GIT_TAG")
 	gitTag, err := readTag(tagFile)
 	if err != nil {
 		return nil, errors.Cause(err)
@@ -39,13 +39,14 @@ func (r *ReleaseConfig) GetAuthenticatorComponent(spec distrov1alpha1.ReleaseSpe
 	for os, arches := range osArchMap {
 		for _, arch := range arches {
 			filename := fmt.Sprintf("aws-iam-authenticator-%s-%s-%s.tar.gz", os, arch, gitTag)
-			tarfile := path.Join(r.BuildRepoSource, projectSource, "_output/tar", filename)
+			dirname := fmt.Sprintf("aws-iam-authenticator/%s/", gitTag)
+			tarfile := filepath.Join(r.ArtifactDir, dirname, filename)
 
 			sha256, sha512, err := r.readShaSums(tarfile)
 			if err != nil {
 				return nil, errors.Cause(err)
 			}
-			assetPath, err := r.GetURI(path.Join(
+			assetPath, err := r.GetURI(filepath.Join(
 				fmt.Sprintf("kubernetes-%s", spec.Channel),
 				"releases",
 				fmt.Sprintf("%d", spec.Number),

--- a/release/pkg/assets_cni.go
+++ b/release/pkg/assets_cni.go
@@ -16,7 +16,7 @@ package pkg
 
 import (
 	"fmt"
-	"path"
+	"path/filepath"
 
 	distrov1alpha1 "github.com/aws/eks-distro-build-tooling/release/api/v1alpha1"
 	"github.com/pkg/errors"
@@ -25,7 +25,7 @@ import (
 // GetKubernetesComponent returns the Component for Kubernetes
 func (r *ReleaseConfig) GetCniComponent(spec distrov1alpha1.ReleaseSpec) (*distrov1alpha1.Component, error) {
 	projectSource := "projects/containernetworking/plugins"
-	tagFile := path.Join(r.BuildRepoSource, projectSource, "GIT_TAG")
+	tagFile := filepath.Join(r.BuildRepoSource, projectSource, "GIT_TAG")
 	gitTag, err := readTag(tagFile)
 	if err != nil {
 		return nil, errors.Cause(err)
@@ -37,13 +37,14 @@ func (r *ReleaseConfig) GetCniComponent(spec distrov1alpha1.ReleaseSpec) (*distr
 	for os, arches := range osArchMap {
 		for _, arch := range arches {
 			filename := fmt.Sprintf("cni-plugins-%s-%s-%s.tar.gz", os, arch, gitTag)
-			tarfile := path.Join(r.BuildRepoSource, projectSource, "_output/tar", filename)
+			dirname := fmt.Sprintf("plugins/%s/", gitTag)
+			tarfile := filepath.Join(r.ArtifactDir, dirname, filename)
 
 			sha256, sha512, err := r.readShaSums(tarfile)
 			if err != nil {
 				return nil, errors.Cause(err)
 			}
-			assetPath, err := r.GetURI(path.Join(
+			assetPath, err := r.GetURI(filepath.Join(
 				fmt.Sprintf("kubernetes-%s", spec.Channel),
 				"releases",
 				fmt.Sprintf("%d", spec.Number),

--- a/release/pkg/assets_cni.go
+++ b/release/pkg/assets_cni.go
@@ -37,8 +37,7 @@ func (r *ReleaseConfig) GetCniComponent(spec distrov1alpha1.ReleaseSpec) (*distr
 	for os, arches := range osArchMap {
 		for _, arch := range arches {
 			filename := fmt.Sprintf("cni-plugins-%s-%s-%s.tar.gz", os, arch, gitTag)
-			dirname := fmt.Sprintf("plugins/%s/", gitTag)
-			tarfile := filepath.Join(r.ArtifactDir, dirname, filename)
+			tarfile := filepath.Join(r.ArtifactDir, "plugins", gitTag, filename)
 
 			sha256, sha512, err := r.readShaSums(tarfile)
 			if err != nil {

--- a/release/pkg/assets_coredns.go
+++ b/release/pkg/assets_coredns.go
@@ -16,7 +16,7 @@ package pkg
 
 import (
 	"fmt"
-	"path"
+	"path/filepath"
 
 	distrov1alpha1 "github.com/aws/eks-distro-build-tooling/release/api/v1alpha1"
 	"github.com/pkg/errors"
@@ -25,7 +25,7 @@ import (
 // GetCorednsComponent returns the Component for Kubernetes
 func (r *ReleaseConfig) GetCorednsComponent(spec distrov1alpha1.ReleaseSpec) (*distrov1alpha1.Component, error) {
 	projectSource := "projects/coredns/coredns"
-	tagFile := path.Join(r.BuildRepoSource, projectSource, "GIT_TAG")
+	tagFile := filepath.Join(r.BuildRepoSource, projectSource, "GIT_TAG")
 	gitTag, err := readTag(tagFile)
 	if err != nil {
 		return nil, errors.Cause(err)

--- a/release/pkg/assets_etcd.go
+++ b/release/pkg/assets_etcd.go
@@ -16,7 +16,7 @@ package pkg
 
 import (
 	"fmt"
-	"path"
+	"path/filepath"
 
 	distrov1alpha1 "github.com/aws/eks-distro-build-tooling/release/api/v1alpha1"
 	"github.com/pkg/errors"
@@ -25,7 +25,7 @@ import (
 // GetEtcdComponent returns the Component for Etcd
 func (r *ReleaseConfig) GetEtcdComponent(spec distrov1alpha1.ReleaseSpec) (*distrov1alpha1.Component, error) {
 	projectSource := "projects/etcd-io/etcd"
-	tagFile := path.Join(r.BuildRepoSource, projectSource, "GIT_TAG")
+	tagFile := filepath.Join(r.BuildRepoSource, projectSource, "GIT_TAG")
 	gitTag, err := readTag(tagFile)
 	if err != nil {
 		return nil, errors.Cause(err)
@@ -37,13 +37,14 @@ func (r *ReleaseConfig) GetEtcdComponent(spec distrov1alpha1.ReleaseSpec) (*dist
 	for os, arches := range osArchMap {
 		for _, arch := range arches {
 			filename := fmt.Sprintf("etcd-%s-%s-%s.tar.gz", os, arch, gitTag)
-			tarfile := path.Join(r.BuildRepoSource, projectSource, "_output/tar", filename)
+			dirname := fmt.Sprintf("etcd/%s/", gitTag)
+			tarfile := filepath.Join(r.ArtifactDir, dirname, filename)
 
 			sha256, sha512, err := r.readShaSums(tarfile)
 			if err != nil {
 				return nil, errors.Cause(err)
 			}
-			assetPath, err := r.GetURI(path.Join(
+			assetPath, err := r.GetURI(filepath.Join(
 				fmt.Sprintf("kubernetes-%s", spec.Channel),
 				"releases",
 				fmt.Sprintf("%d", spec.Number),

--- a/release/pkg/assets_etcd.go
+++ b/release/pkg/assets_etcd.go
@@ -38,7 +38,7 @@ func (r *ReleaseConfig) GetEtcdComponent(spec distrov1alpha1.ReleaseSpec) (*dist
 		for _, arch := range arches {
 			filename := fmt.Sprintf("etcd-%s-%s-%s.tar.gz", os, arch, gitTag)
 			dirname := fmt.Sprintf("etcd/%s/", gitTag)
-			tarfile := filepath.Join(r.ArtifactDir, dirname, filename)
+			tarfile := filepath.Join(r.ArtifactDir, "etcd", gitTag, filename)
 
 			sha256, sha512, err := r.readShaSums(tarfile)
 			if err != nil {

--- a/release/pkg/assets_etcd.go
+++ b/release/pkg/assets_etcd.go
@@ -37,7 +37,6 @@ func (r *ReleaseConfig) GetEtcdComponent(spec distrov1alpha1.ReleaseSpec) (*dist
 	for os, arches := range osArchMap {
 		for _, arch := range arches {
 			filename := fmt.Sprintf("etcd-%s-%s-%s.tar.gz", os, arch, gitTag)
-			dirname := fmt.Sprintf("etcd/%s/", gitTag)
 			tarfile := filepath.Join(r.ArtifactDir, "etcd", gitTag, filename)
 
 			sha256, sha512, err := r.readShaSums(tarfile)

--- a/release/pkg/assets_k8s.go
+++ b/release/pkg/assets_k8s.go
@@ -16,7 +16,7 @@ package pkg
 
 import (
 	"fmt"
-	"path"
+	"path/filepath"
 
 	distrov1alpha1 "github.com/aws/eks-distro-build-tooling/release/api/v1alpha1"
 )
@@ -68,12 +68,12 @@ func (r *ReleaseConfig) GetKubernetesComponent(spec distrov1alpha1.ReleaseSpec) 
 	for os, arches := range osArchMap {
 		for _, arch := range arches {
 			for _, binary := range osBinaryMap[os] {
-				filename := path.Join("bin", os, arch, binary)
-				sha256, sha512, err := r.ReadK8sShaSums(spec.Channel, filename)
+				filename := filepath.Join("bin", os, arch, binary)
+				sha256, sha512, err := r.ReadK8sShaSums(gitTag, filename)
 				if err != nil {
 					return nil, err
 				}
-				assetPath, err := r.GetURI(path.Join(
+				assetPath, err := r.GetURI(filepath.Join(
 					fmt.Sprintf("kubernetes-%s", spec.Channel),
 					"releases",
 					fmt.Sprintf("%d", spec.Number),
@@ -100,11 +100,11 @@ func (r *ReleaseConfig) GetKubernetesComponent(spec distrov1alpha1.ReleaseSpec) 
 			}
 			for _, component := range osComponentMap[os] {
 				filename := fmt.Sprintf("kubernetes-%s-%s-%s.tar.gz", component, os, arch)
-				sha256, sha512, err := r.ReadK8sShaSums(spec.Channel, filename)
+				sha256, sha512, err := r.ReadK8sShaSums(gitTag, filename)
 				if err != nil {
 					return nil, err
 				}
-				assetPath, err := r.GetURI(path.Join(
+				assetPath, err := r.GetURI(filepath.Join(
 					fmt.Sprintf("kubernetes-%s", spec.Channel),
 					"releases",
 					fmt.Sprintf("%d", spec.Number),
@@ -159,12 +159,12 @@ func (r *ReleaseConfig) GetKubernetesComponent(spec distrov1alpha1.ReleaseSpec) 
 		})
 		if binary != "pause" {
 			for _, arch := range linuxImageArches {
-				filename := path.Join("bin", "linux", arch, fmt.Sprintf("%s.tar", binary))
-				sha256, sha512, err := r.ReadK8sShaSums(spec.Channel, filename)
+				filename := filepath.Join("bin", "linux", arch, fmt.Sprintf("%s.tar", binary))
+				sha256, sha512, err := r.ReadK8sShaSums(gitTag, filename)
 				if err != nil {
 					return nil, err
 				}
-				assetPath, err := r.GetURI(path.Join(
+				assetPath, err := r.GetURI(filepath.Join(
 					fmt.Sprintf("kubernetes-%s", spec.Channel),
 					"releases",
 					fmt.Sprintf("%d", spec.Number),
@@ -196,11 +196,11 @@ func (r *ReleaseConfig) GetKubernetesComponent(spec distrov1alpha1.ReleaseSpec) 
 	assets = append(assets, imageTarAssets...)
 
 	filename := "kubernetes-src.tar.gz"
-	sha256, sha512, err := r.ReadK8sShaSums(spec.Channel, filename)
+	sha256, sha512, err := r.ReadK8sShaSums(gitTag, filename)
 	if err != nil {
 		return nil, err
 	}
-	assetPath, err := r.GetURI(path.Join(
+	assetPath, err := r.GetURI(filepath.Join(
 		fmt.Sprintf("kubernetes-%s", spec.Channel),
 		"releases",
 		fmt.Sprintf("%d", spec.Number),

--- a/release/pkg/assets_livenessprobe.go
+++ b/release/pkg/assets_livenessprobe.go
@@ -16,7 +16,7 @@ package pkg
 
 import (
 	"fmt"
-	"path"
+	"path/filepath"
 
 	distrov1alpha1 "github.com/aws/eks-distro-build-tooling/release/api/v1alpha1"
 	"github.com/pkg/errors"
@@ -25,7 +25,7 @@ import (
 // GetLivenessprobeComponent returns the Component for Kubernetes
 func (r *ReleaseConfig) GetLivenessprobeComponent(spec distrov1alpha1.ReleaseSpec) (*distrov1alpha1.Component, error) {
 	projectSource := "projects/kubernetes-csi/livenessprobe"
-	tagFile := path.Join(r.BuildRepoSource, projectSource, "GIT_TAG")
+	tagFile := filepath.Join(r.BuildRepoSource, projectSource, "GIT_TAG")
 	gitTag, err := readTag(tagFile)
 	if err != nil {
 		return nil, errors.Cause(err)

--- a/release/pkg/assets_metricsserver.go
+++ b/release/pkg/assets_metricsserver.go
@@ -16,7 +16,7 @@ package pkg
 
 import (
 	"fmt"
-	"path"
+	"path/filepath"
 
 	distrov1alpha1 "github.com/aws/eks-distro-build-tooling/release/api/v1alpha1"
 	"github.com/pkg/errors"
@@ -25,7 +25,7 @@ import (
 // GetMetricsServerComponent returns the Component for metrics-server
 func (r *ReleaseConfig) GetMetricsServerComponent(spec distrov1alpha1.ReleaseSpec) (*distrov1alpha1.Component, error) {
 	projectSource := "projects/kubernetes-sigs/metrics-server"
-	tagFile := path.Join(r.BuildRepoSource, projectSource, "GIT_TAG")
+	tagFile := filepath.Join(r.BuildRepoSource, projectSource, "GIT_TAG")
 	gitTag, err := readTag(tagFile)
 	if err != nil {
 		return nil, errors.Cause(err)

--- a/release/pkg/assets_provisioner.go
+++ b/release/pkg/assets_provisioner.go
@@ -16,7 +16,7 @@ package pkg
 
 import (
 	"fmt"
-	"path"
+	"path/filepath"
 
 	distrov1alpha1 "github.com/aws/eks-distro-build-tooling/release/api/v1alpha1"
 	"github.com/pkg/errors"
@@ -25,7 +25,7 @@ import (
 // GetProvisionerComponent returns the Component for Kubernetes
 func (r *ReleaseConfig) GetProvisionerComponent(spec distrov1alpha1.ReleaseSpec) (*distrov1alpha1.Component, error) {
 	projectSource := "projects/kubernetes-csi/external-provisioner"
-	tagFile := path.Join(r.BuildRepoSource, projectSource, "GIT_TAG")
+	tagFile := filepath.Join(r.BuildRepoSource, projectSource, "GIT_TAG")
 	gitTag, err := readTag(tagFile)
 	if err != nil {
 		return nil, errors.Cause(err)

--- a/release/pkg/assets_registrar.go
+++ b/release/pkg/assets_registrar.go
@@ -16,7 +16,7 @@ package pkg
 
 import (
 	"fmt"
-	"path"
+	"path/filepath"
 
 	distrov1alpha1 "github.com/aws/eks-distro-build-tooling/release/api/v1alpha1"
 	"github.com/pkg/errors"
@@ -25,7 +25,7 @@ import (
 // GetRegistrarComponent returns the Component for Kubernetes
 func (r *ReleaseConfig) GetRegistrarComponent(spec distrov1alpha1.ReleaseSpec) (*distrov1alpha1.Component, error) {
 	projectSource := "projects/kubernetes-csi/node-driver-registrar"
-	tagFile := path.Join(r.BuildRepoSource, projectSource, "GIT_TAG")
+	tagFile := filepath.Join(r.BuildRepoSource, projectSource, "GIT_TAG")
 	gitTag, err := readTag(tagFile)
 	if err != nil {
 		return nil, errors.Cause(err)

--- a/release/pkg/assets_resizer.go
+++ b/release/pkg/assets_resizer.go
@@ -16,7 +16,7 @@ package pkg
 
 import (
 	"fmt"
-	"path"
+	"path/filepath"
 
 	distrov1alpha1 "github.com/aws/eks-distro-build-tooling/release/api/v1alpha1"
 	"github.com/pkg/errors"
@@ -25,7 +25,7 @@ import (
 // GetResizerComponent returns the Component for Kubernetes
 func (r *ReleaseConfig) GetResizerComponent(spec distrov1alpha1.ReleaseSpec) (*distrov1alpha1.Component, error) {
 	projectSource := "projects/kubernetes-csi/external-resizer"
-	tagFile := path.Join(r.BuildRepoSource, projectSource, "GIT_TAG")
+	tagFile := filepath.Join(r.BuildRepoSource, projectSource, "GIT_TAG")
 	gitTag, err := readTag(tagFile)
 	if err != nil {
 		return nil, errors.Cause(err)

--- a/release/pkg/assets_snapshotter.go
+++ b/release/pkg/assets_snapshotter.go
@@ -16,7 +16,7 @@ package pkg
 
 import (
 	"fmt"
-	"path"
+	"path/filepath"
 
 	distrov1alpha1 "github.com/aws/eks-distro-build-tooling/release/api/v1alpha1"
 	"github.com/pkg/errors"
@@ -25,7 +25,7 @@ import (
 // GetSnapshotterComponent returns the Component for Kubernetes
 func (r *ReleaseConfig) GetSnapshotterComponent(spec distrov1alpha1.ReleaseSpec) (*distrov1alpha1.Component, error) {
 	projectSource := "projects/kubernetes-csi/external-snapshotter"
-	tagFile := path.Join(r.BuildRepoSource, projectSource, "GIT_TAG")
+	tagFile := filepath.Join(r.BuildRepoSource, projectSource, "GIT_TAG")
 	gitTag, err := readTag(tagFile)
 	if err != nil {
 		return nil, errors.Cause(err)

--- a/release/pkg/generate_spec.go
+++ b/release/pkg/generate_spec.go
@@ -27,6 +27,7 @@ type ReleaseConfig struct {
 	ContainerImageRepository string
 	ArtifactURL              string
 	BuildRepoSource          string
+	ArtifactDir              string
 	ReleaseDate              time.Time
 }
 

--- a/release/pkg/kube_reader.go
+++ b/release/pkg/kube_reader.go
@@ -16,7 +16,6 @@ package pkg
 
 import (
 	"bufio"
-	"fmt"
 	"io"
 	"os"
 	"path/filepath"

--- a/release/pkg/kube_reader.go
+++ b/release/pkg/kube_reader.go
@@ -27,8 +27,7 @@ import (
 )
 
 func (r *ReleaseConfig) ReadK8sShaSums(gitTag, filename string) (sha256, sha512 string, err error) {
-	dirname := fmt.Sprintf("kubernetes/%s/", gitTag)
-	assetFile := filepath.Join(r.ArtifactDir, dirname, filename)
+	assetFile := filepath.Join(r.ArtifactDir, "kubernetes", gitTag, filename)
 	return r.readShaSums(assetFile)
 }
 

--- a/release/pkg/kube_reader.go
+++ b/release/pkg/kube_reader.go
@@ -16,6 +16,7 @@ package pkg
 
 import (
 	"bufio"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -25,9 +26,9 @@ import (
 	"github.com/pkg/errors"
 )
 
-func (r *ReleaseConfig) ReadK8sShaSums(releaseBranch, filename string) (sha256, sha512 string, err error) {
-
-	assetFile := filepath.Join(r.BuildRepoSource, "projects/kubernetes/kubernetes/_output", releaseBranch, filename)
+func (r *ReleaseConfig) ReadK8sShaSums(gitTag, filename string) (sha256, sha512 string, err error) {
+	dirname := fmt.Sprintf("kubernetes/%s/", gitTag)
+	assetFile := filepath.Join(r.ArtifactDir, dirname, filename)
 	return r.readShaSums(assetFile)
 }
 


### PR DESCRIPTION
Generate CRD from generated artifact directory. Previously, we were generating from all over the repo in the _output directories. This will help ensure that the artifact directory matches the CRD.
