### PR TITLE
Use Bash shell in Makefile to source script

### DIFF
--- a/eks-distro-base/Makefile
+++ b/eks-distro-base/Makefile
@@ -1,3 +1,5 @@
+SHELL := /bin/bash
+
 AWS_ACCOUNT_ID?=$(shell aws sts get-caller-identity --query Account --output text)
 AWS_REGION?=us-west-2
 


### PR DESCRIPTION
Makefile by default uses `sh` shell, which doesn't implement source. Hence we are changing it to use `bash` shell so that the periodic can source the setup script.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
