### PR TITLE
attribution: improve prefix matching of modules

### DIFF
--- a/generate-attribution/generate-attribution-file.js
+++ b/generate-attribution/generate-attribution-file.js
@@ -327,12 +327,20 @@ async function populateVersionAndModuleFromDep(dependencies) {
         });
 
         if (!found) {
+            let match;
             goListDeps.forEach((goListDep) => {
+                // these matches were found by the prefix match above
+                // find the longest prefix and use that as our module
                 if (isModuleMatch(dep, goListDep, true)) {
-                    handleFound(dep, goListDep, found);
-                    found = true;
+                    if (!match || goListDep.Module.Path.length > match.Module.Path.length) {
+                        match = goListDep;
+                    }                
                 }
             });
+            if (match) {
+                handleFound(dep, match, found);
+                found = true;
+            }
         }
 
         if (!found) {
@@ -347,6 +355,10 @@ async function populateVersionAndModuleFromDep(dependencies) {
 }
 
 async function generateAuthorizationHeader() {
+    if (process.env.GITHUB_TOKEN) {
+        return { headers: { 'Authorization': 'token ' + process.env.GITHUB_TOKEN } };
+    }
+
     const githubTokenFile = "/secrets/github-secrets/token";
     try {
         await fsPromises.access(githubTokenFile);


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

When a module is not found by a string match, a second search is done looking for matches based on prefix.  For ex, 
`k8s.io/apimachinery/third_party/forked/golang` is in the licenses.csv file but does not support up directly in the go-deps.json file.  Instead it gets matched against `k8s.io/apimachinery/third_party/forked/golang/reflect`, which is fine.  What was happening before is it would also match against `k8s.io/api`.  This adds a check to only match the one that has the longest prefix.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
