### PR TITLE
Add script to run buildctl in daemonless mode

### DIFF
--- a/builder-base/Dockerfile
+++ b/builder-base/Dockerfile
@@ -20,6 +20,7 @@ COPY buildkit-checksum /buildkit-checksum
 COPY rootlesskit-checksum /rootlesskit-checksum
 COPY bazel-checksum /bazel-checksum
 COPY bash-checksum /bash-checksum
+COPY buildkit.sh /buildkit.sh
 COPY install.sh /opt/install.sh
 RUN bash /opt/install.sh
 

--- a/builder-base/buildkit.sh
+++ b/builder-base/buildkit.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Copyright 2020 Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Script to perform buildkit builds in daemonless mode
+
+set -e
+set -o pipefail
+set -x
+
+tmp=$(mktemp -d /tmp/buildctl-daemonless.XXXXXX)
+trap "kill \$(cat $tmp/pid); rm -rf $tmp" EXIT
+
+start::buildkitd() {
+    buildkitd --addr=unix:///run/buildkit/buildkitd.sock --oci-worker-platform=linux/amd64 --oci-worker-platform=linux/arm64 >$tmp/log 2>&1 &
+    pid=$!
+    echo $pid >$tmp/pid
+}
+
+wait::for::buildkitd() {
+    try=0
+    max_retries=10
+    until buildctl --addr=unix:///run/buildkit/buildkitd.sock debug workers >/dev/null 2>&1; do
+        if [ $try -gt $max_retries ]; then
+            echo >&2 "could not connect to Buildkit socket after $max_retries trials"
+            echo >&2 "========== log =========="
+            cat >&2 $tmp/log
+            exit 1
+        fi
+        sleep $(awk "BEGIN{print (100 + $try * 20) * 0.001}")
+        try=$(expr $try + 1)
+    done
+}
+
+start::buildkitd
+wait::for::buildkitd
+
+buildctl --addr=unix:///run/buildkit/buildkitd.sock "$@"


### PR DESCRIPTION
Adding script to builder-base image to perform image builds in CodeBuild in daemonless mode. This script was largely inspired from https://github.com/moby/buildkit/blob/master/examples/buildctl-daemonless/buildctl-daemonless.sh, and slightly modified to suit our usecase.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
