### PR TITLE
Downgrading Grafana helm chart version to 6.13.6

### DIFF
--- a/projects/grafana/helm-charts/Makefile
+++ b/projects/grafana/helm-charts/Makefile
@@ -1,6 +1,6 @@
 GRAFANA_CHART_REPO?=helm-charts
 GRAFANA_CHART_CLONE_URL?=https://github.com/grafana/$(GRAFANA_CHART_REPO).git
-GRAFANA_CHART_GIT_TAG?=grafana-6.4.4
+GRAFANA_CHART_GIT_TAG?=grafana-6.14.1
 
 ifeq ("$(GRAFANA_CHART_REPO)","")
 	$(error No repository name for Grafana chart was provided.)

--- a/projects/grafana/helm-charts/Makefile
+++ b/projects/grafana/helm-charts/Makefile
@@ -1,6 +1,6 @@
 GRAFANA_CHART_REPO?=helm-charts
 GRAFANA_CHART_CLONE_URL?=https://github.com/grafana/$(GRAFANA_CHART_REPO).git
-GRAFANA_CHART_GIT_TAG?=grafana-6.14.1
+GRAFANA_CHART_GIT_TAG?=grafana-6.13.6
 
 ifeq ("$(GRAFANA_CHART_REPO)","")
 	$(error No repository name for Grafana chart was provided.)


### PR DESCRIPTION
Upgrading the Grafana helm chart to version 6.14.1 created some unexpected network errors in my Grafana dashboard, so downgrading to see if the new version fixes the issue. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
