### PR TITLE
Add hugo binary to base docker container

### DIFF
--- a/builder-base/hugo-checksum
+++ b/builder-base/hugo-checksum
@@ -1,0 +1,1 @@
+26e1656dc77b49011a9c859fc90648a8f457af4f68e0f641a3a7a7210952e0af  hugo_extended_0.85.0_Linux-64bit.tar.gz

--- a/builder-base/install.sh
+++ b/builder-base/install.sh
@@ -199,7 +199,6 @@ GO111MODULE=on go get github.com/google/go-licenses@v0.0.0-20201026145851-73411c
 # Install hugo for docs
 HUGOVERSION=0.85.0
 wget https://github.com/gohugoio/hugo/releases/download/v${HUGOVERSION}/hugo_extended_${HUGOVERSION}_Linux-64bit.tar.gz
-wget https://github.com/gohugoio/hugo/releases/download/v${HUGOVERSION}/hugo_${HUGOVERSION}_checksums.txt
 sha256sum -c ${BASE_DIR}/hugo-checksum
 tar -xf hugo_extended_${HUGOVERSION}_Linux-64bit.tar.gz
 mv hugo /usr/bin/hugo

--- a/builder-base/install.sh
+++ b/builder-base/install.sh
@@ -203,7 +203,7 @@ wget https://github.com/gohugoio/hugo/releases/download/v${HUGOVERSION}/hugo_${H
 sha256sum -c ${BASE_DIR}/hugo-checksum
 tar -xf hugo_extended_${HUGOVERSION}_Linux-64bit.tar.gz
 mv hugo /usr/bin/hugo
-rm -rf hugo_extended_${HUGOVERSION}_Linux-64bit.tar.gz hugo_${HUGO_VERSION}_checksums.txt
+rm -rf hugo_extended_${HUGOVERSION}_Linux-64bit.tar.gz ${BASE_DIR}/hugo-checksum
 
 NODEJS_VERSION="${NODEJS_VERSION:-v15.11.0}" 
 wget --progress dot:giga \

--- a/builder-base/install.sh
+++ b/builder-base/install.sh
@@ -200,9 +200,7 @@ GO111MODULE=on go get github.com/google/go-licenses@v0.0.0-20201026145851-73411c
 HUGOVERSION=0.85.0
 wget https://github.com/gohugoio/hugo/releases/download/v${HUGOVERSION}/hugo_extended_${HUGOVERSION}_Linux-64bit.tar.gz
 wget https://github.com/gohugoio/hugo/releases/download/v${HUGOVERSION}/hugo_${HUGOVERSION}_checksums.txt
-grep hugo_extended_${HUGOVERSION}_Linux-64bit.tar.gz hugo_${HUGOVERSION}_checksums.txt \
-	| sha256sum -c -
-sha256sum -c hugo_extended_${HUGOVERSION}_Linux-64bit.tar.gz
+sha256sum -c ${BASE_DIR}/hugo-checksum
 tar -xf hugo_extended_${HUGOVERSION}_Linux-64bit.tar.gz
 mv hugo /usr/bin/hugo
 rm -rf hugo_extended_${HUGOVERSION}_Linux-64bit.tar.gz hugo_${HUGO_VERSION}_checksums.txt

--- a/builder-base/install.sh
+++ b/builder-base/install.sh
@@ -201,7 +201,7 @@ HUGOVERSION=0.85.0
 wget https://github.com/gohugoio/hugo/releases/download/v${HUGOVERSION}/hugo_extended_${HUGOVERSION}_Linux-64bit.tar.gz
 wget https://github.com/gohugoio/hugo/releases/download/v${HUGOVERSION}/hugo_${HUGOVERSION}_checksums.txt
 grep hugo_extended_${HUGOVERSION}_Linux-64bit.tar.gz hugo_${HUGOVERSION}_checksums.txt \
-	sha256sum -c -
+	| sha256sum -c -
 sha256sum -c hugo_extended_${HUGOVERSION}_Linux-64bit.tar.gz
 tar -xf hugo_extended_${HUGOVERSION}_Linux-64bit.tar.gz
 mv hugo /usr/bin/hugo

--- a/builder-base/install.sh
+++ b/builder-base/install.sh
@@ -199,9 +199,13 @@ GO111MODULE=on go get github.com/google/go-licenses@v0.0.0-20201026145851-73411c
 # Install hugo for docs
 HUGOVERSION=0.85.0
 wget https://github.com/gohugoio/hugo/releases/download/v${HUGOVERSION}/hugo_extended_${HUGOVERSION}_Linux-64bit.tar.gz
+wget https://github.com/gohugoio/hugo/releases/download/v${HUGOVERSION}/hugo_${HUGOVERSION}_checksums.txt
+grep hugo_extended_${HUGOVERSION}_Linux-64bit.tar.gz hugo_${HUGOVERSION}_checksums.txt \
+	sha256sum -c -
+sha256sum -c hugo_extended_${HUGOVERSION}_Linux-64bit.tar.gz
 tar -xf hugo_extended_${HUGOVERSION}_Linux-64bit.tar.gz
 mv hugo /usr/bin/hugo
-rm -rf hugo_extended_${HUGOVERSION}_Linux-64bit.tar.gz
+rm -rf hugo_extended_${HUGOVERSION}_Linux-64bit.tar.gz hugo_${HUGO_VERSION}_checksums.txt
 
 NODEJS_VERSION="${NODEJS_VERSION:-v15.11.0}" 
 wget --progress dot:giga \

--- a/builder-base/install.sh
+++ b/builder-base/install.sh
@@ -194,7 +194,14 @@ setupgo "${GOLANG115_VERSION:-1.15.11}"
 setupgo "${GOLANG116_VERSION:-1.16.3}"
 
 # go-licenses doesnt have any release tags, using the latest master
-GO111MODULE=on go get github.com/google/go-licenses@v0.0.0-20201026145851-73411c8fa237     
+GO111MODULE=on go get github.com/google/go-licenses@v0.0.0-20201026145851-73411c8fa237
+
+# Install hugo for docs
+HUGOVERSION=0.85.0
+wget https://github.com/gohugoio/hugo/releases/download/v${HUGOVERSION}/hugo_extended_${HUGOVERSION}_Linux-64bit.tar.gz
+tar -xf hugo_extended_${HUGOVERSION}_Linux-64bit.tar.gz
+mv hugo /usr/bin/hugo
+rm -rf hugo_extended_${HUGOVERSION}_Linux-64bit.tar.gz
 
 NODEJS_VERSION="${NODEJS_VERSION:-v15.11.0}" 
 wget --progress dot:giga \


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This adds hugo binary to the base container build.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
