### PR TITLE
Modify url for dev releases

### DIFF
--- a/release/cmd/release.go
+++ b/release/cmd/release.go
@@ -64,22 +64,24 @@ var releaseCmd = &cobra.Command{
 		release.APIVersion = "distro.eks.amazonaws.com/v1alpha1"
 		release.Kind = "Release"
 		if devRelease {
-			ecrPublicClient, err := releaseConfig.CreateDevReleaseClients()
+			client, err := releaseConfig.CreateDevReleaseClients()
 			if err != nil {
 				fmt.Printf("Error creating clients: %v\n", err)
 				os.Exit(1)
 			}
+			ecrPublicClient = client
 			cdnURL, err = buildDevS3URL()
 			if err != nil {
 				fmt.Printf("Error building dev s3 url: %v\n", err)
 				os.Exit(1)
 			}
 		} else {
-			ecrPublicClient, err := releaseConfig.CreateProdReleaseClients()
+			client, err := releaseConfig.CreateProdReleaseClients()
 			if err != nil {
 				fmt.Printf("Error creating clients: %v\n", err)
 				os.Exit(1)
 			}
+			ecrPublicClient = client
 		}
 		releaseConfig.ArtifactURL = cdnURL
 

--- a/release/cmd/release.go
+++ b/release/cmd/release.go
@@ -48,7 +48,6 @@ var releaseCmd = &cobra.Command{
 		var ecrPublicClient *ecrpublic.ECRPublic
 		releaseConfig := &pkg.ReleaseConfig{
 			ContainerImageRepository: imageRepository,
-			ArtifactURL:              cdnURL,
 			BuildRepoSource:          sourceDir,
 			ArtifactDir:              artifactDir,
 			ReleaseDate:              time.Now().UTC(),
@@ -75,7 +74,6 @@ var releaseCmd = &cobra.Command{
 				fmt.Printf("Error building dev s3 url: %v\n", err)
 				os.Exit(1)
 			}
-			releaseConfig.ArtifactURL = cdnURL
 		} else {
 			ecrPublicClient, err = releaseConfig.CreateProdReleaseClients()
 			if err != nil {
@@ -83,6 +81,7 @@ var releaseCmd = &cobra.Command{
 				os.Exit(1)
 			}
 		}
+		releaseConfig.ArtifactURL = cdnURL
 
 		componentsTable, err := releaseConfig.GenerateComponentsTable(release)
 		if err != nil {

--- a/release/cmd/release.go
+++ b/release/cmd/release.go
@@ -64,7 +64,7 @@ var releaseCmd = &cobra.Command{
 		release.APIVersion = "distro.eks.amazonaws.com/v1alpha1"
 		release.Kind = "Release"
 		if devRelease {
-			ecrPublicClient, err = releaseConfig.CreateDevReleaseClients()
+			ecrPublicClient, err := releaseConfig.CreateDevReleaseClients()
 			if err != nil {
 				fmt.Printf("Error creating clients: %v\n", err)
 				os.Exit(1)

--- a/release/cmd/release.go
+++ b/release/cmd/release.go
@@ -75,7 +75,7 @@ var releaseCmd = &cobra.Command{
 				os.Exit(1)
 			}
 		} else {
-			ecrPublicClient, err = releaseConfig.CreateProdReleaseClients()
+			ecrPublicClient, err := releaseConfig.CreateProdReleaseClients()
 			if err != nil {
 				fmt.Printf("Error creating clients: %v\n", err)
 				os.Exit(1)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Currently the dev release manifests are pointing to the prod cdn, which is causing our builds from the EKS-A side to fail because the artifacts don't exist in the urls specified. This will read the bucket from the env var and if the dev-release flag is set, use the dev url instead.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
