### PR TITLE
Revert "Release number as string (#103)"

### DIFF
--- a/release/Makefile
+++ b/release/Makefile
@@ -20,7 +20,7 @@ build: fmt vet
 
 # Run against the configured Kubernetes cluster in ~/.kube/config
 run: generate fmt vet manifests
-	go run ./main.go release
+	go run ./main.go
 
 # Install CRDs into a cluster
 install: manifests

--- a/release/api/v1alpha1/release.go
+++ b/release/api/v1alpha1/release.go
@@ -24,8 +24,9 @@ type ReleaseSpec struct {
 	// +kubebuilder:validation:Required
 	Channel string `json:"channel,omitempty"`
 	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:Minimum=1
 	// Monotonically increasing release number
-	Number string `json:"number,omitempty"`
+	Number int `json:"number,omitempty"`
 
 	// +kubebuilder:validation:Required
 	BuildRepoCommit string `json:"buildRepoCommit,omitempty"`
@@ -33,7 +34,7 @@ type ReleaseSpec struct {
 
 // +kubebuilder:object:root=true
 // +kubebuilder:printcolumn:name="Release Channel",type=string,JSONPath=`.spec.channel`,description="The release channel"
-// +kubebuilder:printcolumn:name="Release",type=string,JSONPath=`.spec.number`,description="Release number"
+// +kubebuilder:printcolumn:name="Release",type=integer,JSONPath=`.spec.number`,description="Release number"
 // +kubebuilder:printcolumn:name="Release Date",type=string,format=date-time,JSONPath=`.status.date`,description="The date the release was published"
 // +kubebuilder:resource:singular="release",path="releases",shortName={"rel"}
 

--- a/release/api/v1alpha1/releasechannel.go
+++ b/release/api/v1alpha1/releasechannel.go
@@ -26,7 +26,7 @@ type ReleaseChannelSpec struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:printcolumn:name="TopicARN",type=string,JSONPath=`.spec.snsTopicARN`,description="The SNS Topic ARN for this release channel"
 // +kubebuilder:printcolumn:name="Active",type=boolean,JSONPath=`.status.active`,description="Indicates if this channel is active"
-// +kubebuilder:printcolumn:name="Latest Release",type=string,JSONPath=`.status.latestRelease`,description="The latest release of this channel"
+// +kubebuilder:printcolumn:name="Latest Release",type=integer,format=int32,JSONPath=`.status.latestRelease`,description="The latest release of this channel"
 // +kubebuilder:resource:singular="releasechannel",path="releasechannels"
 
 // ReleaseChannel is the Schema for the releasechannels API

--- a/release/cmd/release.go
+++ b/release/cmd/release.go
@@ -40,8 +40,8 @@ var releaseCmd = &cobra.Command{
 		gitCommit := viper.GetString("git-commit")
 		imageRepository := viper.GetString("image-repository")
 		cdnURL := viper.GetString("cdn")
-		releaseNumber := viper.GetString("release-number")
-		artifactDir := fmt.Sprintf("kubernetes-%s/releases/%s/artifacts/", releaseBranch, releaseNumber)
+		releaseNumber := viper.GetInt("release-number")
+		artifactDir := fmt.Sprintf("kubernetes-%s/releases/%d/artifacts/", releaseBranch, releaseNumber)
 
 		releaseConfig := &pkg.ReleaseConfig{
 			ContainerImageRepository: imageRepository,
@@ -57,7 +57,7 @@ var releaseCmd = &cobra.Command{
 				BuildRepoCommit: gitCommit,
 			},
 		}
-		release.Name = fmt.Sprintf("kubernetes-%s-eks-%s", releaseBranch, releaseNumber)
+		release.Name = fmt.Sprintf("kubernetes-%s-eks-%d", releaseBranch, releaseNumber)
 		// TODO figure out how to get these automatically added
 		release.APIVersion = "distro.eks.amazonaws.com/v1alpha1"
 		release.Kind = "Release"
@@ -94,6 +94,6 @@ func init() {
 	releaseCmd.Flags().String("git-commit", "", "The eks-distro git commit")
 	releaseCmd.Flags().String("image-repository", "", "The container image repository name")
 	releaseCmd.Flags().String("cdn", "https://distro.eks.amazonaws.com", "The URL base for artifacts")
-	releaseCmd.Flags().String("release-number", "1", "The release-number to create")
+	releaseCmd.Flags().Int("release-number", 1, "The release-number to create")
 
 }

--- a/release/config/crds/distro.eks.amazonaws.com_releasechannels.yaml
+++ b/release/config/crds/distro.eks.amazonaws.com_releasechannels.yaml
@@ -1,3 +1,17 @@
+# Copyright 2020 Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
@@ -19,8 +33,9 @@ spec:
     type: boolean
   - JSONPath: .status.latestRelease
     description: The latest release of this channel
+    format: int32
     name: Latest Release
-    type: string
+    type: integer
   group: distro.eks.amazonaws.com
   names:
     kind: ReleaseChannel

--- a/release/config/crds/distro.eks.amazonaws.com_releases.yaml
+++ b/release/config/crds/distro.eks.amazonaws.com_releases.yaml
@@ -1,3 +1,17 @@
+# Copyright 2020 Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
@@ -16,7 +30,7 @@ spec:
   - JSONPath: .spec.number
     description: Release number
     name: Release
-    type: string
+    type: integer
   - JSONPath: .status.date
     description: The date the release was published
     format: date-time
@@ -57,7 +71,8 @@ spec:
               type: string
             number:
               description: Monotonically increasing release number
-              type: string
+              minimum: 1
+              type: integer
           type: object
         status:
           description: ReleaseStatus defines the observed state of Release

--- a/release/pkg/assets_attacher.go
+++ b/release/pkg/assets_attacher.go
@@ -39,7 +39,7 @@ func (r *ReleaseConfig) GetAttacherComponent(spec distrov1alpha1.ReleaseSpec) (*
 		OS:          "linux",
 		Arch:        []string{"amd64", "arm64"},
 		Image: &distrov1alpha1.AssetImage{
-			URI: fmt.Sprintf("%s/kubernetes-csi/%s:%s-eks-%s-%s",
+			URI: fmt.Sprintf("%s/kubernetes-csi/%s:%s-eks-%s-%d",
 				r.ContainerImageRepository,
 				binary,
 				gitTag,

--- a/release/pkg/assets_authenticator.go
+++ b/release/pkg/assets_authenticator.go
@@ -49,7 +49,7 @@ func (r *ReleaseConfig) GetAuthenticatorComponent(spec distrov1alpha1.ReleaseSpe
 			assetPath, err := r.GetURI(filepath.Join(
 				fmt.Sprintf("kubernetes-%s", spec.Channel),
 				"releases",
-				fmt.Sprintf("%s", spec.Number),
+				fmt.Sprintf("%d", spec.Number),
 				"artifacts",
 				"aws-iam-authenticator",
 				gitTag,
@@ -80,7 +80,7 @@ func (r *ReleaseConfig) GetAuthenticatorComponent(spec distrov1alpha1.ReleaseSpe
 		OS:          "linux",
 		Arch:        []string{"amd64", "arm64"},
 		Image: &distrov1alpha1.AssetImage{
-			URI: fmt.Sprintf("%s/kubernetes-sigs/%s:%s-eks-%s-%s",
+			URI: fmt.Sprintf("%s/kubernetes-sigs/%s:%s-eks-%s-%d",
 				r.ContainerImageRepository,
 				binary,
 				gitTag,

--- a/release/pkg/assets_cni.go
+++ b/release/pkg/assets_cni.go
@@ -46,7 +46,7 @@ func (r *ReleaseConfig) GetCniComponent(spec distrov1alpha1.ReleaseSpec) (*distr
 			assetPath, err := r.GetURI(filepath.Join(
 				fmt.Sprintf("kubernetes-%s", spec.Channel),
 				"releases",
-				fmt.Sprintf("%s", spec.Number),
+				fmt.Sprintf("%d", spec.Number),
 				"artifacts",
 				"plugins",
 				gitTag,

--- a/release/pkg/assets_coredns.go
+++ b/release/pkg/assets_coredns.go
@@ -39,7 +39,7 @@ func (r *ReleaseConfig) GetCorednsComponent(spec distrov1alpha1.ReleaseSpec) (*d
 		OS:          "linux",
 		Arch:        []string{"amd64", "arm64"},
 		Image: &distrov1alpha1.AssetImage{
-			URI: fmt.Sprintf("%s/coredns/%s:%s-eks-%s-%s",
+			URI: fmt.Sprintf("%s/coredns/%s:%s-eks-%s-%d",
 				r.ContainerImageRepository,
 				binary,
 				gitTag,

--- a/release/pkg/assets_etcd.go
+++ b/release/pkg/assets_etcd.go
@@ -46,7 +46,7 @@ func (r *ReleaseConfig) GetEtcdComponent(spec distrov1alpha1.ReleaseSpec) (*dist
 			assetPath, err := r.GetURI(filepath.Join(
 				fmt.Sprintf("kubernetes-%s", spec.Channel),
 				"releases",
-				fmt.Sprintf("%s", spec.Number),
+				fmt.Sprintf("%d", spec.Number),
 				"artifacts",
 				"etcd",
 				gitTag,
@@ -77,7 +77,7 @@ func (r *ReleaseConfig) GetEtcdComponent(spec distrov1alpha1.ReleaseSpec) (*dist
 		OS:          "linux",
 		Arch:        []string{"amd64", "arm64"},
 		Image: &distrov1alpha1.AssetImage{
-			URI: fmt.Sprintf("%s/etcd-io/%s:%s-eks-%s-%s",
+			URI: fmt.Sprintf("%s/etcd-io/%s:%s-eks-%s-%d",
 				r.ContainerImageRepository,
 				binary,
 				gitTag,

--- a/release/pkg/assets_k8s.go
+++ b/release/pkg/assets_k8s.go
@@ -76,7 +76,7 @@ func (r *ReleaseConfig) GetKubernetesComponent(spec distrov1alpha1.ReleaseSpec) 
 				assetPath, err := r.GetURI(filepath.Join(
 					fmt.Sprintf("kubernetes-%s", spec.Channel),
 					"releases",
-					fmt.Sprintf("%s", spec.Number),
+					fmt.Sprintf("%d", spec.Number),
 					"artifacts",
 					"kubernetes",
 					gitTag,
@@ -107,7 +107,7 @@ func (r *ReleaseConfig) GetKubernetesComponent(spec distrov1alpha1.ReleaseSpec) 
 				assetPath, err := r.GetURI(filepath.Join(
 					fmt.Sprintf("kubernetes-%s", spec.Channel),
 					"releases",
-					fmt.Sprintf("%s", spec.Number),
+					fmt.Sprintf("%d", spec.Number),
 					"artifacts",
 					"kubernetes",
 					gitTag,
@@ -167,7 +167,7 @@ func (r *ReleaseConfig) GetKubernetesComponent(spec distrov1alpha1.ReleaseSpec) 
 				assetPath, err := r.GetURI(filepath.Join(
 					fmt.Sprintf("kubernetes-%s", spec.Channel),
 					"releases",
-					fmt.Sprintf("%s", spec.Number),
+					fmt.Sprintf("%d", spec.Number),
 					"artifacts",
 					"kubernetes",
 					gitTag,
@@ -203,7 +203,7 @@ func (r *ReleaseConfig) GetKubernetesComponent(spec distrov1alpha1.ReleaseSpec) 
 	assetPath, err := r.GetURI(filepath.Join(
 		fmt.Sprintf("kubernetes-%s", spec.Channel),
 		"releases",
-		fmt.Sprintf("%s", spec.Number),
+		fmt.Sprintf("%d", spec.Number),
 		"artifacts",
 		"kubernetes",
 		gitTag,

--- a/release/pkg/assets_livenessprobe.go
+++ b/release/pkg/assets_livenessprobe.go
@@ -39,7 +39,7 @@ func (r *ReleaseConfig) GetLivenessprobeComponent(spec distrov1alpha1.ReleaseSpe
 		OS:          "linux",
 		Arch:        []string{"amd64", "arm64"},
 		Image: &distrov1alpha1.AssetImage{
-			URI: fmt.Sprintf("%s/kubernetes-csi/%s:%s-eks-%s-%s",
+			URI: fmt.Sprintf("%s/kubernetes-csi/%s:%s-eks-%s-%d",
 				r.ContainerImageRepository,
 				binary,
 				gitTag,

--- a/release/pkg/assets_metricsserver.go
+++ b/release/pkg/assets_metricsserver.go
@@ -39,7 +39,7 @@ func (r *ReleaseConfig) GetMetricsServerComponent(spec distrov1alpha1.ReleaseSpe
 		OS:          "linux",
 		Arch:        []string{"amd64", "arm64"},
 		Image: &distrov1alpha1.AssetImage{
-			URI: fmt.Sprintf("%s/kubernetes-sigs/%s:%s-eks-%s-%s",
+			URI: fmt.Sprintf("%s/kubernetes-sigs/%s:%s-eks-%s-%d",
 				r.ContainerImageRepository,
 				binary,
 				gitTag,

--- a/release/pkg/assets_provisioner.go
+++ b/release/pkg/assets_provisioner.go
@@ -39,7 +39,7 @@ func (r *ReleaseConfig) GetProvisionerComponent(spec distrov1alpha1.ReleaseSpec)
 		OS:          "linux",
 		Arch:        []string{"amd64", "arm64"},
 		Image: &distrov1alpha1.AssetImage{
-			URI: fmt.Sprintf("%s/kubernetes-csi/%s:%s-eks-%s-%s",
+			URI: fmt.Sprintf("%s/kubernetes-csi/%s:%s-eks-%s-%d",
 				r.ContainerImageRepository,
 				binary,
 				gitTag,

--- a/release/pkg/assets_registrar.go
+++ b/release/pkg/assets_registrar.go
@@ -39,7 +39,7 @@ func (r *ReleaseConfig) GetRegistrarComponent(spec distrov1alpha1.ReleaseSpec) (
 		OS:          "linux",
 		Arch:        []string{"amd64", "arm64"},
 		Image: &distrov1alpha1.AssetImage{
-			URI: fmt.Sprintf("%s/kubernetes-csi/%s:%s-eks-%s-%s",
+			URI: fmt.Sprintf("%s/kubernetes-csi/%s:%s-eks-%s-%d",
 				r.ContainerImageRepository,
 				binary,
 				gitTag,

--- a/release/pkg/assets_resizer.go
+++ b/release/pkg/assets_resizer.go
@@ -39,7 +39,7 @@ func (r *ReleaseConfig) GetResizerComponent(spec distrov1alpha1.ReleaseSpec) (*d
 		OS:          "linux",
 		Arch:        []string{"amd64", "arm64"},
 		Image: &distrov1alpha1.AssetImage{
-			URI: fmt.Sprintf("%s/kubernetes-csi/%s:%s-eks-%s-%s",
+			URI: fmt.Sprintf("%s/kubernetes-csi/%s:%s-eks-%s-%d",
 				r.ContainerImageRepository,
 				binary,
 				gitTag,

--- a/release/pkg/assets_snapshotter.go
+++ b/release/pkg/assets_snapshotter.go
@@ -40,7 +40,7 @@ func (r *ReleaseConfig) GetSnapshotterComponent(spec distrov1alpha1.ReleaseSpec)
 			OS:          "linux",
 			Arch:        []string{"amd64", "arm64"},
 			Image: &distrov1alpha1.AssetImage{
-				URI: fmt.Sprintf("%s/kubernetes-csi/external-snapshotter/%s:%s-eks-%s-%s",
+				URI: fmt.Sprintf("%s/kubernetes-csi/external-snapshotter/%s:%s-eks-%s-%d",
 					r.ContainerImageRepository,
 					binary,
 					gitTag,


### PR DESCRIPTION
These CRD changes are causing incompatibilities. We did this for tests, we are no longer using that approach. This is just a straight `git revert` on PR 103
