### PR TITLE
Fix comments for asset component methods

### DIFF
--- a/release/pkg/assets_attacher.go
+++ b/release/pkg/assets_attacher.go
@@ -22,7 +22,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-// GetAttacherComponent returns the Component for Kubernetes
+// GetAttacherComponent returns the Component for External Attacher
 func (r *ReleaseConfig) GetAttacherComponent(spec distrov1alpha1.ReleaseSpec) (*distrov1alpha1.Component, error) {
 	projectSource := "projects/kubernetes-csi/external-attacher"
 	tagFile := filepath.Join(r.BuildRepoSource, projectSource, "GIT_TAG")

--- a/release/pkg/assets_authenticator.go
+++ b/release/pkg/assets_authenticator.go
@@ -22,7 +22,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-// GetKubernetesComponent returns the Component for Kubernetes
+// GetAuthenticatorComponent returns the Component for AWS IAM Authenticator
 func (r *ReleaseConfig) GetAuthenticatorComponent(spec distrov1alpha1.ReleaseSpec) (*distrov1alpha1.Component, error) {
 	projectSource := "projects/kubernetes-sigs/aws-iam-authenticator"
 	tagFile := filepath.Join(r.BuildRepoSource, projectSource, spec.Channel, "GIT_TAG")

--- a/release/pkg/assets_cni.go
+++ b/release/pkg/assets_cni.go
@@ -22,7 +22,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-// GetKubernetesComponent returns the Component for Kubernetes
+// GetCniComponent returns the Component for CNI plugins
 func (r *ReleaseConfig) GetCniComponent(spec distrov1alpha1.ReleaseSpec) (*distrov1alpha1.Component, error) {
 	projectSource := "projects/containernetworking/plugins"
 	tagFile := filepath.Join(r.BuildRepoSource, projectSource, "GIT_TAG")

--- a/release/pkg/assets_coredns.go
+++ b/release/pkg/assets_coredns.go
@@ -22,7 +22,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-// GetCorednsComponent returns the Component for Kubernetes
+// GetCorednsComponent returns the Component for CoreDNS
 func (r *ReleaseConfig) GetCorednsComponent(spec distrov1alpha1.ReleaseSpec) (*distrov1alpha1.Component, error) {
 	projectSource := "projects/coredns/coredns"
 	tagFile := filepath.Join(r.BuildRepoSource, projectSource, spec.Channel, "GIT_TAG")

--- a/release/pkg/assets_livenessprobe.go
+++ b/release/pkg/assets_livenessprobe.go
@@ -22,7 +22,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-// GetLivenessprobeComponent returns the Component for Kubernetes
+// GetLivenessprobeComponent returns the Component for Liveness Probe
 func (r *ReleaseConfig) GetLivenessprobeComponent(spec distrov1alpha1.ReleaseSpec) (*distrov1alpha1.Component, error) {
 	projectSource := "projects/kubernetes-csi/livenessprobe"
 	tagFile := filepath.Join(r.BuildRepoSource, projectSource, "GIT_TAG")

--- a/release/pkg/assets_metricsserver.go
+++ b/release/pkg/assets_metricsserver.go
@@ -22,7 +22,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-// GetMetricsServerComponent returns the Component for metrics-server
+// GetMetricsServerComponent returns the Component for Metrics Server
 func (r *ReleaseConfig) GetMetricsServerComponent(spec distrov1alpha1.ReleaseSpec) (*distrov1alpha1.Component, error) {
 	projectSource := "projects/kubernetes-sigs/metrics-server"
 	tagFile := filepath.Join(r.BuildRepoSource, projectSource, spec.Channel, "GIT_TAG")

--- a/release/pkg/assets_provisioner.go
+++ b/release/pkg/assets_provisioner.go
@@ -22,7 +22,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-// GetProvisionerComponent returns the Component for Kubernetes
+// GetProvisionerComponent returns the Component for External Provisioner
 func (r *ReleaseConfig) GetProvisionerComponent(spec distrov1alpha1.ReleaseSpec) (*distrov1alpha1.Component, error) {
 	projectSource := "projects/kubernetes-csi/external-provisioner"
 	tagFile := filepath.Join(r.BuildRepoSource, projectSource, "GIT_TAG")

--- a/release/pkg/assets_registrar.go
+++ b/release/pkg/assets_registrar.go
@@ -22,7 +22,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-// GetRegistrarComponent returns the Component for Kubernetes
+// GetRegistrarComponent returns the Component for Node Driver Registrar
 func (r *ReleaseConfig) GetRegistrarComponent(spec distrov1alpha1.ReleaseSpec) (*distrov1alpha1.Component, error) {
 	projectSource := "projects/kubernetes-csi/node-driver-registrar"
 	tagFile := filepath.Join(r.BuildRepoSource, projectSource, "GIT_TAG")

--- a/release/pkg/assets_resizer.go
+++ b/release/pkg/assets_resizer.go
@@ -22,7 +22,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-// GetResizerComponent returns the Component for Kubernetes
+// GetResizerComponent returns the Component for External Resizer
 func (r *ReleaseConfig) GetResizerComponent(spec distrov1alpha1.ReleaseSpec) (*distrov1alpha1.Component, error) {
 	projectSource := "projects/kubernetes-csi/external-resizer"
 	tagFile := filepath.Join(r.BuildRepoSource, projectSource, "GIT_TAG")

--- a/release/pkg/assets_snapshotter.go
+++ b/release/pkg/assets_snapshotter.go
@@ -22,7 +22,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-// GetSnapshotterComponent returns the Component for Kubernetes
+// GetSnapshotterComponent returns the Component for External Snapshotter
 func (r *ReleaseConfig) GetSnapshotterComponent(spec distrov1alpha1.ReleaseSpec) (*distrov1alpha1.Component, error) {
 	projectSource := "projects/kubernetes-csi/external-snapshotter"
 	tagFile := filepath.Join(r.BuildRepoSource, projectSource, "GIT_TAG")


### PR DESCRIPTION
Fix comments for release asset component methods.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
