### PR TITLE
Remove print statements from output except for error

### DIFF
--- a/release/pkg/clients.go
+++ b/release/pkg/clients.go
@@ -15,8 +15,6 @@
 package pkg
 
 import (
-	"fmt"
-
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ecrpublic"
@@ -25,8 +23,6 @@ import (
 
 // Function to create release clients for dev release
 func (r *ReleaseConfig) CreateDevReleaseClients() (*ecrpublic.ECRPublic, error) {
-	fmt.Println("Creating new dev release client for ECR public")
-
 	// IAD session for eks-d-build-prod-pdx
 	session, err := session.NewSession(&aws.Config{
 		Region: aws.String("us-east-1"),
@@ -36,7 +32,6 @@ func (r *ReleaseConfig) CreateDevReleaseClients() (*ecrpublic.ECRPublic, error) 
 	}
 
 	// Create release ECR Public client
-	fmt.Printf("Release container registry is: %s", r.ContainerImageRepository)
 	ecrPublicClient := ecrpublic.New(session)
 
 	return ecrPublicClient, nil
@@ -44,8 +39,6 @@ func (r *ReleaseConfig) CreateDevReleaseClients() (*ecrpublic.ECRPublic, error) 
 
 // Function to create clients for production release
 func (r *ReleaseConfig) CreateProdReleaseClients() (*ecrpublic.ECRPublic, error) {
-	fmt.Println("Creating new production release client for ECR public")
-
 	// Session for eks-d-artifact-prod-iad
 	session, err := session.NewSessionWithOptions(session.Options{
 		Config: aws.Config{
@@ -58,7 +51,6 @@ func (r *ReleaseConfig) CreateProdReleaseClients() (*ecrpublic.ECRPublic, error)
 	}
 
 	// Create release ECR Public client
-	fmt.Printf("Release container registry is: %s", r.ContainerImageRepository)
 	ecrPublicClient := ecrpublic.New(session)
 
 	return ecrPublicClient, nil

--- a/release/pkg/generate_spec.go
+++ b/release/pkg/generate_spec.go
@@ -15,7 +15,6 @@
 package pkg
 
 import (
-	"fmt"
 	"net/url"
 	"strings"
 	"time"
@@ -78,10 +77,6 @@ func (r *ReleaseConfig) UpdateReleaseStatus(release *distrov1alpha1.Release, com
 }
 
 func UpdateImageDigests(ecrPublicClient *ecrpublic.ECRPublic, r *ReleaseConfig, componentsTable map[string]*distrov1alpha1.Component) error {
-	fmt.Println("============================================================")
-	fmt.Println("                 Updating Image Digests                     ")
-	fmt.Println("============================================================")
-
 	for _, component := range componentsTable {
 		componentDer := *component
 		assets := componentDer.Assets
@@ -108,7 +103,6 @@ func UpdateImageDigests(ecrPublicClient *ecrpublic.ECRPublic, r *ReleaseConfig, 
 				imageDigest := describeImagesOutput.ImageDetails[0].ImageDigest
 
 				asset.Image.ImageDigest = *imageDigest
-				fmt.Printf("Image digest for %s - %s\n", asset.Image.URI, *imageDigest)
 			}
 		}
 	}


### PR DESCRIPTION
Prevents the print statements from getting piped into output file.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
