### PR TITLE
Add Helm charts for deploying binfmt Daemonset

### DIFF
--- a/helm-charts/scripts/install-toolchain.sh
+++ b/helm-charts/scripts/install-toolchain.sh
@@ -23,30 +23,42 @@ ARCH=$([[ $(uname -m) = "x86_64" ]] && echo 'amd64' || echo 'arm64')
 TMP_DIR="${BUILD_DIR}/tmp"
 mkdir -p "${TOOLS_DIR}"
 
-HELM_VERSION="v3.4.1"
-KUBECTL_VERSION=v1.19.6
-KIND_VERSION=v0.5.1
-RELEASE_BRANCH=1-19
-RELEASE=1
+HELM_VERSION=v3.7.1
+KUBECTL_VERSION=v1.20.7
+KIND_VERSION=v0.11.1
+RELEASE_BRANCH=1-20
+RELEASE=8
 
 ## Install kubectl
-curl -sSL "https://distro.eks.amazonaws.com/kubernetes-${RELEASE_BRANCH}/releases/${RELEASE}/artifacts/kubernetes/${KUBECTL_VERSION}/bin/linux/amd64/kubectl" -o "${TOOLS_DIR}/kubectl"
-chmod +x "${TOOLS_DIR}/kubectl"
+if ! command -v kubectl &> /dev/null; then
+    echo "kubectl could not be found. Downloading..."
+    curl -sSL "https://distro.eks.amazonaws.com/kubernetes-${RELEASE_BRANCH}/releases/${RELEASE}/artifacts/kubernetes/${KUBECTL_VERSION}/bin/linux/amd64/kubectl" -o "${TOOLS_DIR}/kubectl"
+    chmod +x "${TOOLS_DIR}/kubectl"
+fi
 
 ## Install kubeval
-mkdir -p "${TMP_DIR}/kubeval"
-curl -sSL https://github.com/instrumenta/kubeval/releases/latest/download/kubeval-${PLATFORM}-${ARCH}.tar.gz | tar xz -C "${TMP_DIR}/kubeval"
-mv "${TMP_DIR}/kubeval/kubeval" "${TOOLS_DIR}/kubeval"
+if ! command -v kubeval &> /dev/null; then
+    echo "kubeval could not be found. Downloading..."
+    mkdir -p "${TMP_DIR}/kubeval"
+    curl -sSL https://github.com/instrumenta/kubeval/releases/latest/download/kubeval-${PLATFORM}-${ARCH}.tar.gz | tar xz -C "${TMP_DIR}/kubeval"
+    mv "${TMP_DIR}/kubeval/kubeval" "${TOOLS_DIR}/kubeval"
+fi
 
 ## Install helm
-mkdir -p "${TMP_DIR}/helm"
-curl -sSL https://get.helm.sh/helm-${HELM_VERSION}-${PLATFORM}-${ARCH}.tar.gz | tar xz -C "${TMP_DIR}/helm"
-mv "${TMP_DIR}/helm/${PLATFORM}-${ARCH}/helm" "${TOOLS_DIR}/helm"
-rm -rf "${PLATFORM}-${ARCH}"
+if ! command -v helm &> /dev/null; then
+    echo "helm could not be found. Downloading..."
+    mkdir -p "${TMP_DIR}/helm"
+    curl -sSL https://get.helm.sh/helm-${HELM_VERSION}-${PLATFORM}-${ARCH}.tar.gz | tar xz -C "${TMP_DIR}/helm"
+    mv "${TMP_DIR}/helm/${PLATFORM}-${ARCH}/helm" "${TOOLS_DIR}/helm"
+    rm -rf "${PLATFORM}-${ARCH}"
+fi
 
 ## Install kind
-curl -sSL "https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-${PLATFORM}-${ARCH}" -o "${TOOLS_DIR}/kind"
-chmod +x "${TOOLS_DIR}/kind"
+if ! command -v kind &> /dev/null; then
+    echo "kind could not be found. Downloading..."
+    curl -sSL "https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-${PLATFORM}-${ARCH}" -o "${TOOLS_DIR}/kind"
+    chmod +x "${TOOLS_DIR}/kind"
+fi
 
 rm -rf ${TMP_DIR}
 

--- a/helm-charts/scripts/verify-version.sh
+++ b/helm-charts/scripts/verify-version.sh
@@ -28,29 +28,40 @@ git fetch $REMOTE_URL $PREV_RELEASE_HASH
 EXIT_CODE=0
 
 cd $CHARTS_DIR
-for d in */; do
-  if git diff-index ${PREV_RELEASE_HASH} --quiet -- $d/templates $d/values.yaml --; then
-    echo "✅ $d has no changes since last release"
+for chart in *; do
+  DIFF_CHECK_TARGETS="$chart/templates $chart/values.yaml"
+  if [ $chart = "amazon-eks-pod-identity-webhook" ]; then
+    DIFF_CHECK_TARGETS="$chart/config $DIFF_CHECK_TARGETS"
+  fi
+  CHART_EXISTED=$(git ls-tree -r ${PREV_RELEASE_HASH} --name-only | grep -c ${chart}/Chart.yaml || true)
+  if [ $CHART_EXISTED -eq 0 ]; then
+    echo "✅ This is the first release of chart $chart, nothing to compare"
+  elif git diff-index ${PREV_RELEASE_HASH} --quiet -- $DIFF_CHECK_TARGETS --; then
+    echo "✅ Chart $chart has no changes since last release"
   else
