### PR TITLE
Increase prowjob age so that jobs stay longer on deck

### DIFF
--- a/helm-charts/stable/prow-control-plane/Chart.yaml
+++ b/helm-charts/stable/prow-control-plane/Chart.yaml
@@ -29,7 +29,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.7
+version: 1.0.8
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm-charts/stable/prow-control-plane/templates/config-ConfigMap.yaml
+++ b/helm-charts/stable/prow-control-plane/templates/config-ConfigMap.yaml
@@ -24,6 +24,8 @@ data:
     sinker:
       # defaults to 1 hour
       resync_period: 2m
+      # approximately equal to 1 month, defaults to 1 week
+      max_prowjob_age: 730h
       # defaults to 1 day
       max_pod_age: 12h
       # defaults to max_pod_age


### PR DESCRIPTION
Make the prowjob CRD's more persistent by increasing their age. This will enable them to be displayed on deck for longer (1 month as opposed to 1 week by default), so we can have badges for infrequent jobs like release-postsubmits.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
