### PR TITLE
Avoid re-running check-update script in periodic

### DIFF
--- a/eks-distro-base/Makefile
+++ b/eks-distro-base/Makefile
@@ -36,7 +36,9 @@ local-images: buildkit-check
 
 .PHONY: images
 images: buildkit-check
-	./check_update.sh $(IMAGE_TAG)
+	if [ "$(JOB_TYPE)" = "postsubmit" ]; then \
+		./check_update.sh $(IMAGE_TAG); \
+	fi
 	buildctl \
 		build \
 		--frontend dockerfile.v0 \


### PR DESCRIPTION
Fixing the Makefile to run the check-update script only once during the periodic.
/hold

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
