### PR TITLE
Update golang versions

### DIFF
--- a/builder-base/golang-checksum
+++ b/builder-base/golang-checksum
@@ -1,1 +1,1 @@
-4aa1267517df32f2bf1cc3d55dfc27d0c6b2c2b0989449c96dd19273ccca051d  go1.15.10.linux-amd64.tar.gz
+951a3c7c6ce4e56ad883f97d9db74d3d6d80d5fec77455c6ada6c1f7ac4776d2  go1.16.3.linux-amd64.tar.gz

--- a/builder-base/install.sh
+++ b/builder-base/install.sh
@@ -54,7 +54,7 @@ aws --version
 rm awscli-exe-linux-x86_64.zip
 rm -rf /aws
 
-GOLANG_VERSION="${GOLANG_VERSION:-1.15.10}"
+GOLANG_VERSION="${GOLANG_VERSION:-1.16.3}"
 wget \
     --progress dot:giga \
     --max-redirect=1 \
@@ -178,7 +178,8 @@ setupgo() {
 
 setupgo "${GOLANG113_VERSION:-1.13.15}"
 setupgo "${GOLANG114_VERSION:-1.14.15}"
-setupgo "${GOLANG115_VERSION:-1.15.10}"
+setupgo "${GOLANG115_VERSION:-1.15.11}"
+setupgo "${GOLANG115_VERSION:-1.16.3}"
 
 # go-licenses doesnt have any release tags, using the latest master
 GO111MODULE=on go get github.com/google/go-licenses@v0.0.0-20201026145851-73411c8fa237     

--- a/builder-base/install.sh
+++ b/builder-base/install.sh
@@ -179,7 +179,7 @@ setupgo() {
 setupgo "${GOLANG113_VERSION:-1.13.15}"
 setupgo "${GOLANG114_VERSION:-1.14.15}"
 setupgo "${GOLANG115_VERSION:-1.15.11}"
-setupgo "${GOLANG115_VERSION:-1.16.3}"
+setupgo "${GOLANG116_VERSION:-1.16.3}"
 
 # go-licenses doesnt have any release tags, using the latest master
 GO111MODULE=on go get github.com/google/go-licenses@v0.0.0-20201026145851-73411c8fa237     


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Updating the go versions and also the default go for our builder base. This should not break existing dependencies because the ones that are tied to specific versions have overrides, and we should always be updating our default go version in the builder base. This is also needed to consume the embed package for the CLI.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
