### PR TITLE
Remove unnecessary args when invoking script in periodic

### DIFF
--- a/eks-distro-base/Makefile
+++ b/eks-distro-base/Makefile
@@ -93,7 +93,7 @@ release: images
 update:
 	# Sleeping until buildkit daemon is running on the other container
 	sleep 10
-	$(eval RETURN_MESSAGE="$(shell ./check_update.sh $(IMAGE_REPO) $(IMAGE_NAME) $(IMAGE_TAG))")
+	$(eval RETURN_MESSAGE="$(shell ./check_update.sh $(IMAGE_TAG))")
 	if [ $(RETURN_MESSAGE) = "Updates required" ]; then \
 		$(MAKE) images; \
 	elif [ $(RETURN_MESSAGE) = "Error" ]; then \


### PR DESCRIPTION
Since we've hardcoded the image name and image repo, we don't need to pass them in as arguments to the script.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
