### PR TITLE
Change PREV_RELEASE_HASH to PULL_BASE_SHA

### DIFF
--- a/helm-charts/scripts/verify-version.sh
+++ b/helm-charts/scripts/verify-version.sh
@@ -21,8 +21,8 @@ CHARTS_DIR=$1
 GIT_REPO_ROOT=$(git rev-parse --show-toplevel)
 REMOTE_URL="https://github.com/aws/eks-distro-build-tooling.git"
 
-# PULL_PULL_SHA is environment variable set by the presubmit job. More info here: https://github.com/kubernetes/test-infra/blob/master/prow/jobs.md#job-environment-variables
-PREV_RELEASE_HASH=${PULL_PULL_SHA}
+# PULL_BASE_SHA is environment variable set by the presubmit job. More info here: https://github.com/kubernetes/test-infra/blob/master/prow/jobs.md#job-environment-variables
+PREV_RELEASE_HASH=${PULL_BASE_SHA}
 git fetch $REMOTE_URL $PREV_RELEASE_HASH
 
 EXIT_CODE=0


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Change `PREV_RELEASE_HASH` to `PULL_BASE_SHA` in `verify_version.sh` to fix `helm-chart-tooling-presubmit` prowjob

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
