### PR TITLE
distro-base: add al2022 build option to use new al2022 as the base image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+
+.PHONY: run-buildkit-and-registry
+run-buildkit-and-registry:
+	docker run -d --name buildkitd --net host --privileged moby/buildkit:v0.9.3-rootless
+	docker run -d --name registry  --net host registry:2
+
+.PHONY: stop-buildkit-and-registry
+stop-buildkit-and-registry:
+	docker rm -v --force buildkitd
+	docker rm -v --force registry

--- a/eks-distro-base/Dockerfile.minimal-base-docker-client
+++ b/eks-distro-base/Dockerfile.minimal-base-docker-client
@@ -21,15 +21,31 @@
 # is no overlay fs and we will run out of space quickly
 
 ################# BUILDER ######################
+
+#### Sketch alert ####
+# We are pulling docker/container from al2 since it is not currently provided by al2022
+# when al2022 adds these as packages we would want to switch asap
+# Looking at the dependencies to the docker and containerd binaries, its really just libc
+# From looking at upstream docs using a binary built against an older libc with a newer libc, which
+# is what we would be doing here, *should* be ok
+######################
 ARG BASE_IMAGE
 ARG BUILDER_IMAGE
+ARG AL2_IMAGE
+FROM ${AL2_IMAGE} as al2
+RUN amazon-linux-extras enable docker
+
+
 FROM ${BUILDER_IMAGE} as base-docker-client-builder
+
+COPY --from=al2 /etc/pki/rpm-gpg/RPM-GPG-KEY-amazon-linux-2 /etc/pki/rpm-gpg
+COPY --from=al2 /etc/yum.repos.d/amzn2-extras.repo /etc/yum.repos.d
 
 RUN set -x && \
     # we only want the docker client cli and not the service
     # installing the package one off since the only deps of the client
     # are already provided by glibc
-    amazon-linux-extras enable docker && \
+    enable_docker_install && \
     # has to be extracted instead of installed to work around scriptlet
     # issue that only affects the service component which we arent using
     clean_install docker true true true && \

--- a/eks-distro-base/Dockerfile.minimal-base-git
+++ b/eks-distro-base/Dockerfile.minimal-base-git
@@ -28,7 +28,7 @@ ARG TARGETARCH
 ENV CMAKE_VERSION=3.20.2
 ENV LIBSSH2_VERSION=1.10.0
 ENV LIBGIT2_VERSION=1.1.1
-ENV BUILD_DEPS="gcc gzip install make openssl-devel openssl-libs tar wget"
+ENV BUILD_DEPS="gcc gzip make openssl-devel openssl-libs tar wget"
 
 COPY "${TARGETARCH}-git-checksums" /tmp/checksums
 

--- a/eks-distro-base/Dockerfile.minimal-base-haproxy
+++ b/eks-distro-base/Dockerfile.minimal-base-haproxy
@@ -45,10 +45,12 @@ RUN set -x && \
     clean_yum && \
     rm -rf haproxy-$HAPROXY_VERSION haproxy-$HAPROXY_VERSION.tar.gz
 
-ENV HAPROXY_DEPS="bash libcrypt openssl-libs zlib"
+ENV HAPROXY_DEPS="bash openssl-libs zlib"
 RUN set -x && \
     # manually "install" systemd to avoid installing the entire dep tree
     clean_install systemd true true && \
+    install_if_al2 libcrypt && \
+    install_if_al2022 libxcrypt-compat && \
     # libacl is needed for cp + mkdir
     clean_install "libacl $HAPROXY_DEPS" && \
     # remove unncessary utils and other binary deps that are not needed by nginx during runtime

--- a/eks-distro-base/Dockerfile.minimal-base-iptables
+++ b/eks-distro-base/Dockerfile.minimal-base-iptables
@@ -30,7 +30,10 @@ RUN set -x && \
     clean_install systemd true true && \
     # following are from coreutils needed by install scriptlets
     for cmd in "readlink" "rm"; do cp /usr/bin/$cmd $NEWROOT/usr/bin/; done && \
-    clean_install "conntrack-tools ebtables ipset iptables iptables-nft kmod" && \
+    clean_install "ebtables ipset iptables iptables-nft kmod" && \
+    # al2022 does not have this package yet.  it may not actually be needed but is included in upstrea
+    # kube-proxy base image
+    install_if_al2 conntrack-tools && \
     for cmd in "readlink" "rm"; do rm $NEWROOT/usr/bin/$cmd; done && \
     # remove bash + systemd and deps
     remove_package systemd true && \

