### PR TITLE
Install openssl devel for OpenSSL lib headers

### DIFF
--- a/builder-base/install.sh
+++ b/builder-base/install.sh
@@ -111,6 +111,7 @@ yum install -y \
     libassuan-devel \
     openssh-clients \
     openssl \
+    openssl-devel \
     pkgconfig \
     procps-ng \
     python3-pip \


### PR DESCRIPTION
Install openssl devel package for Tuftool build.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
