### PR TITLE
builder-base: add openssl to support running helm without yum install

### DIFF
--- a/builder-base/install.sh
+++ b/builder-base/install.sh
@@ -99,7 +99,7 @@ yum install -y \
     jq \
     less \
     openssh-clients \
-	openssl \
+    openssl \
     procps-ng \
     python3-pip \
     rsync \


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Remove the need for: https://github.com/jaxesn/eks-anywhere-build-tooling/blob/main/projects/cilium/cilium/build/create_manifests.sh#L31

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