--- a/eks-distro-base/Dockerfile.minimal-base-kind
+++ b/eks-distro-base/Dockerfile.minimal-base-kind
@@ -20,10 +20,25 @@
 # *NOTE* we have to limit our number of layers heres because in presubmits there
 # is no overlay fs and we will run out of space quickly
 
-################# BUILDER ######################
+#### Sketch alert ####
+# We are pulling docker/container from al2 since it is not currently provided by al2022
+# when al2022 adds these as packages we would want to switch asap
+# Looking at the dependencies to the docker and containerd binaries, its really just libc
+# From looking at upstream docs using a binary built against an older libc with a newer libc, which
+# is what we would be doing here, *should* be ok
+######################
+ARG AL2_IMAGE
 ARG BASE_IMAGE
 ARG BUILDER_IMAGE
+FROM ${AL2_IMAGE} as al2
+RUN amazon-linux-extras enable docker
+
+
+################# BUILDER ######################
 FROM ${BUILDER_IMAGE} as base-kind-builder
+
+COPY --from=al2 /etc/pki/rpm-gpg/RPM-GPG-KEY-amazon-linux-2 /etc/pki/rpm-gpg
+COPY --from=al2 /etc/yum.repos.d/amzn2-extras.repo /etc/yum.repos.d
 
 # This build is meant to include the deps from the kind base image defined in the upstream
 # dockerfile, plus the changes from the patching we do in eks-anywhere-build-tooling
@@ -31,13 +46,13 @@ FROM ${BUILDER_IMAGE} as base-kind-builder
 # will contain yum and the eks-anwyhere build can instal additional packages as neccessary
 # the intent is for the yum installs downstream are no-ops
 RUN set -x && \
-    amazon-linux-extras enable docker && \
-    cp /etc/yum.repos.d/amzn2-extras.repo /newroot/etc/yum.repos.d/amzn2-extras.repo && \
+    enable_docker_install && \
     # some of the install scriptlets need coreutils but the dep ordering
     # doesnt reflect, install manually to make sure its first
     clean_install coreutils && \
     clean_install findutils && \
-    clean_install "amazon-linux-extras containerd curl ethtool hostname iproute nfs-utils pigz procps rsync seccomp2 socat systemd tar udev util-linux which yum" && \
+    install_if_al2 amazon-linux-extras && \    
+    clean_install "containerd curl ethtool hostname iproute nfs-utils pigz procps rsync libseccomp socat systemd tar udev util-linux which yum" && \
     cleanup "kind"
 
 

--- a/eks-distro-base/Dockerfile.minimal-base-nginx
+++ b/eks-distro-base/Dockerfile.minimal-base-nginx
@@ -28,8 +28,8 @@ FROM ${BUILDER_IMAGE} as base-nginx-builder
 # This image will include bash because the downstream eks-anywhere-test image needs it
 # for its entrypoint
 RUN set -x && \
-    amazon-linux-extras enable nginx1 && \
-    cp /etc/yum.repos.d/amzn2-extras.repo /newroot/etc/yum.repos.d/amzn2-extras.repo && \
+    if command -v amazon-linux-extras &> /dev/null; then amazon-linux-extras enable nginx1; fi && \
+    if [ -f /etc/yum.repos.d/amzn2-extras.repo ]; then cp /etc/yum.repos.d/amzn2-extras.repo /newroot/etc/yum.repos.d/amzn2-extras.repo; fi && \
     # manually "install" systemd to avoid installing the entire dep tree
     clean_install systemd true true && \
     clean_install "nginx" && \

--- a/eks-distro-base/Makefile
+++ b/eks-distro-base/Makefile
@@ -8,7 +8,8 @@ BASE_IMAGE_REPO?=$(IMAGE_REPO)
 IMAGE_NAME?=eks-distro-$(VARIANT)
 IMAGE_TAG?=$(shell date "+%F-%s")
 IMAGE?=$(IMAGE_REPO)/$(IMAGE_NAME):$(IMAGE_TAG)
-LATEST_IMAGE?=$(IMAGE_REPO)/$(IMAGE_NAME):latest
+LATEST?=latest
+LATEST_IMAGE?=$(IMAGE_REPO)/$(IMAGE_NAME):$(LATEST)
 
 VARIANT?=base
 IMAGE_TARGET?=base
@@ -30,23 +31,29 @@ BASE_IMAGE_TAG?=$(IMAGE_TAG)
 BUILDKIT_OUTPUT=type=image,oci-mediatypes=true,\"name=$(IMAGE),$(LATEST_IMAGE)\",push=true
 
 # base and minimal-base use al2 as the base image
