### PR TITLE
Add EKS-A build tooling repo to condition

### DIFF
--- a/pr-scripts/create_pr.sh
+++ b/pr-scripts/create_pr.sh
@@ -29,7 +29,7 @@ fi
 
 SCRIPT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 
-if [ $REPO = "eks-distro-build-tooling" ] || [ $REPO = "eks-distro" ]; then
+if [[ $REPO =~ "build-tooling" ]] || [ $REPO = "eks-distro" ]; then
     CHANGED_FILE="tag file(s)"
 elif [[ $REPO =~ "prow-jobs" ]]; then
     CHANGED_FILE="Prowjobs"
@@ -47,7 +47,7 @@ if [[ $REPO =~ "prow-jobs" ]]; then
 fi
 
 PR_TITLE="Update base image tag in ${CHANGED_FILE}"
-if [ $REPO = "eks-distro-build-tooling" ] || [ $REPO = "eks-distro" ]; then
+if [[ $REPO =~ "build-tooling" ]] || [ $REPO = "eks-distro" ]; then
     $SED -i "s,in .* with,in ${CHANGED_FILE} with," ${SCRIPT_ROOT}/../pr-scripts/eks_distro_base_pr_body
     cp ${SCRIPT_ROOT}/../pr-scripts/eks_distro_base_pr_body ${SCRIPT_ROOT}/../pr-scripts/${REPO}_pr_body
     


### PR DESCRIPTION
The same conditions and assignments apply to the eks-anywhere-build-tooling repo too.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
