### PR TITLE
builder-base: update package/ansible and add yq

### DIFF
--- a/builder-base/goss-checksum
+++ b/builder-base/goss-checksum
@@ -1,1 +1,1 @@
-7d8d665c95262bfd7507efe852aa213c46d989e252333d267b1888cb9fc8d139  packer-provisioner-goss-v2.0.0-linux-amd64.tar.gz
+1994069f78d44a76d463b76fef42c7e4ab412df14703a51643642ecdefa2c029  packer-provisioner-goss-v3.0.3-linux-amd64.tar.gz

--- a/builder-base/install.sh
+++ b/builder-base/install.sh
@@ -114,7 +114,7 @@ pip3 install "ansible==$ANSIBLE_VERSION"
 PYWINRM_VERSION="${PYWINRM_VERSION:-0.4.1}"
 pip3 install "pywinrm==$PYWINRM_VERSION"
 
-PACKER_VERSION="${PACKER_VERSION:-1.6.6}"
+PACKER_VERSION="${PACKER_VERSION:-1.7.2}"
 rm -rf /usr/sbin/packer
 wget \
     --progress dot:giga \
@@ -125,7 +125,7 @@ rm -rf packer_${PACKER_VERSION}_linux_amd64.zip
 
 useradd -ms /bin/bash -u 1100 imagebuilder
 mkdir -p /home/imagebuilder/.packer.d/plugins
-GOSS_VERSION="${GOSS_VERSION:-2.0.0}"
+GOSS_VERSION="${GOSS_VERSION:-3.0.3}"
 wget \
     --progress dot:giga \
     https://github.com/YaleUniversity/packer-provisioner-goss/releases/download/v${GOSS_VERSION}/packer-provisioner-goss-v${GOSS_VERSION}-linux-amd64.tar.gz
@@ -149,6 +149,16 @@ sha256sum -c $BASE_DIR/govc-checksum
 gzip -d govc_linux_amd64.gz
 mv govc_linux_amd64 /usr/bin/govc
 chmod +x /usr/bin/govc
+
+# needed to parse eks-d release yaml to get latest artifacts
+YQ_VERSION="${YQ_VERSION:-v4.7.1}"
+wget \
+    --progress dot:giga \
+    https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64.tar.gz
+sha256sum -c $BASE_DIR/yq-checksum
+tar -xzf yq_linux_amd64.tar.gz
+mv yq_linux_amd64 /usr/bin/yq
+rm yq_linux_amd64.tar.gz
 
 # Bash 4.3 is required to run kubernetes make test
 OVERRIDE_BASH_VERSION="${OVERRIDE_BASH_VERSION:-4.3}"

--- a/builder-base/packer-checksum
+++ b/builder-base/packer-checksum
@@ -1,1 +1,1 @@
-721d119fd70e38d6f2b4ccd8a39daf6b4d36bf5f7640036acafcaaa967b00c3b  packer_1.6.6_linux_amd64.zip
+9429c3a6f80b406dbddb9b30a4e468aeac59ab6ae4d09618c8d70c4f4188442e  packer_1.7.2_linux_amd64.zip

--- a/builder-base/yq-checksum
+++ b/builder-base/yq-checksum
@@ -1,0 +1,1 @@
+4eee4d884da169b2bfdab545d2b149b4d6a0050e86e3906088f8fae6ee509394  yq_linux_amd64.tar.gz


### PR DESCRIPTION
Updated image-builder tag which needs newer packer+ansible. Also adding yq for parsing the eks-d release yaml

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