-BASE_IMAGE=public.ecr.aws/amazonlinux/amazonlinux:2
-BUILDER_IMAGE=public.ecr.aws/amazonlinux/amazonlinux:2
+AL_TAG?=2
+BASE_IMAGE=public.ecr.aws/amazonlinux/amazonlinux:$(AL_TAG)
+BUILDER_IMAGE=public.ecr.aws/amazonlinux/amazonlinux:$(AL_TAG)
+AL2_IMAGE=public.ecr.aws/amazonlinux/amazonlinux:2
 
 ifeq ($(VARIANT),$(filter $(VARIANT), minimal-base-nonroot minimal-base-glibc))
 	BASE_IMAGE_NAME=eks-distro-minimal-base
 	BUILDER_IMAGE_NAME=eks-distro-minimal-base-builder
 	BASE_IMAGE_TAG=$(shell cat $(MAKE_ROOT)/../EKS_DISTRO_MINIMAL_BASE_TAG_FILE)
+	BASE_DEP_TARGET=minimal-images-base
 else ifeq ($(VARIANT),$(filter $(VARIANT), minimal-base-iptables minimal-base-csi minimal-base-git minimal-base-docker-client minimal-base-nginx minimal-base-haproxy))
 	BASE_IMAGE_NAME=eks-distro-minimal-base-glibc
 	BUILDER_IMAGE_NAME=eks-distro-minimal-base-glibc-builder
 	BASE_IMAGE_TAG=$(shell cat $(MAKE_ROOT)/../EKS_DISTRO_MINIMAL_BASE_GLIBC_TAG_FILE)
+	BASE_DEP_TARGET=minimal-images-base-glibc
 else ifeq ($(VARIANT),$(filter $(VARIANT), minimal-base-kind))
 	BASE_IMAGE_NAME=eks-distro-minimal-base-iptables
 	BUILDER_IMAGE_NAME=eks-distro-minimal-base-iptables-builder
 	BASE_IMAGE_TAG=$(shell cat $(MAKE_ROOT)/../EKS_DISTRO_MINIMAL_BASE_IPTABLES_TAG_FILE)
+	BASE_DEP_TARGET=minimal-images-base-iptables
 else ifeq ($(VARIANT), minimal-base)
 	BASE_IMAGE=scratch
+	BASE_DEP_TARGET=
 endif
 
 # if the image was built, either via this being a pre/post submit job
@@ -81,7 +88,7 @@ buildkit-check:
 # in prow we run a docker registry as a sidecar
 # see the README.md on how to run these targets locally
 .PHONY: images-%
-images-%: buildkit-check
+images-%: buildkit-check $(BASE_DEP_TARGET)
 	if [ "$(JOB_TYPE)" = "presubmit" ] || [ "$(JOB_TYPE)" = "postsubmit" ]; then \
 		./check_update.sh $(IMAGE_NAME) ; \
 	fi
@@ -92,6 +99,7 @@ images-%: buildkit-check
 		--opt platform=$(PLATFORMS) \
 		--opt build-arg:BASE_IMAGE=$(BASE_IMAGE) \
 		--opt build-arg:BUILDER_IMAGE=$(BUILDER_IMAGE) \
+		--opt build-arg:AL2_IMAGE=$(AL2_IMAGE) \
 		--progress plain \
 		--local dockerfile=./ \
 		--local context=. \
@@ -112,7 +120,7 @@ minimal-images-%:
 export-minimal-images-%:
 	if [ "$(JOB_TYPE)" = "postsubmit" ] || \
 		[ "$(shell cat $(MAKE_ROOT)/eks-distro-minimal-$*-pushed)" = "true" ]; then \
-		$(MAKE) images-minimal-$* VARIANT=minimal-$* IMAGE_TARGET=$*-export PLATFORMS=$(PLATFORMS) BUILDKIT_OUTPUT="type=local,dest=$(MAKE_ROOT)/../eks-distro-base-minimal-packages"; \
+		$(MAKE) images-minimal-$* VARIANT=minimal-$* IMAGE_TARGET=$*-export PLATFORMS=$(PLATFORMS) BUILDKIT_OUTPUT="type=local,dest=$(MAKE_ROOT)/../eks-distro-base-minimal-packages/$(AL_TAG)"; \
 	fi
 
 .PHONY: export-minimal-images
@@ -207,7 +215,7 @@ minimal-images-base-iptables: ## Build and push minimal base image with iptables
 minimal-images-base-csi: ## Build and push minimal base image with common packages needed for csi drivers
 minimal-images-base-git: ## Build and push minimal base image with git + libgit
 minimal-images-base-docker-client: ## Build and push minimal base image with docker client
