### PR TITLE
builder-base: use go 1.15 from al2 yum repo

### DIFF
--- a/builder-base/Makefile
+++ b/builder-base/Makefile
@@ -12,7 +12,7 @@ IMAGE?=$(IMAGE_REPO)/$(IMAGE_NAME):$(IMAGE_TAG)
 LATEST_IMAGE=$(IMAGE_REPO)/$(IMAGE_NAME):latest
 
 BUILDKIT_OUTPUT=type=image,oci-mediatypes=true,\"name=$(IMAGE),$(LATEST_IMAGE)\",push=true
-BUILDKIT_PLATFORMS=linux/amd64,linux/arm64
+BUILDKIT_PLATFORMS?=linux/amd64,linux/arm64
 
 MAKE_ROOT=$(shell cd "$(shell dirname "${BASH_SOURCE[0]}")" && pwd -P)
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
AL2 provides golang 1.15 from, use it instead of pulling from upstream.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
