### PR TITLE
Handling CRD generation support for release based GIT_TAG

### DIFF
--- a/release/pkg/assets_authenticator.go
+++ b/release/pkg/assets_authenticator.go
@@ -25,7 +25,7 @@ import (
 // GetKubernetesComponent returns the Component for Kubernetes
 func (r *ReleaseConfig) GetAuthenticatorComponent(spec distrov1alpha1.ReleaseSpec) (*distrov1alpha1.Component, error) {
 	projectSource := "projects/kubernetes-sigs/aws-iam-authenticator"
-	tagFile := filepath.Join(r.BuildRepoSource, projectSource, "GIT_TAG")
+	tagFile := filepath.Join(r.BuildRepoSource, projectSource, spec.Channel, "GIT_TAG")
 	gitTag, err := readTag(tagFile)
 	if err != nil {
 		return nil, errors.Cause(err)

--- a/release/pkg/assets_coredns.go
+++ b/release/pkg/assets_coredns.go
@@ -25,7 +25,7 @@ import (
 // GetCorednsComponent returns the Component for Kubernetes
 func (r *ReleaseConfig) GetCorednsComponent(spec distrov1alpha1.ReleaseSpec) (*distrov1alpha1.Component, error) {
 	projectSource := "projects/coredns/coredns"
-	tagFile := filepath.Join(r.BuildRepoSource, projectSource, "GIT_TAG")
+	tagFile := filepath.Join(r.BuildRepoSource, projectSource, spec.Channel, "GIT_TAG")
 	gitTag, err := readTag(tagFile)
 	if err != nil {
 		return nil, errors.Cause(err)

--- a/release/pkg/assets_metricsserver.go
+++ b/release/pkg/assets_metricsserver.go
@@ -25,7 +25,7 @@ import (
 // GetMetricsServerComponent returns the Component for metrics-server
 func (r *ReleaseConfig) GetMetricsServerComponent(spec distrov1alpha1.ReleaseSpec) (*distrov1alpha1.Component, error) {
 	projectSource := "projects/kubernetes-sigs/metrics-server"
-	tagFile := filepath.Join(r.BuildRepoSource, projectSource, "GIT_TAG")
+	tagFile := filepath.Join(r.BuildRepoSource, projectSource, spec.Channel, "GIT_TAG")
 	gitTag, err := readTag(tagFile)
 	if err != nil {
 		return nil, errors.Cause(err)


### PR DESCRIPTION
Adding support for CRD generation for resources coredns, aws-iam-authenticator and metrics server for release version dependent GIT_TAG. 