### PR TITLE
Mount kubeconfig on crier pods for dataplane cluster communication

### DIFF
--- a/helm-charts/stable/prow-control-plane/Chart.yaml
+++ b/helm-charts/stable/prow-control-plane/Chart.yaml
@@ -29,7 +29,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.12
+version: 1.0.13
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm-charts/stable/prow-control-plane/templates/crier-Deployment.yaml
+++ b/helm-charts/stable/prow-control-plane/templates/crier-Deployment.yaml
@@ -56,6 +56,7 @@ spec:
         - --github-token-path=/etc/github/token
         - --github-workers=10
         - --kubernetes-blob-storage-workers=10
+        - --kubeconfig=/etc/kubeconfig/config
         volumeMounts:
         - name: config
           mountPath: /etc/config
@@ -69,6 +70,24 @@ spec:
         - name: s3-credentials
           mountPath: /etc/s3-credentials
           readOnly: true
+        - name: kubeconfig
+          mountPath: /etc/kubeconfig
+          readOnly: true
+        - name: shared-bins
+          mountPath: /shared-bins
+      initContainers:
+      - name: aws-iam-authenticator
+        env:
+        - name: AWS_STS_REGIONAL_ENDPOINTS
+          value: regional
+        image: {{ .Values.awsIamAuthenticator.image }}
+        command:
+        - cp
+        - /aws-iam-authenticator
+        - /shared-bins/aws-iam-authenticator
+        volumeMounts:
+        - name: shared-bins
+          mountPath: /shared-bins
       volumes:
       - name: config
         configMap:
@@ -82,3 +101,9 @@ spec:
       - name: s3-credentials
         secret:
           secretName: s3-credentials
+      - name: shared-bins
+        emptyDir: {}
+      - name: kubeconfig
+        secret:
+          defaultMode: 0644
+          secretName: kubeconfig


### PR DESCRIPTION
Crier pods need the kubeconfig mounted on them to facilitate communication with the presubmit and postsubmit clusters to get the pod info.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
