### PR TITLE
Add Makefile target for complete builds of base images

### DIFF
--- a/builder-base/Makefile
+++ b/builder-base/Makefile
@@ -66,3 +66,6 @@ build: copy-generate-attribution local-images remove-generate-attribution
 
 .PHONY: release
 release: copy-generate-attribution images remove-generate-attribution
+
+.PHONY: all
+all: release

--- a/eks-distro-base/Makefile
+++ b/eks-distro-base/Makefile
@@ -104,3 +104,6 @@ update:
 	elif [ $(RETURN_MESSAGE) = "Error" ]; then \
 		exit 1; \
 	fi
+
+.PHONY: all
+all: release


### PR DESCRIPTION
Add a Make target for `all`. Also triggers base image jobs to ultimately push to public ECR 🤞.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
