### PR TITLE
adding bind-utils for the dig command on builder-base

### DIFF
--- a/builder-base/install.sh
+++ b/builder-base/install.sh
@@ -90,6 +90,7 @@ fi
 mkdir -p /go/src /go/bin /go/pkg /go/src/github.com/aws/eks-distro
 
 yum install -y \
+    bind-utils \
     curl \
     gcc \
     jq \


### PR DESCRIPTION
I added a call to dig in eks-distro to help debug some sporadic dns issues, but dig is missing.  bind-utils includes it.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
