### PR TITLE
Add prometheus annotations to Prow pods to scrape metrics

### DIFF
--- a/helm-charts/stable/prow-control-plane/Chart.yaml
+++ b/helm-charts/stable/prow-control-plane/Chart.yaml
@@ -29,7 +29,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.6
+version: 1.0.7
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm-charts/stable/prow-control-plane/templates/crier-Deployment.yaml
+++ b/helm-charts/stable/prow-control-plane/templates/crier-Deployment.yaml
@@ -25,6 +25,12 @@ spec:
       app: crier
   template:
     metadata:
+      {{- if .Values.crier.scrape_metrics }}
+      annotations:
+        prometheus.io/path: /metrics
+        prometheus.io/port: '9090'
+        prometheus.io/scrape: 'true'
+      {{- end }}
       labels:
         app: crier
     spec:

--- a/helm-charts/stable/prow-control-plane/templates/deck-Deployment.yaml
+++ b/helm-charts/stable/prow-control-plane/templates/deck-Deployment.yaml
@@ -30,6 +30,12 @@ spec:
       app: deck
   template:
     metadata:
+      {{- if .Values.deck.scrape_metrics }}
+      annotations:
+        prometheus.io/path: /metrics
+        prometheus.io/port: '9090'
+        prometheus.io/scrape: 'true'
+      {{- end }}
       labels:
         app: deck
     spec:

--- a/helm-charts/stable/prow-control-plane/templates/ghProxy-Deployment.yaml
+++ b/helm-charts/stable/prow-control-plane/templates/ghProxy-Deployment.yaml
@@ -28,6 +28,12 @@ spec:
   replicas: 1
   template:
     metadata:
+      {{- if .Values.ghproxy.scrape_metrics }}
+      annotations:
+        prometheus.io/path: /metrics
+        prometheus.io/port: '9090'
+        prometheus.io/scrape: 'true'
+      {{- end }}
       labels:
         app: ghproxy
     spec:

--- a/helm-charts/stable/prow-control-plane/templates/hook-Deployment.yaml
+++ b/helm-charts/stable/prow-control-plane/templates/hook-Deployment.yaml
@@ -30,6 +30,12 @@ spec:
       app: hook
   template:
     metadata:
+      {{- if .Values.hook.scrape_metrics }}
+      annotations:
+        prometheus.io/path: /metrics
+        prometheus.io/port: '9090'
+        prometheus.io/scrape: 'true'
+      {{- end }}
       labels:
         app: hook
     spec:

--- a/helm-charts/stable/prow-control-plane/templates/horologium-Deployment.yaml
+++ b/helm-charts/stable/prow-control-plane/templates/horologium-Deployment.yaml
@@ -27,6 +27,12 @@ spec:
       app: horologium
   template:
     metadata:
+      {{- if .Values.horologium.scrape_metrics }}
+      annotations:
+        prometheus.io/path: /metrics
+        prometheus.io/port: '9090'
+        prometheus.io/scrape: 'true'
+      {{- end }}
       labels:
         app: horologium
     spec:

--- a/helm-charts/stable/prow-control-plane/templates/prow-controller-manager-Deployment.yaml
+++ b/helm-charts/stable/prow-control-plane/templates/prow-controller-manager-Deployment.yaml
@@ -25,6 +25,12 @@ spec:
       app: prow-controller-manager
   template:
     metadata:
+      {{- if .Values.prowControllerManager.scrape_metrics }}
+      annotations:
+        prometheus.io/path: /metrics
+        prometheus.io/port: '9090'
+        prometheus.io/scrape: 'true'
+      {{- end }}
       labels:
         app: prow-controller-manager
     spec:

--- a/helm-charts/stable/prow-control-plane/templates/sinker-Deployment.yaml
+++ b/helm-charts/stable/prow-control-plane/templates/sinker-Deployment.yaml
@@ -25,6 +25,12 @@ spec:
   replicas: 1
   template:
     metadata:
+      {{- if .Values.sinker.scrape_metrics }}
+      annotations:
+        prometheus.io/path: /metrics
+        prometheus.io/port: '9090'
+        prometheus.io/scrape: 'true'
+      {{- end }}
       labels:
         app: sinker
     spec:

--- a/helm-charts/stable/prow-control-plane/templates/tide-Deployment.yaml
+++ b/helm-charts/stable/prow-control-plane/templates/tide-Deployment.yaml
@@ -27,6 +27,12 @@ spec:
       app: tide
   template:
     metadata:
+      {{- if .Values.tide.scrape_metrics }}
+      annotations:
+        prometheus.io/path: /metrics
+        prometheus.io/port: '9090'
+        prometheus.io/scrape: 'true'
+      {{- end }}
       labels:
         app: tide
     spec:

--- a/helm-charts/stable/prow-control-plane/values.yaml
+++ b/helm-charts/stable/prow-control-plane/values.yaml
@@ -39,20 +39,24 @@ ingress:
   annotations: {}
 
 crier:
+  scrape_metrics: false
   image: gcr.io/k8s-prow/crier:v20200924-369a496323
   serviceAccount:
     create: false
 
 deck:
+  scrape_metrics: false
   image: gcr.io/k8s-prow/deck:v20200924-369a496323
   serviceAccount:
     create: false
 
 ghproxy:
+  scrape_metrics: false
   image: gcr.io/k8s-prow/ghproxy:v20200924-369a496323
   volumeSize: 100
 
 hook:
+  scrape_metrics: false
   image: gcr.io/k8s-prow/hook:v20200924-369a496323
   service:
     type: 'LoadBalancer'
@@ -60,16 +64,19 @@ hook:
     create: false
 
 horologium:
+  scrape_metrics: false
   image: gcr.io/k8s-prow/horologium:v20200924-369a496323
   serviceAccount:
     create: false
 
 prowControllerManager:
+  scrape_metrics: false
   image: gcr.io/k8s-prow/prow-controller-manager:v20200924-369a496323
   serviceAccount:
     create: false
 
 sinker:
+  scrape_metrics: false
   image: gcr.io/k8s-prow/sinker:v20200924-369a496323
   serviceAccount:
     create: false
@@ -80,6 +87,7 @@ statusreconciler:
     create: false
 
 tide:
+  scrape_metrics: false
   image: gcr.io/k8s-prow/tide:v20200924-369a496323
   serviceAccount:
     create: false


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Add prometheus annotations to Prow pods to scrape metrics

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
