### PR TITLE
Fixed bug related to etcd GIT_TAG

### DIFF
--- a/release/pkg/assets_etcd.go
+++ b/release/pkg/assets_etcd.go
@@ -25,7 +25,7 @@ import (
 // GetEtcdComponent returns the Component for Etcd
 func (r *ReleaseConfig) GetEtcdComponent(spec distrov1alpha1.ReleaseSpec) (*distrov1alpha1.Component, error) {
 	projectSource := "projects/etcd-io/etcd"
-	tagFile := filepath.Join(r.BuildRepoSource, projectSource, "GIT_TAG")
+	tagFile := filepath.Join(r.BuildRepoSource, projectSource, spec.Channel, "GIT_TAG")
 	gitTag, err := readTag(tagFile)
 	if err != nil {
 		return nil, errors.Cause(err)


### PR DESCRIPTION
*Problem:*
* Prow job [fails](https://prow.eks.amazonaws.com/view/s3/prowdataclusterstack-316434458-prowbucket7c73355c-1n9f9v93wpjcm/logs/dev-release-1-20-postsubmit/1393357204056182784#2:build-container-build-log.txt%3A15064)

*Description of changes:*
* Fixes bug from https://github.com/aws/eks-distro-prow-jobs/pull/177
* Related to other bug fix https://github.com/aws/eks-distro/pull/357

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
