### PR TITLE
Install GH cli locally in addition to builder-base

### DIFF
--- a/builder-base/install.sh
+++ b/builder-base/install.sh
@@ -73,6 +73,13 @@ sha256sum -c $BASE_DIR/buildkit-checksum
 tar -C /usr -xzf buildkit-$BUILDKIT_VERSION.linux-amd64.tar.gz
 rm -rf buildkit-$BUILDKIT_VERSION.linux-amd64.tar.gz
 
+GITHUB_CLI_VERSION="${GITHUB_CLI_VERSION:-1.2.1}"
+wget --progress dot:giga https://github.com/cli/cli/releases/download/v${GITHUB_CLI_VERSION}/gh_${GITHUB_CLI_VERSION}_linux_amd64.tar.gz
+sha256sum -c $BASE_DIR/github-cli-checksum
+tar -xzf gh_${GITHUB_CLI_VERSION}_linux_amd64.tar.gz
+mv gh_${GITHUB_CLI_VERSION}_linux_amd64/bin/gh /usr/bin
+rm -rf gh_${GITHUB_CLI_VERSION}_linux_amd64.tar.gz
+
 if [[ "$CI" == "true" ]]; then
     exit
 fi
@@ -110,13 +117,6 @@ wget \
 sha256sum -c $BASE_DIR/bazel-checksum
 mv bazel-$BAZEL_VERSION-linux-x86_64 /usr/bin/bazel
 chmod +x /usr/bin/bazel
-
-GITHUB_CLI_VERSION="${GITHUB_CLI_VERSION:-1.2.1}"
-wget --progress dot:giga https://github.com/cli/cli/releases/download/v${GITHUB_CLI_VERSION}/gh_${GITHUB_CLI_VERSION}_linux_amd64.tar.gz
-sha256sum -c $BASE_DIR/github-cli-checksum
-tar -xzf gh_${GITHUB_CLI_VERSION}_linux_amd64.tar.gz
-mv gh_${GITHUB_CLI_VERSION}_linux_amd64/bin/gh /usr/bin
-rm -rf gh_${GITHUB_CLI_VERSION}_linux_amd64.tar.gz
 
 # Bash 4.3 is required to run kubernetes make test
 OVERRIDE_BASH_VERSION="${OVERRIDE_BASH_VERSION:-4.3}"


### PR DESCRIPTION
With the builder-base jobs, we need to install the Github cli in the pod running the job (the image being ECR-vended AL2) in order to perform the actual update of builder-base PR's on prowjobs, in addition to baking it into the builder-base image itself to be used in other jobs performing PR updates (attribution files, eks-distro-base image).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
