### PR TITLE
Call async function outside return statement

### DIFF
--- a/generate-attribution/generate-attribution-file.js
+++ b/generate-attribution/generate-attribution-file.js
@@ -151,9 +151,9 @@ async function addGoLicense(dependencies) {
 }
 
 async function readLicenseFromUpstream(upstreamUrl) {
+    let finalDoc = '';
+    const options = await generateAuthorizationHeader()
     return new Promise((resolve, reject) => {
-        let finalDoc = '';
-        const options = await generateAuthorizationHeader()
         const req = https.get(upstreamUrl, options, res => {
             res.on('data', d => {
                 finalDoc += d;
@@ -172,10 +172,10 @@ async function readLicenseFromUpstream(upstreamUrl) {
 
 
 async function getPackageRepo(package) {
+    let finalDoc = '';
+    const url = `https://${package}?go-get=1`
+    const options = await generateAuthorizationHeader()
     return new Promise((resolve, reject) => {
-        let finalDoc = '';
-        const url = `https://${package}?go-get=1`
-        const options = await generateAuthorizationHeader()
         const req = https.get(url, options, res => {
             if (res.statusCode !== 200) {
                 if (package.startsWith('github.com')) {


### PR DESCRIPTION
Waiting for an async method inside a Promise closure is kind of an anti-pattern.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
