### PR TITLE
Add docker to builder-base

### DIFF
--- a/builder-base/install.sh
+++ b/builder-base/install.sh
@@ -92,6 +92,7 @@ mkdir -p /go/src /go/bin /go/pkg /go/src/github.com/aws/eks-distro
 yum install -y \
     bind-utils \
     curl \
+    docker \
     gcc \
     gettext \
     jq \


### PR DESCRIPTION
Install docker on builder-base to build kind node image

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
