### PR TITLE
minimal image: add nonroot variant and clean up static files

### DIFF
--- a/eks-distro-base/Dockerfile.minimal
+++ b/eks-distro-base/Dockerfile.minimal
@@ -43,6 +43,7 @@ RUN mkdir -p /newroot/var/{backups,cache,lib,local,lock,log,run,spool,tmp}
 RUN cp -rf /etc/pki/ca-trust/extracted /newroot/etc/pki/ca-trust
 # non root user
 RUN mkdir -p /newroot/home/nonroot
+RUN chown 65532:65532 /newroot/home/nonroot
 # tmp directory with correct permissions
 RUN mkdir -p -m 1777 /newroot/tmp
 COPY files/ /newroot

--- a/eks-distro-base/Dockerfile.minimal
+++ b/eks-distro-base/Dockerfile.minimal
@@ -30,6 +30,7 @@ RUN yum reinstall \
     tzdata
 
 WORKDIR /newroot
+
 # ca certs
 RUN rpm2cpio $DOWNLOAD_DIR/$(rpm -qa ca-certificates).rpm | cpio -idmv
 RUN rpm2cpio $DOWNLOAD_DIR/$(rpm -qa setup).rpm | cpio -idmv 
@@ -37,19 +38,16 @@ RUN rpm2cpio $DOWNLOAD_DIR/$(rpm -qa system-release).rpm | cpio -idmv
 RUN rpm2cpio $DOWNLOAD_DIR/$(rpm -qa tzdata).rpm | cpio -idmv
 RUN mkdir -p /newroot/{bin,boot,lib,root,run,sbin,var}
 RUN mkdir -p /newroot/var/{backups,cache,lib,local,lock,log,run,spool,tmp}
+
 # cert files created by post install of ca-certs
 RUN cp -rf /etc/pki/ca-trust/extracted /newroot/etc/pki/ca-trust
 # non root user
 RUN mkdir -p /newroot/home/nonroot
 # tmp directory with correct permissions
-RUN mkdir -p /newroot/tmp
-RUN chmod 1777 /newroot/tmp
-RUN cp /etc/nsswitch.conf /newroot/etc/
-RUN cp /etc/passwd /newroot/etc
-RUN cp /etc/group /newroot/etc
+RUN mkdir -p -m 1777 /newroot/tmp
+COPY files/ /newroot
 
 FROM scratch
 ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 ENV SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt
 COPY --from=builder /newroot /
-# nonroot variant is the same with the USER 65532 defined

--- a/eks-distro-base/Dockerfile.minimal-nonroot
+++ b/eks-distro-base/Dockerfile.minimal-nonroot
@@ -1,0 +1,18 @@
+# Copyright 2020 Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE} 
+
+USER 65532

--- a/eks-distro-base/files/etc/group
+++ b/eks-distro-base/files/etc/group
@@ -1,0 +1,5 @@
+root:x:0:
+nobody:x:65534:
+tty:x:5:
+staff:x:50:
+nonroot:x:65532:

--- a/eks-distro-base/files/etc/nsswitch.conf
+++ b/eks-distro-base/files/etc/nsswitch.conf
@@ -1,0 +1,12 @@
+passwd:         compat
+group:          compat
+shadow:         compat
+gshadow:        files
+
+hosts:          files dns
+networks:       files
+
+protocols:      files
+services:       files
+ethers:         files
+rpc:            files

--- a/eks-distro-base/files/etc/os-release
+++ b/eks-distro-base/files/etc/os-release
@@ -1,0 +1,8 @@
+NAME="Amazon Linux"
+VERSION="2"
+ID="amzn"
+ID_LIKE="centos rhel fedora"
+VERSION_ID="2"
+PRETTY_NAME="Minimal"
+ANSI_COLOR="0;33"
+HOME_URL="https://amazonlinux.com/"

--- a/eks-distro-base/files/etc/passwd
+++ b/eks-distro-base/files/etc/passwd
@@ -1,0 +1,3 @@
+root:x:0:0:root:/root:/sbin/nologin
+nobody:x:65534:65534:nobody:/nonexistent:/sbin/nologin
+nonroot:x:65532:65532:nonroot:/home/nonroot:/sbin/nologin


### PR DESCRIPTION
- Instead of using nsswitch from al2, use a more generic similar to distroless
- add passwd/group files to define root and nonroot users
- add os-release file similar to distroless 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
