### PR TITLE
Add affinity spec to Helm chart values and templates

### DIFF
--- a/helm-charts/stable/amazon-eks-pod-identity-webhook/Chart.yaml
+++ b/helm-charts/stable/amazon-eks-pod-identity-webhook/Chart.yaml
@@ -29,7 +29,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.7
+version: 1.0.8
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm-charts/stable/amazon-eks-pod-identity-webhook/templates/Deployment.yaml
+++ b/helm-charts/stable/amazon-eks-pod-identity-webhook/templates/Deployment.yaml
@@ -63,3 +63,7 @@ spec:
       volumes:
       - name: webhook-certs
         emptyDir: {}
+    {{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }} 

--- a/helm-charts/stable/amazon-eks-pod-identity-webhook/templates/install-CronJob.yaml
+++ b/helm-charts/stable/amazon-eks-pod-identity-webhook/templates/install-CronJob.yaml
@@ -47,3 +47,7 @@ spec:
             configMap:
               name: {{ .Values.installJobName }}-configmap
           restartPolicy: OnFailure
+        {{- with .Values.affinity }}
+          affinity:
+{{ toYaml . | indent 12 }}
+        {{- end }}

--- a/helm-charts/stable/amazon-eks-pod-identity-webhook/templates/install-Job.yaml
+++ b/helm-charts/stable/amazon-eks-pod-identity-webhook/templates/install-Job.yaml
@@ -56,3 +56,7 @@ spec:
         configMap:
           name: {{ .Values.installJobName }}-configmap
       restartPolicy: OnFailure
+    {{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}

--- a/helm-charts/stable/amazon-eks-pod-identity-webhook/templates/uninstall-Job.yaml
+++ b/helm-charts/stable/amazon-eks-pod-identity-webhook/templates/uninstall-Job.yaml
@@ -47,3 +47,7 @@ spec:
         configMap:
           name: {{ .Values.uninstallJobName }}-configmap
       restartPolicy: OnFailure
+    {{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}

--- a/helm-charts/stable/amazon-eks-pod-identity-webhook/values.yaml
+++ b/helm-charts/stable/amazon-eks-pod-identity-webhook/values.yaml
@@ -41,3 +41,5 @@ service:
   port: 443
 
 replicaCount: 1
+
+affinity: {}


### PR DESCRIPTION
This is to help us constrain what nodes these pods get deployed on.

**Note:** I chose to use `nodeAffinity` instead of `nodeSelector` since the former is a superclass of and provides a more expressive way to schedule nodes than the latter, and at some point, `nodeSelector` will be deprecated (although not until K8s launches v2 API).


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