-minimal-images-base-nginx: ## Build and push minimal base image with nginx for use by eks-anywhere-test
+# minimal-images-base-nginx: ## Build and push minimal base image with nginx for use by eks-anywhere-test
 minimal-images-base-haproxy: ## Build and push minimal base image with haproxy for use by the kind haproxy image
 minimal-images-base-kind: ## Build and push minimal base image with containerd and other deps for the kind base image
 

--- a/eks-distro-base/Makefile
+++ b/eks-distro-base/Makefile
@@ -40,20 +40,16 @@ ifeq ($(VARIANT),$(filter $(VARIANT), minimal-base-nonroot minimal-base-glibc))
 	BASE_IMAGE_NAME=eks-distro-minimal-base
 	BUILDER_IMAGE_NAME=eks-distro-minimal-base-builder
 	BASE_IMAGE_TAG=$(shell cat $(MAKE_ROOT)/../EKS_DISTRO_MINIMAL_BASE_TAG_FILE)
-	BASE_DEP_TARGET=minimal-images-base
 else ifeq ($(VARIANT),$(filter $(VARIANT), minimal-base-iptables minimal-base-csi minimal-base-git minimal-base-docker-client minimal-base-nginx minimal-base-haproxy))
 	BASE_IMAGE_NAME=eks-distro-minimal-base-glibc
 	BUILDER_IMAGE_NAME=eks-distro-minimal-base-glibc-builder
 	BASE_IMAGE_TAG=$(shell cat $(MAKE_ROOT)/../EKS_DISTRO_MINIMAL_BASE_GLIBC_TAG_FILE)
-	BASE_DEP_TARGET=minimal-images-base-glibc
 else ifeq ($(VARIANT),$(filter $(VARIANT), minimal-base-kind))
 	BASE_IMAGE_NAME=eks-distro-minimal-base-iptables
 	BUILDER_IMAGE_NAME=eks-distro-minimal-base-iptables-builder
 	BASE_IMAGE_TAG=$(shell cat $(MAKE_ROOT)/../EKS_DISTRO_MINIMAL_BASE_IPTABLES_TAG_FILE)
-	BASE_DEP_TARGET=minimal-images-base-iptables
 else ifeq ($(VARIANT), minimal-base)
 	BASE_IMAGE=scratch
-	BASE_DEP_TARGET=
 endif
 
 # if the image was built, either via this being a pre/post submit job
@@ -88,7 +84,7 @@ buildkit-check:
 # in prow we run a docker registry as a sidecar
 # see the README.md on how to run these targets locally
 .PHONY: images-%
-images-%: buildkit-check $(BASE_DEP_TARGET)
+images-%: buildkit-check
 	if [ "$(JOB_TYPE)" = "presubmit" ] || [ "$(JOB_TYPE)" = "postsubmit" ]; then \
 		./check_update.sh $(IMAGE_NAME) ; \
 	fi
@@ -215,7 +211,7 @@ minimal-images-base-iptables: ## Build and push minimal base image with iptables
 minimal-images-base-csi: ## Build and push minimal base image with common packages needed for csi drivers
 minimal-images-base-git: ## Build and push minimal base image with git + libgit
 minimal-images-base-docker-client: ## Build and push minimal base image with docker client
-# minimal-images-base-nginx: ## Build and push minimal base image with nginx for use by eks-anywhere-test
+minimal-images-base-nginx: ## Build and push minimal base image with nginx for use by eks-anywhere-test
 minimal-images-base-haproxy: ## Build and push minimal base image with haproxy for use by the kind haproxy image
 minimal-images-base-kind: ## Build and push minimal base image with containerd and other deps for the kind base image
 

--- a/eks-distro-base/scripts/enable_docker_install
+++ b/eks-distro-base/scripts/enable_docker_install
@@ -18,30 +18,10 @@ set -e
 set -o pipefail
 set -x
 
-PACKAGES=$1
-JUSTDB=${2:false}
+# for al2022 we are copying the repo conf from an al2 intermediate stage
+# some of the yum vars have changed so we need to modify the file some
+sed -i -e 's/$awsproto/http/g' /etc/yum.repos.d/amzn2-extras.repo
+sed -i -e 's/$amazonlinux/amazonlinux/g' /etc/yum.repos.d/amzn2-extras.repo 
+sed -i -e 's/$releasever/2/g' /etc/yum.repos.d/amzn2-extras.repo 
 
