### PR TITLE
Import upstream grafana chart and publish to S3 for PROW

### DIFF
--- a/helm-charts/scripts/install-toolchain.sh
+++ b/helm-charts/scripts/install-toolchain.sh
@@ -24,11 +24,13 @@ TMP_DIR="${BUILD_DIR}/tmp"
 mkdir -p "${TOOLS_DIR}"
 
 HELM_VERSION="v3.4.1"
-KUBECTL_VERSION=v1.18.9
+KUBECTL_VERSION=v1.19.6
 KIND_VERSION=v0.5.1
+RELEASE_BRANCH=1-19
+RELEASE=1
 
 ## Install kubectl
-curl -sSL "https://distro.eks.amazonaws.com/kubernetes-1-18/releases/1/artifacts/kubernetes/${KUBECTL_VERSION}/bin/linux/amd64/kubectl" -o "${TOOLS_DIR}/kubectl"
+curl -sSL "https://distro.eks.amazonaws.com/kubernetes-${RELEASE_BRANCH}/releases/${RELEASE}/artifacts/kubernetes/${KUBECTL_VERSION}/bin/linux/amd64/kubectl" -o "${TOOLS_DIR}/kubectl"
 chmod +x "${TOOLS_DIR}/kubectl"
 
 ## Install kubeval

--- a/projects/grafana/helm-charts/Makefile
+++ b/projects/grafana/helm-charts/Makefile
@@ -1,0 +1,41 @@
+GRAFANA_CHART_REPO?=helm-charts
+GRAFANA_CHART_CLONE_URL?=https://github.com/grafana/$(GRAFANA_CHART_REPO).git
+GRAFANA_CHART_GIT_TAG?=grafana-6.4.4
+
+ifeq ("$(GRAFANA_CHART_REPO)","")
+	$(error No repository name for Grafana chart was provided.)
+endif
+
+ifeq ("$(GRAFANA_CHART_CLONE_URL)","")
+	$(error No Grafana chart clone url was provided.)
+endif
+
+ifeq ("$(GRAFANA_CHART_GIT_TAG)","")
+	$(error No git tag for Grafana chart was provided.)
+endif
+
+CHART_SCRIPTS_DIR=$(shell git rev-parse --show-toplevel)/helm-charts/scripts
+MAKE_ROOT=$(shell cd "$(dirname "$(BASH_SOURCE[0])")" && pwd -P)
+CLONE_ROOT=$(MAKE_ROOT)/helm-charts
+
+.PHONY: clone
+clone: clean
+	git clone $(GRAFANA_CHART_CLONE_URL) $(GRAFANA_CHART_REPO)
+	cd $(GRAFANA_CHART_REPO) && git checkout $(GRAFANA_CHART_GIT_TAG)
+
+.PHONY: install-toolchain
+install-toolchain:
+	$(CHART_SCRIPTS_DIR)/install-toolchain.sh
+
+verify: install-toolchain clone
+
+.PHONY: publish
+publish:
+	$(CHART_SCRIPTS_DIR)/publish-charts.sh $(CLONE_ROOT)/charts/grafana
+
+.PHONY: release
+release: install-toolchain clone publish
+
+.PHONY: clean
+clean:
+	rm -rf $(GRAFANA_CHART_REPO)


### PR DESCRIPTION
Currently PROW clusters use managed Grafana. This prevents us from using the declarative approach of adding dashboards for Grafana. So we are switching to using the upstream helm chart to install grafana and configure the dashboards.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
