### PR TITLE
Increase sleep before building images, fix region as us-east-1 for ECR public push

### DIFF
--- a/builder-base/Makefile
+++ b/builder-base/Makefile
@@ -46,7 +46,7 @@ local-images:
 .PHONY: images
 images: setup-public-ecr-push
 	# Sleeping until buildkit daemon is running on the other container
-	sleep 10
+	sleep 15
 	buildctl \
 		build \
 		--frontend dockerfile.v0 \

--- a/eks-distro-base/Makefile
+++ b/eks-distro-base/Makefile
@@ -42,7 +42,7 @@ local-images:
 .PHONY: images
 images: setup-public-ecr-push
 	# Sleeping until buildkit daemon is running on the other container
-	sleep 10
+	sleep 15
 	buildctl \
 		build \
 		--frontend dockerfile.v0 \

--- a/scripts/setup_public_ecr_push.sh
+++ b/scripts/setup_public_ecr_push.sh
@@ -27,7 +27,7 @@ web_identity_token_file=/var/run/secrets/eks.amazonaws.com/serviceaccount/token
 
 [profile ecr-public-push]
 role_arn=$ECR_PUBLIC_PUSH_ROLE_ARN
-region=${AWS_REGION:-${AWS_DEFAULT_REGION:-us-east-1}}
+region=us-east-1
 source_profile=default
 EOF
 


### PR DESCRIPTION
Fixing the region in the script; sleep increase is just to trigger image builds.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
