### PR TITLE
Prevent heredoc from expanding Bash exit code variable

### DIFF
--- a/builder-base/update_base_image.sh
+++ b/builder-base/update_base_image.sh
@@ -21,7 +21,7 @@ set -x
 SCRIPT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 DRY_RUN_FLAG=$1
 
-if [ $DRY_RUN_FLAG = "--dry-run" ]; then
+if [ "$DRY_RUN_FLAG" = "--dry-run" ]; then
     NEW_TAG=$PULL_PULL_SHA
 else
     NEW_TAG=$PULL_BASE_SHA

--- a/pr-scripts/create_pr.sh
+++ b/pr-scripts/create_pr.sh
@@ -67,7 +67,7 @@ for FILE in $(find ./ -type f -name $FILEPATH); do
     git add $FILE
 done
 git commit -m "$COMMIT_MESSAGE" || true
-if [ $DRY_RUN_FLAG = "--dry-run" ]; then
+if [ "$DRY_RUN_FLAG" = "--dry-run" ]; then
     exit 0
 fi
 ssh-agent bash -c 'ssh-add /secrets/ssh-secrets/ssh-key; ssh -o StrictHostKeyChecking=no git@github.com; git push -u origin $PR_BRANCH -f'


### PR DESCRIPTION
The Dockerfile generated was being hardcoded with an exit code of 0 since the Heredoc did the variable expansion of `$?` instead of keeping it as such.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
