### PR TITLE
Adding rootlesskit to builder base image

### DIFF
--- a/builder-base/Dockerfile
+++ b/builder-base/Dockerfile
@@ -17,6 +17,7 @@ FROM ${BASE_IMAGE}
 
 COPY golang-checksum /golang-checksum
 COPY buildkit-checksum /buildkit-checksum
+COPY rootlesskit-checksum /rootlesskit-checksum
 COPY bash-checksum /bash-checksum
 COPY install.sh /opt/install.sh
 RUN bash /opt/install.sh

--- a/builder-base/install.sh
+++ b/builder-base/install.sh
@@ -70,6 +70,14 @@ sha256sum -c $BASE_DIR/buildkit-checksum
 tar -C /usr -xzf buildkit-$BUILDKIT_VERSION.linux-amd64.tar.gz
 rm -rf buildkit-$BUILDKIT_VERSION.linux-amd64.tar.gz
 
+ROOTLESSKIT_VERSION="${ROOTLESSKIT_VERSION:-v0.13.2}"
+wget \
+    --progress dot:giga \
+    https://github.com/rootless-containers/rootlesskit/releases/download/$ROOTLESSKIT_VERSION/rootlesskit-x86_64.tar.gz
+sha256sum -c $BASE_DIR/rootlesskit-checksum
+tar -C /usr/bin -xvf rootlesskit-x86_64.tar.gz
+rm -rf rootlesskit-x86_64.tar.gz
+
 # Bash 4.3 is required to run kubernetes make test
 OVERRIDE_BASH_VERSION="${OVERRIDE_BASH_VERSION:-4.3}"
 wget http://ftp.gnu.org/gnu/bash/bash-$OVERRIDE_BASH_VERSION.tar.gz 

--- a/builder-base/rootlesskit-checksum
+++ b/builder-base/rootlesskit-checksum
@@ -1,0 +1,1 @@
+4d2296dd33a4cab3784adce812da98944b6ca31145043b10c8cf0f94e22000fb  rootlesskit-x86_64.tar.gz


### PR DESCRIPTION
*Description of changes:*
Adding rootlesskit from rootless-containers to builder-base image. This helps to run buildkitd in rootless mode.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
