### PR TITLE
Cleanup Go source code, bring back gofmt

### DIFF
--- a/builder-base/Dockerfile
+++ b/builder-base/Dockerfile
@@ -15,6 +15,8 @@
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
+ARG GOPROXY
+
 ENV GOPATH /go
 ENV PATH="/go/bin/:$PATH"
 
@@ -30,7 +32,8 @@ COPY generate-attribution/package*.json \
     generate-attribution/LICENSE-2.0.txt \ 
     /opt/generate-attribution/
 
-RUN bash /opt/install.sh && \
+RUN export GOPROXY=${GOPROXY} && \
+    bash /opt/install.sh && \
     rm /opt/install.sh /*-checksum
 
 WORKDIR /go/src/github.com/aws/eks-distro

--- a/builder-base/Makefile
+++ b/builder-base/Makefile
@@ -11,6 +11,8 @@ IMAGE_TAG?=latest
 IMAGE?=$(IMAGE_REPO)/$(IMAGE_NAME):$(IMAGE_TAG)
 LATEST_IMAGE=$(IMAGE_REPO)/$(IMAGE_NAME):latest
 
+BUILDKIT_OUTPUT=type=image,oci-mediatypes=true,\"name=$(IMAGE),$(LATEST_IMAGE)\",push=true
+
 MAKE_ROOT=$(shell cd "$(shell dirname "${BASH_SOURCE[0]}")" && pwd -P)
 
 .PHONY: buildkit-check
@@ -26,18 +28,9 @@ remove-generate-attribution:
 	rm -rf ./generate-attribution
 
 .PHONY: local-images
-local-images: buildkit-check
-	buildctl \
-		build \
-		--frontend dockerfile.v0 \
-		--opt platform=linux/amd64 \
-		--opt build-arg:BASE_IMAGE=$(BASE_IMAGE) \
-		--local dockerfile=./ \
-		--local context=. \
-		--progress plain \
-		--output type=tar,dest=/tmp/builder-base.tar
-	./update_base_image.sh
-
+local-images: BUILDKIT_OUTPUT=type=tar,dest=/tmp/builder-base.tar
+local-images: images
+	
 .PHONY: images
 images: buildkit-check
 	buildctl \
@@ -45,10 +38,11 @@ images: buildkit-check
 		--frontend dockerfile.v0 \
 		--opt platform=linux/amd64 \
 		--opt build-arg:BASE_IMAGE=$(BASE_IMAGE) \
+		--opt build-arg:GOPROXY=$(GOPROXY) \
 		--local dockerfile=./ \
 		--local context=. \
 		--progress plain \
-		--output type=image,oci-mediatypes=true,\"name=$(IMAGE),$(LATEST_IMAGE)\",push=true
+		--output $(BUILDKIT_OUTPUT)
 	./update_base_image.sh
 
 # for local development only

--- a/builder-base/install.sh
+++ b/builder-base/install.sh
@@ -183,7 +183,7 @@ setupgo() {
     local -r majorversion=${version%.*}
     mkdir -p ${GOPATH}/go${majorversion}/bin
     ln -s ${GOPATH}/bin/go${version} ${GOPATH}/go${majorversion}/bin/go
-    ln -s /root/sdk/${version}/bin/gofmt ${GOPATH}/go${majorversion}/bin/gofmt
+    ln -s /root/sdk/go${version}/bin/gofmt ${GOPATH}/go${majorversion}/bin/gofmt
     # Removing the source code and other files from GOROOT for each version
     rm -rf /root/sdk/${version}/!(bin/pkg)
 }

--- a/builder-base/install.sh
+++ b/builder-base/install.sh
@@ -46,15 +46,6 @@ yum install -y \
     unzip \
     wget
 
-wget \
-    --progress dot:giga \
-    https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip
-unzip awscli-exe-linux-x86_64.zip
-./aws/install
-aws --version
-rm awscli-exe-linux-x86_64.zip
-rm -rf /aws
-
 GOLANG_VERSION="${GOLANG_VERSION:-1.16.7}"
 wget \
     --progress dot:giga \
@@ -65,6 +56,20 @@ sha256sum -c $BASE_DIR/golang-checksum
 tar -C /usr/local -xzf go${GOLANG_VERSION}.linux-amd64.tar.gz
 rm go${GOLANG_VERSION}.linux-amd64.tar.gz
 mv /usr/local/go/bin/* /usr/bin/
+
+# go-licenses doesnt have any release tags, using the latest master
+# intentionally installing this very early to catch if goproxy is going to be issue
+# such if running in a an env where proxy.golang.org is blocked
+GO111MODULE=on go get github.com/google/go-licenses@v0.0.0-20210816172045-3099c18c36e1
+
+wget \
+    --progress dot:giga \
+    https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip
+unzip awscli-exe-linux-x86_64.zip
+./aws/install
+aws --version
+rm awscli-exe-linux-x86_64.zip
+rm -rf /aws
 
 BUILDKIT_VERSION="${BUILDKIT_VERSION:-v0.9.0}"
 wget \
@@ -178,6 +183,7 @@ setupgo() {
     local -r majorversion=${version%.*}
     mkdir -p ${GOPATH}/go${majorversion}/bin
     ln -s ${GOPATH}/bin/go${version} ${GOPATH}/go${majorversion}/bin/go
+    ln -s /root/sdk/${version}/bin/gofmt ${GOPATH}/go${majorversion}/bin/gofmt
     # Removing the source code and other files from GOROOT for each version
     rm -rf /root/sdk/${version}/!(bin/pkg)
 }
@@ -186,15 +192,14 @@ setupgo "${GOLANG113_VERSION:-1.13.15}"
 setupgo "${GOLANG114_VERSION:-1.14.15}"
 setupgo "${GOLANG115_VERSION:-1.15.14}"
 setupgo "${GOLANG116_VERSION:-1.16.7}"
+GOLANG_LATEST_MAJOR="1.16"
 
 shopt -u extglob
 
 # use the go installed using go get
-rm -rf /usr/local/go /usr/bin/go
-ln -s ${GOPATH}/go1.16/bin/go /usr/bin/go
-
-# go-licenses doesnt have any release tags, using the latest master
-GO111MODULE=on go get github.com/google/go-licenses@v0.0.0-20210816172045-3099c18c36e1
+rm -rf /usr/local/go /usr/bin/go /usr/bin/gofmt
+ln -s ${GOPATH}/go${GOLANG_LATEST_MAJOR}/bin/go /usr/bin/go
+ln -s ${GOPATH}/go${GOLANG_LATEST_MAJOR}/bin/gofmt /usr/bin/gofmt
 
 # Install hugo for docs
 HUGOVERSION=0.85.0


### PR DESCRIPTION
Fixing the issue with removal of `gofmt` binary.
More cleanup to decrease image size.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
