### PR TITLE
Adding image-builder dependencies to builder-base

### DIFF
--- a/builder-base/goss-checksum
+++ b/builder-base/goss-checksum
@@ -1,0 +1,1 @@
+7d8d665c95262bfd7507efe852aa213c46d989e252333d267b1888cb9fc8d139  packer-provisioner-goss-v2.0.0-linux-amd64.tar.gz

--- a/builder-base/install.sh
+++ b/builder-base/install.sh
@@ -103,29 +103,34 @@ yum install -y \
     which
 
 # Install image-builder build dependencies
+# Post upgrade, pip3 got renamed to pip and moved locations. It works completely with python3
+# Symlinking pip3 to pip, to have pip3 commands work successfully
 pip3 install -U pip setuptools
+ln -s /usr/local/bin/pip /usr/bin/pip3
 ANSIBLE_VERSION="${ANSIBLE_VERSION:-2.10.0}"
-pip3 install --user "ansible==$ANSIBLE_VERSION"
+pip3 install "ansible==$ANSIBLE_VERSION"
 
 PYWINRM_VERSION="${PYWINRM_VERSION:-0.4.1}"
-pip3 install --user "pywinrm==$PYWINRM_VERSION"
+pip3 install "pywinrm==$PYWINRM_VERSION"
 
 PACKER_VERSION="${PACKER_VERSION:-1.6.6}"
 rm -rf /usr/sbin/packer
 wget \
     --progress dot:giga \
-    https://releases.hashicorp.com/packer/$PACKER_VERSION/packer_$PACKER_VERSION_linux_amd64.zip
+    https://releases.hashicorp.com/packer/$PACKER_VERSION/packer_${PACKER_VERSION}_linux_amd64.zip
 sha256sum -c $BASE_DIR/packer-checksum
-unzip -o packer_$PACKER_VERSION_linux_amd64.zip -d /usr/bin
-rm -rf packer_$PACKER_VERSION_linux_amd64.zip
+unzip -o packer_${PACKER_VERSION}_linux_amd64.zip -d /usr/bin
+rm -rf packer_${PACKER_VERSION}_linux_amd64.zip
 
 GOSS_VERSION="${GOSS_VERSION:-2.0.0}"
 wget \
     --progress dot:giga \
-    https://github.com/YaleUniversity/packer-provisioner-goss/releases/download/v$GOSS_VERSION/packer-provisioner-goss-v$GOSS_VERSION-linux-amd64.tar.gz
+    https://github.com/YaleUniversity/packer-provisioner-goss/releases/download/v${GOSS_VERSION}/packer-provisioner-goss-v${GOSS_VERSION}-linux-amd64.tar.gz
 sha256sum -c $BASE_DIR/goss-checksum
-tar -C /usr/bin -xzf packer-provisioner-goss-v$GOSS_VERSION-linux-amd64.tar.gz
-rm -rf packer-provisioner-goss-v$GOSS_VERSION-linux-amd64.tar.gz
+tar -C /usr/bin -xzf packer-provisioner-goss-v${GOSS_VERSION}-linux-amd64.tar.gz
+rm -rf packer-provisioner-goss-v${GOSS_VERSION}-linux-amd64.tar.gz
+
+useradd -ms /bin/bash -u 1100 imagebuilder
 
 BAZEL_VERSION="${BAZEL_VERSION:-4.0.0}"
 wget \

--- a/builder-base/install.sh
+++ b/builder-base/install.sh
@@ -102,13 +102,30 @@ yum install -y \
     vim \
     which
 
-ROOTLESSKIT_VERSION="${ROOTLESSKIT_VERSION:-v0.13.2}"
+# Install image-builder build dependencies
+pip3 install -U pip setuptools
+ANSIBLE_VERSION="${ANSIBLE_VERSION:-2.10.0}"
+pip3 install --user "ansible==$ANSIBLE_VERSION"
+
+PYWINRM_VERSION="${PYWINRM_VERSION:-0.4.1}"
+pip3 install --user "pywinrm==$PYWINRM_VERSION"
+
+PACKER_VERSION="${PACKER_VERSION:-1.6.6}"
+rm -rf /usr/sbin/packer
 wget \
     --progress dot:giga \
-    https://github.com/rootless-containers/rootlesskit/releases/download/$ROOTLESSKIT_VERSION/rootlesskit-x86_64.tar.gz
-sha256sum -c $BASE_DIR/rootlesskit-checksum
-tar -C /usr/bin -xvf rootlesskit-x86_64.tar.gz
-rm -rf rootlesskit-x86_64.tar.gz
+    https://releases.hashicorp.com/packer/$PACKER_VERSION/packer_$PACKER_VERSION_linux_amd64.zip
+sha256sum -c $BASE_DIR/packer-checksum
+unzip -o packer_$PACKER_VERSION_linux_amd64.zip -d /usr/bin
+rm -rf packer_$PACKER_VERSION_linux_amd64.zip
+
+GOSS_VERSION="${GOSS_VERSION:-2.0.0}"
+wget \
+    --progress dot:giga \
+    https://github.com/YaleUniversity/packer-provisioner-goss/releases/download/v$GOSS_VERSION/packer-provisioner-goss-v$GOSS_VERSION-linux-amd64.tar.gz
+sha256sum -c $BASE_DIR/goss-checksum
+tar -C /usr/bin -xzf packer-provisioner-goss-v$GOSS_VERSION-linux-amd64.tar.gz
+rm -rf packer-provisioner-goss-v$GOSS_VERSION-linux-amd64.tar.gz
 
 BAZEL_VERSION="${BAZEL_VERSION:-4.0.0}"
 wget \

--- a/builder-base/packer-checksum
+++ b/builder-base/packer-checksum
@@ -1,0 +1,1 @@
+721d119fd70e38d6f2b4ccd8a39daf6b4d36bf5f7640036acafcaaa967b00c3b  packer_1.6.6_linux_amd64.zip

--- a/builder-base/rootlesskit-checksum
+++ b/builder-base/rootlesskit-checksum
@@ -1,1 +1,0 @@
-4d2296dd33a4cab3784adce812da98944b6ca31145043b10c8cf0f94e22000fb  rootlesskit-x86_64.tar.gz


### PR DESCRIPTION
Adding packer, ansible, goss and pywinrm to builder-base.

These dependencies are used by kubernetes-sigs/image-builder to create capi images.

We will be removing older version of packer and installing a more stable and newer version with this change.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