-if [ $JUSTDB ]; then
-    JUSTDB="--justdb"
-else
-    JUSTDB=""
-fi
-
-RPMS=(${PACKAGES// / })
-FINAL_RPMS=""
-for rpm in "${RPMS[@]}"; do
-    if rpm --root $NEWROOT -q --quiet $rpm ; then
-        FINAL_RPMS+="$rpm "
-    fi
-done
-rpm --root $NEWROOT --nodeps $JUSTDB -e FINAL_RPMS
-clean_yum
-
-# autoremove does not always look at the full dep tree and sometimes needs to
-# be run multiple times to get everything that can safely be removed
-while ! yum --installroot $NEWROOT autoremove -y | tee /dev/stderr | grep -q 'No Packages marked for removal\|Nothing to do.'
-do
-    :
-done
-
-clean_yum
+cp /etc/yum.repos.d/amzn2-extras.repo /newroot/etc/yum.repos.d/amzn2-extras.repo

--- a/eks-distro-base/scripts/install_if_al2
+++ b/eks-distro-base/scripts/install_if_al2
@@ -18,30 +18,8 @@ set -e
 set -o pipefail
 set -x
 
-PACKAGES=$1
-JUSTDB=${2:false}
+PACKAGES="$1"
 
-if [ $JUSTDB ]; then
-    JUSTDB="--justdb"
-else
-    JUSTDB=""
+if ! grep -q "2022" "/etc/os-release"; then 
+    clean_install $PACKAGES
 fi
-
-RPMS=(${PACKAGES// / })
-FINAL_RPMS=""
-for rpm in "${RPMS[@]}"; do
-    if rpm --root $NEWROOT -q --quiet $rpm ; then
-        FINAL_RPMS+="$rpm "
-    fi
-done
-rpm --root $NEWROOT --nodeps $JUSTDB -e FINAL_RPMS
-clean_yum
-
-# autoremove does not always look at the full dep tree and sometimes needs to
-# be run multiple times to get everything that can safely be removed
-while ! yum --installroot $NEWROOT autoremove -y | tee /dev/stderr | grep -q 'No Packages marked for removal\|Nothing to do.'
-do
-    :
-done
-
-clean_yum

--- a/eks-distro-base/scripts/install_if_al2022
+++ b/eks-distro-base/scripts/install_if_al2022
@@ -18,30 +18,8 @@ set -e
 set -o pipefail
 set -x
 
-PACKAGES=$1
-JUSTDB=${2:false}
+PACKAGES="$1"
 
-if [ $JUSTDB ]; then
-    JUSTDB="--justdb"
-else
-    JUSTDB=""
+if grep -q "2022" "/etc/os-release"; then 
+    clean_install $PACKAGES
 fi
-
-RPMS=(${PACKAGES// / })
-FINAL_RPMS=""
-for rpm in "${RPMS[@]}"; do
-    if rpm --root $NEWROOT -q --quiet $rpm ; then
-        FINAL_RPMS+="$rpm "
-    fi
-done
-rpm --root $NEWROOT --nodeps $JUSTDB -e FINAL_RPMS
-clean_yum
-
-# autoremove does not always look at the full dep tree and sometimes needs to
-# be run multiple times to get everything that can safely be removed
-while ! yum --installroot $NEWROOT autoremove -y | tee /dev/stderr | grep -q 'No Packages marked for removal\|Nothing to do.'
-do
-    :
-done
-
-clean_yum

--- a/eks-distro-base/scripts/remove_package
+++ b/eks-distro-base/scripts/remove_package
@@ -34,7 +34,7 @@ for rpm in "${RPMS[@]}"; do
         FINAL_RPMS+="$rpm "
     fi
 done
-rpm --root $NEWROOT --nodeps $JUSTDB -e FINAL_RPMS
+rpm --root $NEWROOT --nodeps $JUSTDB -e $FINAL_RPMS
 clean_yum
 
 # autoremove does not always look at the full dep tree and sometimes needs to


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This adds an experimental build of our base images based on al2022 instead al2.  Al2022 is not officially released yet, but the plan is to build new base images along with the existing al2 images and tag differently.  We can then use these to test in eks-d and eks-a repos.  There is no current rollout plan other than just verification. 

*NOTE:* AL2022 does not include docker/containerd/runc, yet.  We are doing a really hacky thing here by pulling these from the al2 repo and will do some validation via the kind image, which runs kube inside of a docker container, to confirm if it actually works.

Prow: https://github.com/aws/eks-distro-prow-jobs/pull/259

/hold

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
