### PR TITLE
Add registry endpoint script to config updater

### DIFF
--- a/helm-charts/stable/prow-control-plane/Chart.yaml
+++ b/helm-charts/stable/prow-control-plane/Chart.yaml
@@ -29,7 +29,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.8
+version: 1.0.9
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm-charts/stable/prow-control-plane/templates/plugins-ConfigMap.yaml
+++ b/helm-charts/stable/prow-control-plane/templates/plugins-ConfigMap.yaml
@@ -32,6 +32,7 @@ data:
       - hold
       - label
       - lgtm
+      - size
       - trigger
       - verify-owners
       - wip

--- a/helm-charts/stable/prow-control-plane/values.yaml
+++ b/helm-charts/stable/prow-control-plane/values.yaml
@@ -136,5 +136,10 @@ plugins:
         - default # namespace
         prow-presubmits-cluster: # cluster name
         - default # namespace
+    scripts/registry-entrypoint.sh:
+      name: registry-entrypoint
+      clusters:
+        prow-presubmits-cluster: # cluster name
+        - default # namespace
     jobs/**/*.yaml:
       name: job-config


### PR DESCRIPTION
Modify config updater plugin to map registry entrypoint script to ConfigMap on presubmits cluster.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
