### PR TITLE
Add buildkit check for postsubmit and periodic make targets

### DIFF
--- a/eks-distro-base/Makefile
+++ b/eks-distro-base/Makefile
@@ -33,9 +33,7 @@ local-images: buildkit-check
 	./update_base_image.sh $(IMAGE_TAG) --dry-run
 
 .PHONY: images
-images:
-	# Sleeping until buildkit daemon is running on the other container
-	sleep 15
+images: buildkit-check
 	buildctl \
 		build \
 		--frontend dockerfile.v0 \
@@ -94,9 +92,7 @@ build: local-images
 release: images
 
 .PHONY: update
-update:
-	# Sleeping until buildkit daemon is running on the other container
-	sleep 10
+update: buildkit-check
 	$(eval RETURN_MESSAGE="$(shell ./check_update.sh $(IMAGE_TAG))")
 	if [ $(RETURN_MESSAGE) = "Updates required" ]; then \
 		$(MAKE) images; \


### PR DESCRIPTION
We need the buildkit check for postsubmits and periodics since we call `buildctl` here as well.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
