### PR TITLE
builder-base: add al2022 build

### DIFF
--- a/builder-base/Makefile
+++ b/builder-base/Makefile
@@ -1,20 +1,39 @@
 AWS_ACCOUNT_ID?=$(shell aws sts get-caller-identity --query Account --output text)
 AWS_REGION?=us-west-2
 
-BASE_IMAGE?=public.ecr.aws/amazonlinux/amazonlinux:2
-
 IMAGE_REPO?=$(AWS_ACCOUNT_ID).dkr.ecr.$(AWS_REGION).amazonaws.com
 IMAGE_NAME?=builder-base
 # This tag is overwritten in the prow job to point to the PR branch commit hash (presubmit)
 # or the base branch commit hash (postsubmit)
 IMAGE_TAG?=latest
+
+AL_TAG?=2
+LATEST?=latest
+
+ifeq (2022,$(AL_TAG))
+	LATEST:=$(LATEST).2022
+else
+	# tag al2 build with latest.2 and latest for backward compat
+	LATEST:=$(LATEST) $(LATEST).2
+endif
+
 IMAGE?=$(IMAGE_REPO)/$(IMAGE_NAME):$(IMAGE_TAG)
-LATEST_IMAGE=$(IMAGE_REPO)/$(IMAGE_NAME):latest
+
+LATEST_TAGS=$(foreach tag,$(LATEST),$(IMAGE_REPO)/$(IMAGE_NAME):$(tag))
+LATEST_IMAGE=$(shell echo $(LATEST_TAGS) | sed "s/ \+/,/g")
+
+BASE_IMAGE_REPO?=public.ecr.aws/eks-distro-build-tooling
+BASE_IMAGE_NAME?=eks-distro-minimal-base-kind
+BASE_IMAGE?=$(BASE_IMAGE_REPO)/$(BASE_IMAGE_NAME):$(call BASE_TAG_FROM_TAG_FILE,$(BASE_IMAGE_NAME))
 
 BUILDKIT_OUTPUT=type=image,oci-mediatypes=true,\"name=$(IMAGE),$(LATEST_IMAGE)\",push=true
 BUILDKIT_PLATFORMS=linux/amd64,linux/arm64
 
 MAKE_ROOT=$(shell cd "$(shell dirname "${BASH_SOURCE[0]}")" && pwd -P)
+
+define BASE_TAG_FROM_TAG_FILE
+$(shell yq e ".al$(AL_TAG).$(1)" $(MAKE_ROOT)/../EKS_DISTRO_TAG_FILE.yaml)
+endef
 
 .PHONY: buildkit-check
 buildkit-check:
@@ -29,7 +48,7 @@ remove-generate-attribution:
 	rm -rf ./generate-attribution
 
 .PHONY: local-images
-local-images: BUILDKIT_OUTPUT=type=tar,dest=/tmp/builder-base.tar
+local-images: BUILDKIT_OUTPUT=type=tar,dest=/dev/null
 local-images: BUILDKIT_PLATFORMS=linux/amd64
 local-images: images
 	
@@ -45,7 +64,10 @@ images: buildkit-check
 		--local context=. \
 		--progress plain \
 		--output $(BUILDKIT_OUTPUT)
-	./update_base_image.sh
+	if [ "$(AL_TAG)" = "2" ]; then \
+		./update_base_image.sh $(IMAGE_TAG); \
+	fi
+	
 
 # for local development only
 docker: copy-generate-attribution

--- a/builder-base/amazon-ecr-cred-helper-amd64-checksum
+++ b/builder-base/amazon-ecr-cred-helper-amd64-checksum
@@ -1,0 +1,1 @@
+af805202cb5d627dde2e6d4be1f519b195fd5a3a35ddc88d5010b4a4e5a98dd8  docker-credential-ecr-login

--- a/builder-base/update_base_image.sh
+++ b/builder-base/update_base_image.sh
@@ -18,13 +18,9 @@ set -e
 set -o pipefail
 set -x
 
-SCRIPT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+NEW_TAG="$1"
 
-if [ "$JOB_TYPE" = "presubmit" ]; then
-    NEW_TAG=$PULL_PULL_SHA
-else
-    NEW_TAG=$PULL_BASE_SHA
-fi
+SCRIPT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 
 ${SCRIPT_ROOT}/../pr-scripts/update_local_branch.sh eks-distro-prow-jobs
 ${SCRIPT_ROOT}/../pr-scripts/update_image_tag.sh eks-distro-prow-jobs 'builder-base:.*' 'builder-base:'"$NEW_TAG" '*.yaml'

--- a/builder-base/update_shasums.sh
+++ b/builder-base/update_shasums.sh
@@ -75,3 +75,6 @@ echo "$(curl -sSL --retry 5 $HUGO_CHECKSUM_URL | grep -r $HUGO_FILENAME | cut -d
 # BASH
 sha256=$(curl -sSL --retry 5 $BASH_DOWNLOAD_URL | sha256sum | awk '{print $1}')
 echo "$sha256  bash-$OVERRIDE_BASH_VERSION.tar.gz" > bash-checksum
+
+# AMAZON_ECR_CRED_HELPER
+curl -sSL --retry 5 $AMAZON_ECR_CRED_HELPER_CHECKSUM_URL -o amazon-ecr-cred-helper-$TARGETARCH-checksum

--- a/builder-base/versions.sh
+++ b/builder-base/versions.sh
@@ -76,3 +76,7 @@ YQ_VERSION="${YQ_VERSION:-v4.7.1}"
 YQ_DOWNLOAD_URL="https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_$TARGETARCH"
 YQ_CHECKSUM_URL="https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/checksums"
 YQ_CHECKSUM_ORDER_URL="https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/checksums_hashes_order"
+
+AMAZON_ECR_CRED_HELPER_VERSION="${AMAZON_ECR_CRED_HELPER_VERSION:-0.6.0}"
+AMAZON_ECR_CRED_HELPER_DOWNLOAD_URL="https://amazon-ecr-credential-helper-releases.s3.us-east-2.amazonaws.com/${AMAZON_ECR_CRED_HELPER_VERSION}/linux-$TARGETARCH/docker-credential-ecr-login"
+AMAZON_ECR_CRED_HELPER_CHECKSUM_URL="${AMAZON_ECR_CRED_HELPER_DOWNLOAD_URL}.sha256"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This introduces an al2022 based builder-base image.  It also changes the base image from al2/2022 directly to the minimal kind image, which has most of the same stuff this image needs.  

Much like the eks-distro-base build, this adds an AL_TAG which is meant to be used to determine the underlying base image.  The al2 build continues to be tagged latest, as well as latest.2, and the 2022 build will be tagged with latest.2022.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
