### PR TITLE
Remove DEVELOPMENT var from build-tooling projet Makefiles

### DIFF
--- a/builder-base/Makefile
+++ b/builder-base/Makefile
@@ -1,4 +1,3 @@
-DEVELOPMENT?=true
 AWS_ACCOUNT_ID?=$(shell aws sts get-caller-identity --query Account --output text)
 AWS_REGION?=us-west-2
 
@@ -10,12 +9,6 @@ IMAGE_NAME?=builder-base
 # or the base branch commit hash (postsubmit)
 IMAGE_TAG?=latest
 IMAGE?=$(IMAGE_REPO)/$(IMAGE_NAME):$(IMAGE_TAG)
-
-MAKE_ROOT=$(shell cd "$(shell dirname "${BASH_SOURCE[0]}")" && pwd -P)
-
-ifeq ($(DEVELOPMENT),true)
-	BASE_IMAGE=amazonlinux:2
-endif
 
 .PHONY: copy-generate-attribution
 copy-generate-attribution:

--- a/eks-distro-base/Makefile
+++ b/eks-distro-base/Makefile
@@ -1,4 +1,3 @@
-DEVELOPMENT?=true
 AWS_ACCOUNT_ID?=$(shell aws sts get-caller-identity --query Account --output text)
 AWS_REGION?=us-west-2
 
@@ -9,12 +8,6 @@ IMAGE_NAME?=eks-distro-base
 IMAGE_TAG?=$(shell date "+%F-%s")
 IMAGE?=$(IMAGE_REPO)/$(IMAGE_NAME):$(IMAGE_TAG)
 
-MAKE_ROOT=$(shell cd "$(shell dirname "${BASH_SOURCE[0]}")" && pwd -P)
-
-ifeq ($(DEVELOPMENT),true)
-	BASE_IMAGE=amazonlinux:2
-endif
-
 ifeq ("$(REPO_OWNER)","")
     $(error No org information was provided, please set and export REPO_OWNER environment variable. \
       This is used to raise a pull request against your org after updating tags in the respective files.)
@@ -24,7 +17,7 @@ endif
 local-images:
 	# Sleeping until buildkit daemon is running on the other container
 	sleep 10 
-	# ./check_update.sh $(IMAGE_REPO) $(IMAGE_NAME) $(IMAGE_TAG) --dry-run
+	./check_update.sh $(IMAGE_TAG) --dry-run
 	buildctl \
 		build \
 		--frontend dockerfile.v0 \

--- a/eks-distro-base/check_update.sh
+++ b/eks-distro-base/check_update.sh
@@ -20,12 +20,10 @@ set -x
 
 SCRIPT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 
-IMAGE_REPO=$1
-IMAGE_NAME=$2
-IMAGE_TAG=$3
-DRY_RUN_FLAG=$4
+IMAGE_TAG=$1
+DRY_RUN_FLAG=$2
 
-BASE_IMAGE=${IMAGE_REPO}/${IMAGE_NAME}:$(cat ${SCRIPT_ROOT}/../EKS_DISTRO_BASE_TAG_FILE)
+BASE_IMAGE=public.ecr.aws/eks-distro-build-tooling/eks-distro-base:$(cat ${SCRIPT_ROOT}/../EKS_DISTRO_BASE_TAG_FILE)
 mkdir check-update
 cat << 'EOF' >> check-update/Dockerfile
 FROM $BASE_IMAGE AS base_image

--- a/projects/aws/amazon-eks-pod-identity-webhook/Makefile
+++ b/projects/aws/amazon-eks-pod-identity-webhook/Makefile
@@ -14,7 +14,6 @@ ifeq ("$(GIT_COMMIT)","")
 	$(error No git commit was provided.)
 endif
 
-DEVELOPMENT?=true
 AWS_ACCOUNT_ID?=$(shell aws sts get-caller-identity --query Account --output text)
 AWS_REGION?=us-west-2
 

--- a/projects/infinityworks/github-exporter/Makefile
+++ b/projects/infinityworks/github-exporter/Makefile
@@ -14,7 +14,6 @@ ifeq ("$(GIT_COMMIT)","")
 	$(error No git commit was provided.)
 endif
 
-DEVELOPMENT?=true
 AWS_ACCOUNT_ID?=$(shell aws sts get-caller-identity --query Account --output text)
 AWS_REGION?=us-west-2
 

--- a/projects/prometheus/alertmanager/Makefile
+++ b/projects/prometheus/alertmanager/Makefile
@@ -14,7 +14,6 @@ ifeq ("$(GIT_COMMIT)","")
 	$(error No git commit was provided.)
 endif
 
-DEVELOPMENT?=true
 AWS_ACCOUNT_ID?=$(shell aws sts get-caller-identity --query Account --output text)
 AWS_REGION?=us-west-2
 


### PR DESCRIPTION
We don't need this variable anymore, since we are consuming public ECR images by default.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
