### PR TITLE
install gettext on builder base for envsubst

### DIFF
--- a/builder-base/install.sh
+++ b/builder-base/install.sh
@@ -93,6 +93,7 @@ yum install -y \
     bind-utils \
     curl \
     gcc \
+    gettext \
     jq \
     less \
     man \


### PR DESCRIPTION
For generating config files on the fly based one eks-distro release yaml, Id like to use envsubst which is provided by gettext.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
