### PR TITLE
Adding govc to builder base

### DIFF
--- a/builder-base/govc-checksum
+++ b/builder-base/govc-checksum
@@ -1,0 +1,1 @@
+faf409c1ecbb23fb4a4a6d2df9092e047b94ed14d8a55768e23957388c6a2117  govc_linux_amd64.gz

--- a/builder-base/install.sh
+++ b/builder-base/install.sh
@@ -141,6 +141,15 @@ sha256sum -c $BASE_DIR/bazel-checksum
 mv bazel-$BAZEL_VERSION-linux-x86_64 /usr/bin/bazel
 chmod +x /usr/bin/bazel
 
+GOVC_VERSION="${GOVC_VERSION:-0.24.0}"
+wget \
+    --progress dot:giga \
+    https://github.com/vmware/govmomi/releases/download/v${GOVC_VERSION}/govc_linux_amd64.gz
+sha256sum -c $BASE_DIR/govc-checksum
+gzip -d govc_linux_amd64.gz
+mv govc_linux_amd64 /usr/bin/govc
+chmod +x /usr/bin/govc
+
 # Bash 4.3 is required to run kubernetes make test
 OVERRIDE_BASH_VERSION="${OVERRIDE_BASH_VERSION:-4.3}"
 wget http://ftp.gnu.org/gnu/bash/bash-$OVERRIDE_BASH_VERSION.tar.gz 


### PR DESCRIPTION
Adding govc to base to run govc commands and interface with vsphere.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
