### PR TITLE
Add exec permissions to yq binary

### DIFF
--- a/builder-base/install.sh
+++ b/builder-base/install.sh
@@ -136,6 +136,7 @@ wget \
     $YQ_DOWNLOAD_URL
 sha256sum -c $BASE_DIR/yq-$TARGETARCH-checksum
 mv yq_linux_$TARGETARCH $USR_BIN/yq
+chmod +x $USR_BIN/yq
 
 # Bash 4.3 is required to run kubernetes make test
 wget $BASH_DOWNLOAD_URL


### PR DESCRIPTION
YQ download was refactored to download the binary directly from the releases instead of from the tarball and unpacking it. Turns out the binary inside the tarball has exec perms on it,  but the standalone binary from release does not.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
