### PR TITLE
Set up base image pushes to eks-distro-build-tooling ECR public registry

### DIFF
--- a/builder-base/Makefile
+++ b/builder-base/Makefile
@@ -5,11 +5,13 @@ AWS_REGION?=us-west-2
 BASE_IMAGE?=public.ecr.aws/amazonlinux/amazonlinux:2
 
 IMAGE_REPO?=$(AWS_ACCOUNT_ID).dkr.ecr.$(AWS_REGION).amazonaws.com
-IMAGE_NAME?=eks-distro/builder
+IMAGE_NAME?=builder-base
 # This tag is overwritten in the prow job to point to the PR branch commit hash (presubmit)
 # or the base branch commit hash (postsubmit)
 IMAGE_TAG?=latest
 IMAGE?=$(IMAGE_REPO)/$(IMAGE_NAME):$(IMAGE_TAG)
+
+MAKE_ROOT=$(shell cd "$(shell dirname "${BASH_SOURCE[0]}")" && pwd -P)
 
 ifeq ($(DEVELOPMENT),true)
 	BASE_IMAGE=amazonlinux:2
@@ -22,6 +24,10 @@ copy-generate-attribution:
 .PHONY: remove-generate-attribution
 remove-generate-attribution:
 	rm -rf ./generate-attribution
+
+.PHONY: setup-public-ecr-push
+setup-public-ecr-push:
+	$(MAKE_ROOT)/../scripts/setup_public_ecr_push.sh
 
 .PHONY: local-images
 local-images:
@@ -38,7 +44,7 @@ local-images:
 	./update_base_image.sh --dry-run
 
 .PHONY: images
-images:
+images: setup-public-ecr-push
 	# Sleeping until buildkit daemon is running on the other container
 	sleep 10
 	buildctl \

--- a/eks-distro-base/Makefile
+++ b/eks-distro-base/Makefile
@@ -5,9 +5,11 @@ AWS_REGION?=us-west-2
 BASE_IMAGE?=public.ecr.aws/amazonlinux/amazonlinux:2
 
 IMAGE_REPO?=$(AWS_ACCOUNT_ID).dkr.ecr.$(AWS_REGION).amazonaws.com
-IMAGE_NAME?=eks-distro/base
+IMAGE_NAME?=eks-distro-base
 IMAGE_TAG?=$(shell date "+%F-%s")
 IMAGE?=$(IMAGE_REPO)/$(IMAGE_NAME):$(IMAGE_TAG)
+
+MAKE_ROOT=$(shell cd "$(shell dirname "${BASH_SOURCE[0]}")" && pwd -P)
 
 ifeq ($(DEVELOPMENT),true)
 	BASE_IMAGE=amazonlinux:2
@@ -18,11 +20,15 @@ ifeq ("$(REPO_OWNER)","")
       This is used to raise a pull request against your org after updating tags in the respective files.)
 endif
 
+.PHONY: setup-public-ecr-push
+setup-public-ecr-push:
+	$(MAKE_ROOT)/../scripts/setup_public_ecr_push.sh
+
 .PHONY: local-images
 local-images:
 	# Sleeping until buildkit daemon is running on the other container
 	sleep 10 
-	./check_update.sh $(IMAGE_REPO) $(IMAGE_NAME) $(IMAGE_TAG) --dry-run
+	# ./check_update.sh $(IMAGE_REPO) $(IMAGE_NAME) $(IMAGE_TAG) --dry-run
 	buildctl \
 		build \
 		--frontend dockerfile.v0 \
@@ -34,7 +40,7 @@ local-images:
 	./update_base_image.sh $(IMAGE_TAG) --dry-run
 
 .PHONY: images
-images:
+images: setup-public-ecr-push
 	# Sleeping until buildkit daemon is running on the other container
 	sleep 10
 	buildctl \

--- a/scripts/setup_public_ecr_push.sh
+++ b/scripts/setup_public_ecr_push.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Copyright 2020 Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+set -e
+set -o pipefail
+set -x
+
+cat << EOF > config
+[default]
+output=json
+region=${AWS_REGION:-${AWS_DEFAULT_REGION:-us-west-2}}
+role_arn=$AWS_ROLE_ARN
+web_identity_token_file=/var/run/secrets/eks.amazonaws.com/serviceaccount/token
+
+[profile ecr-public-push]
+role_arn=$ECR_PUBLIC_PUSH_ROLE_ARN
+region=${AWS_REGION:-${AWS_DEFAULT_REGION:-us-east-1}}
+source_profile=default
+EOF
+
+export AWS_CONFIG_FILE=$(pwd)/config
+export AWS_PROFILE=ecr-public-push
+export AWS_DEFAULT_PROFILE=$AWS_PROFILE


### PR DESCRIPTION
This setup script makes sure we use the proper Role to push to the `eks-distro-build-tooling` repo where we have the base image repos.

/hold

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
