### PR TITLE
Add eks-anywhere repo to base image tag update workflow

### DIFF
--- a/eks-distro-base/Makefile
+++ b/eks-distro-base/Makefile
@@ -179,6 +179,7 @@ endif
 .PHONY: create-pr
 create-pr: $(CREATE_PR_TARGETS)
 	$(MAKE_ROOT)/../pr-scripts/create_pr.sh eks-distro 'EKS_DISTRO*_TAG_FILE'
+	$(MAKE_ROOT)/../pr-scripts/create_pr.sh eks-anywhere 'EKS_DISTRO*_TAG_FILE'
 	$(MAKE_ROOT)/../pr-scripts/create_pr.sh eks-anywhere-build-tooling 'EKS_DISTRO*_TAG_FILE'
 	$(MAKE_ROOT)/../pr-scripts/create_pr.sh eks-distro-build-tooling 'EKS_DISTRO*_TAG_FILE' 'eks-distro-base-minimal-packages/.'
 

--- a/eks-distro-base/update_base_image.sh
+++ b/eks-distro-base/update_base_image.sh
@@ -32,3 +32,6 @@ ${SCRIPT_ROOT}/../pr-scripts/update_image_tag.sh eks-distro '.*' $IMAGE_TAG $BAS
 
 ${SCRIPT_ROOT}/../pr-scripts/update_local_branch.sh eks-anywhere-build-tooling
 ${SCRIPT_ROOT}/../pr-scripts/update_image_tag.sh eks-anywhere-build-tooling '.*' $IMAGE_TAG $BASE_IMAGE_TAG_FILE
+
+${SCRIPT_ROOT}/../pr-scripts/update_local_branch.sh eks-anywhere
+${SCRIPT_ROOT}/../pr-scripts/update_image_tag.sh eks-anywhere '.*' $IMAGE_TAG $BASE_IMAGE_TAG_FILE


### PR DESCRIPTION
The EKS Anywhere cluster controller image uses the minimal eks-d base as the base image, so that tag file needs to be update accordingly when a new image is pushed.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
