### PR TITLE
Make Dockerfile name dynamic based on image target

### DIFF
--- a/eks-distro-base/Makefile
+++ b/eks-distro-base/Makefile
@@ -148,7 +148,7 @@ base-update:
 
 .PHONY: minimal-update-%
 minimal-update-%:
-	$(MAKE) update-$* IMAGE_NAME=eks-distro-minimal-$* DOCKERFILE=Dockerfile.minimal IMAGE_TARGET=$*
+	$(MAKE) update-$* IMAGE_NAME=eks-distro-minimal-$* DOCKERFILE=Dockerfile.minimal-$* IMAGE_TARGET=$*
 
 # Update tag files in and create PR against eks-distro-build-tooling and eks-distro repos
 .PHONY: create-pr-%


### PR DESCRIPTION
Since we have separate targets for each minimal image variant, the Dockerfile should be made dynamic based on the target.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
