### PR TITLE
Increase sleep before building images

### DIFF
--- a/builder-base/Makefile
+++ b/builder-base/Makefile
@@ -46,7 +46,7 @@ local-images:
 .PHONY: images
 images: setup-public-ecr-push
 	# Sleeping until buildkit daemon is running on the other container
-	sleep 10
+	sleep 15
 	buildctl \
 		build \
 		--frontend dockerfile.v0 \

--- a/eks-distro-base/Makefile
+++ b/eks-distro-base/Makefile
@@ -42,7 +42,7 @@ local-images:
 .PHONY: images
 images: setup-public-ecr-push
 	# Sleeping until buildkit daemon is running on the other container
-	sleep 10
+	sleep 15
 	buildctl \
 		build \
 		--frontend dockerfile.v0 \


### PR DESCRIPTION
/hold
Testing whether presubmits pick up latest image.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