-    CURR_VERSION=$(grep "version:" $d/Chart.yaml | grep -Eo "[0-9]+\.[0-9]+\.[0-9]+")
-    PREV_VERSION=$(git show ${PREV_RELEASE_HASH}:helm-charts/stable/${d}Chart.yaml | grep "version:" | grep -Eo "[0-9]+\.[0-9]+\.[0-9]+")
+    CURR_VERSION=$(grep "version:" $chart/Chart.yaml | grep -Eo "[0-9]+\.[0-9]+\.[0-9]+")
+    PREV_VERSION=$(git show ${PREV_RELEASE_HASH}:helm-charts/stable/${chart}/Chart.yaml | grep "version:" | grep -Eo "[0-9]+\.[0-9]+\.[0-9]+")
     TEMPLATES_CHANGED=false
     if [ "${CURR_VERSION}" = "${PREV_VERSION}" ]; then
-      for file in $d/templates/* $d/values.yaml; do
-        CHANGED_LINES=$(git show -U0 $file | grep '^[+-]' | grep -Ev '^(--- a/|\+\+\+ b/|\+#|-#)' || true)
+      FILES_TO_CHECK="$chart/templates/* $chart/values.yaml"
+      if [ $chart = "amazon-eks-pod-identity-webhook" ]; then
+        FILES_TO_CHECK="$chart/config/* $FILES_TO_CHECK"
+      fi
+      for file in $FILES_TO_CHECK; do
+        CHANGED_LINES=$(git show -U0 $file | grep '^[+-]' | grep -Ev '^(--- a/|\+\+\+ b/|\+#|-#|\+$)' || true)
         if [ "$CHANGED_LINES" != "" ]; then
           TEMPLATES_CHANGED=true
           break
         fi
       done
       if [ "$TEMPLATES_CHANGED" = "true" ]; then
-        echo "❌ $d has the same Chart version as the last release $PREV_VERSION, but templates have been modified"
+        echo "❌ Chart $chart has the same Chart version as the last release $PREV_VERSION, but templates have been modified"
         EXIT_CODE=1
       else
-        echo "✅ $d has the same Chart version as the last release $PREV_VERSION and templates have not been modified"
+        echo "✅ Chart $chart has the same Chart version as the last release $PREV_VERSION and templates have not been modified"
       fi
     else 
-      echo "✅ $d has a different version since the last release ($PREV_VERSION -> $CURR_VERSION)"
+      echo "✅ Chart $chart has a different Chart version since the last release ($PREV_VERSION -> $CURR_VERSION)"
     fi
   fi
 done

--- a/helm-charts/stable/binfmt/.helmignore
+++ b/helm-charts/stable/binfmt/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/helm-charts/stable/binfmt/Chart.yaml
+++ b/helm-charts/stable/binfmt/Chart.yaml
@@ -1,0 +1,37 @@
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v2
+name: binfmt
+description: Helm chart for cross-platform emulator support through binfmt
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 1.0.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+appVersion: 1.0.0

--- a/helm-charts/stable/binfmt/README.md
+++ b/helm-charts/stable/binfmt/README.md
@@ -1,0 +1,1 @@
+## Helm chart for Binfmt (Cross-platform emulator collection)

--- a/helm-charts/stable/binfmt/templates/binfmt-DaemonSet.yaml
+++ b/helm-charts/stable/binfmt/templates/binfmt-DaemonSet.yaml
@@ -1,0 +1,52 @@
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: binfmt
+  labels:
+    app: binfmt
+spec:
+  selector:
+    matchLabels:
+      app: binfmt
+  template:
+    metadata:
+      labels:
+        app: binfmt
+    spec:
+      initContainers:
+      - name: binfmt-installer
+        securityContext:
+          privileged: true
+        imagePullPolicy: Always
+        image: {{ .Values.images.binfmtInstallerImage }}
+        args:
+        - --install
+        - {{ .Values.formats }}
+      containers:
+      - name: binfmt-idle
+        image: {{ .Values.images.binfmtIdleImage }}
+        command:
+        - bash
+        - -c
+        - sleep 10000
+        resources:
+          requests:
+            cpu: "1"
+            memory: "4Gi"
+          limits:
+            cpu: "1"
+            memory: "4Gi"

--- a/helm-charts/stable/binfmt/values.yaml
+++ b/helm-charts/stable/binfmt/values.yaml
@@ -1,0 +1,19 @@
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+images:
+  binfmtInstallerImage: public.ecr.aws/eks-distro-build-tooling/binfmt-misc:qemu-v6.1.0
+  binfmtIdleImage: public.ecr.aws/eks-distro-build-tooling/eks-distro-base:latest
+
+formats: "aarch64"


### PR DESCRIPTION
Adding helm charts for deploying the `binfmt` container on clusters to enable QEMU emulation.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
