### PR TITLE
Exit gracefully if no files were changed

### DIFF
--- a/pr-scripts/create_pr.sh
+++ b/pr-scripts/create_pr.sh
@@ -66,7 +66,12 @@ for FILE in $(find ./ -type f -name $FILEPATH); do
     sed -i "s,${OLD_TAG},${NEW_TAG}," $FILE
     git add $FILE
 done
-git commit -m "$COMMIT_MESSAGE" || true
+FILES_ADDED=$(git diff --staged --name-only)
+if [ "$FILES_CHANGED" = "" ]; then
+    exit 0
+fi
+
+git commit -m "$COMMIT_MESSAGE"
 if [ "$DRY_RUN_FLAG" = "--dry-run" ]; then
     exit 0
 fi


### PR DESCRIPTION
We don't want the script to invoke `git commit` and fail if no files were modified, and thus no files were added.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
