### PR TITLE
Add override plugin, remove needs-rebase plugin

### DIFF
--- a/helm-charts/stable/prow-control-plane/Chart.yaml
+++ b/helm-charts/stable/prow-control-plane/Chart.yaml
@@ -29,7 +29,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.11
+version: 1.0.12
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm-charts/stable/prow-control-plane/templates/plugins-ConfigMap.yaml
+++ b/helm-charts/stable/prow-control-plane/templates/plugins-ConfigMap.yaml
@@ -36,7 +36,7 @@ data:
       - lgtm
       - lifecycle
       - milestone
-      - needs-rebase
+      - override
       - size
       - trigger
       - verify-owners


### PR DESCRIPTION
The `override` plugins allows PR authors to force job statuses on Github to pass. This is especially useful when adding new blocking presubmits (for example, adding presubmit for a new project) which causes the status reconciler to run the job on all open PRs and fail citing the path references by the job doesn't exist ([example](https://github.com/aws/eks-anywhere-build-tooling/pull/228)).

The `needs-rebase` plugin is an external plugin whose events are not handled by Prow's hook component but through an external endpoint that has been configured to handle GitHub webhooks. We don't have support for it at this point, so removing it.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
