### PR TITLE
Configure ECR Public push setup script and make target to run in same shell

### DIFF
--- a/eks-distro-base/Makefile
+++ b/eks-distro-base/Makefile
@@ -95,7 +95,7 @@ release: images
 update: buildkit-check
 	$(eval RETURN_MESSAGE="$(shell ./check_update.sh $(IMAGE_TAG))")
 	if [ $(RETURN_MESSAGE) = "Updates required" ]; then \
-		$(MAKE) images; \
+		source $(MAKE_ROOT)/../scripts/setup_public_ecr_push.sh && $(MAKE) images; \
 	elif [ $(RETURN_MESSAGE) = "Error" ]; then \
 		exit 1; \
 	fi


### PR DESCRIPTION
The env vars set by the script are not available in the same shell as the one in which the make target is invoked.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
