### PR TITLE
Create base image PRs for eks-anywhere-build-tooling

### DIFF
--- a/builder-base/buildkit.sh
+++ b/builder-base/buildkit.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2020 Amazon.com Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/builder-base/docker.sh
+++ b/builder-base/docker.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2020 Amazon.com Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/builder-base/install.sh
+++ b/builder-base/install.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2020 Amazon.com Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/builder-base/update_base_image.sh
+++ b/builder-base/update_base_image.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2020 Amazon.com Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/eks-distro-base/Makefile
+++ b/eks-distro-base/Makefile
@@ -197,6 +197,7 @@ minimal-create-pr-%:
 .PHONY: create-pr
 create-pr: $(CREATE_PR_TARGETS)
 	$(MAKE_ROOT)/../pr-scripts/create_pr.sh eks-distro 'EKS_DISTRO*_TAG_FILE'
+	$(MAKE_ROOT)/../pr-scripts/create_pr.sh eks-anywhere-build-tooling 'EKS_DISTRO*_TAG_FILE'
 	$(MAKE_ROOT)/../pr-scripts/create_pr.sh eks-distro-build-tooling 'EKS_DISTRO*_TAG_FILE' 'eks-distro-base-minimal-packages/.'
 
 .PHONY: update

--- a/pr-scripts/create_pr.sh
+++ b/pr-scripts/create_pr.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2020 Amazon.com Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -30,9 +30,9 @@ fi
 SCRIPT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 
 if [ $REPO = "eks-distro-build-tooling" ] || [ $REPO = "eks-distro" ]; then
-    CHANGED_FILE="Tag file"
-elif [ $REPO = "eks-distro-prow-jobs" ]; then
-    CHANGED_FILE="Prow jobs"
+    CHANGED_FILE="tag file(s)"
+elif [[ $REPO =~ "prow-jobs" ]]; then
+    CHANGED_FILE="Prowjobs"
 fi
 
 if [ $REPO_OWNER = "aws" ]; then
@@ -41,8 +41,8 @@ else
     ORIGIN_ORG=$REPO_OWNER
 fi
 
-COMMIT_MESSAGE="[PR BOT] Update EKS Distro base image tag(s)"
-if [ $REPO = "eks-distro-prow-jobs" ]; then
+COMMIT_MESSAGE="[PR BOT] Update base image tag file(s)"
+if [[ $REPO =~ "prow-jobs" ]]; then
     COMMIT_MESSAGE="[PR BOT] Update builder-base image tag in Prow jobs"
 fi
 


### PR DESCRIPTION
This change actually creates PRs for `eks-anywhere-build-tooling` repo.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
