### PR TITLE
Fix PR creation parameters for eks-anywhere repo

### DIFF
--- a/pr-scripts/create_pr.sh
+++ b/pr-scripts/create_pr.sh
@@ -29,9 +29,8 @@ fi
 
 SCRIPT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 
-if [[ $REPO =~ "build-tooling" ]] || [ $REPO = "eks-distro" ]; then
-    CHANGED_FILE="tag file(s)"
-elif [[ $REPO =~ "prow-jobs" ]]; then
+CHANGED_FILE="tag file(s)"
+if [[ $REPO =~ "prow-jobs" ]]; then
     CHANGED_FILE="Prowjobs"
 fi
 
@@ -47,7 +46,9 @@ if [[ $REPO =~ "prow-jobs" ]]; then
 fi
 
 PR_TITLE="Update base image tag in ${CHANGED_FILE}"
-if [[ $REPO =~ "build-tooling" ]] || [ $REPO = "eks-distro" ]; then
+if [[ $REPO =~ "prow-jobs" ]]; then
+    PR_BODY=$(cat ${SCRIPT_ROOT}/../pr-scripts/builder_base_pr_body)
+else
     $SED -i "s,in .* with,in ${CHANGED_FILE} with," ${SCRIPT_ROOT}/../pr-scripts/eks_distro_base_pr_body
     cp ${SCRIPT_ROOT}/../pr-scripts/eks_distro_base_pr_body ${SCRIPT_ROOT}/../pr-scripts/${REPO}_pr_body
     
@@ -66,8 +67,6 @@ if [[ $REPO =~ "build-tooling" ]] || [ $REPO = "eks-distro" ]; then
 
     PR_BODY=$(cat ${SCRIPT_ROOT}/../pr-scripts/${REPO}_pr_body)
     rm ${SCRIPT_ROOT}/../pr-scripts/${REPO}_pr_body
-else
-    PR_BODY=$(cat ${SCRIPT_ROOT}/../pr-scripts/builder_base_pr_body)
 fi
 PR_BRANCH="image-tag-update"
 


### PR DESCRIPTION
This is to set the proper title and body in the PR created to bump image tag in eks-anywhere repo.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
