### PR TITLE
Remove ECR setup scripts from Makefile

### DIFF
--- a/builder-base/Makefile
+++ b/builder-base/Makefile
@@ -25,12 +25,8 @@ copy-generate-attribution:
 remove-generate-attribution:
 	rm -rf ./generate-attribution
 
-.PHONY: setup-public-ecr-push
-setup-public-ecr-push:
-	$(MAKE_ROOT)/../scripts/setup_public_ecr_push.sh
-
 .PHONY: local-images
-local-images: setup-public-ecr-push
+local-images:
 	# Sleeping until buildkit daemon is running on the other container
 	sleep 10
 	buildctl \
@@ -44,7 +40,7 @@ local-images: setup-public-ecr-push
 	./update_base_image.sh --dry-run
 
 .PHONY: images
-images: setup-public-ecr-push
+images:
 	# Sleeping until buildkit daemon is running on the other container
 	sleep 15
 	buildctl \

--- a/eks-distro-base/Makefile
+++ b/eks-distro-base/Makefile
@@ -20,10 +20,6 @@ ifeq ("$(REPO_OWNER)","")
       This is used to raise a pull request against your org after updating tags in the respective files.)
 endif
 
-.PHONY: setup-public-ecr-push
-setup-public-ecr-push:
-	$(MAKE_ROOT)/../scripts/setup_public_ecr_push.sh
-
 .PHONY: local-images
 local-images:
 	# Sleeping until buildkit daemon is running on the other container
@@ -40,7 +36,7 @@ local-images:
 	./update_base_image.sh $(IMAGE_TAG) --dry-run
 
 .PHONY: images
-images: setup-public-ecr-push
+images:
 	# Sleeping until buildkit daemon is running on the other container
 	sleep 15
 	buildctl \


### PR DESCRIPTION
This script has now been moved to the Prowjobs to be invoked before the make target.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
