### PR TITLE
Modify script to automate builder-base image tag update in tag file

### DIFF
--- a/pr-scripts/create_pr.sh
+++ b/pr-scripts/create_pr.sh
@@ -66,6 +66,15 @@ for FILE in $(find ./ -type f -name $FILEPATH); do
     sed -i "s,${OLD_TAG},${NEW_TAG}," $FILE
     git add $FILE
 done
+if [ $REPO = "eks-distro-prow-jobs" ]; then
+    if [ "$DRY_RUN_FLAG" = "--dry-run" ]; then
+        sed -i "s,.*,${PULL_PULL_SHA}," ./BUILDER_BASE_TAG_FILE
+    else
+        sed -i "s,.*,${PULL_BASE_SHA}," ./BUILDER_BASE_TAG_FILE
+    fi
+    git add ./BUILDER_BASE_TAG_FILE
+fi
+
 FILES_ADDED=$(git diff --staged --name-only)
 if [ "$FILES_ADDED" = "" ]; then
     exit 0


### PR DESCRIPTION
We are tracking builder-base image in a separate file. The automated PR should update the tag in that file too when a new image is created.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
