### PR TITLE
support eks-d 1.22 release and fix snapshotter

### DIFF
--- a/release/config/1-22/1-22.yaml
+++ b/release/config/1-22/1-22.yaml
@@ -1,0 +1,25 @@
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+apiVersion: distro.eks.amazonaws.com/v1alpha1
+kind: ReleaseChannel
+metadata:
+  creationTimestamp: null
+  name: 1-21
+spec:
+  snsTopicARN: "arn:aws:sns:us-east-1:379412251201:eks-distro-updates"
+status:
+  active: true
+  latestRelease: 1

--- a/release/config/1-22/1-22.yaml
+++ b/release/config/1-22/1-22.yaml
@@ -17,7 +17,7 @@ apiVersion: distro.eks.amazonaws.com/v1alpha1
 kind: ReleaseChannel
 metadata:
   creationTimestamp: null
-  name: 1-21
+  name: 1-22
 spec:
   snsTopicARN: "arn:aws:sns:us-east-1:379412251201:eks-distro-updates"
 status:

--- a/release/pkg/assets_snapshotter.go
+++ b/release/pkg/assets_snapshotter.go
@@ -25,7 +25,7 @@ import (
 // GetSnapshotterComponent returns the Component for External Snapshotter
 func (r *ReleaseConfig) GetSnapshotterComponent(spec distrov1alpha1.ReleaseSpec) (*distrov1alpha1.Component, error) {
 	projectSource := "projects/kubernetes-csi/external-snapshotter"
-	tagFile := filepath.Join(r.BuildRepoSource, projectSource, "GIT_TAG")
+	tagFile := filepath.Join(r.BuildRepoSource, projectSource, spec.Channel, "GIT_TAG")
 	gitTag, err := readTag(tagFile)
 	if err != nil {
 		return nil, errors.Cause(err)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Support 1-22 by adding channel.yaml.  Similar to #173 
- Snapshotter was broken out into release branches. Similar to #168 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
