### PR TITLE
builder-base: fix prow-jobs update and shasum update

### DIFF
--- a/builder-base/update_base_image.sh
+++ b/builder-base/update_base_image.sh
@@ -24,6 +24,7 @@ SCRIPT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 
 ${SCRIPT_ROOT}/../pr-scripts/update_local_branch.sh eks-distro-prow-jobs
 ${SCRIPT_ROOT}/../pr-scripts/update_image_tag.sh eks-distro-prow-jobs 'builder-base:.*' 'builder-base:'"$NEW_TAG" '*.yaml'
+${SCRIPT_ROOT}/../pr-scripts/update_image_tag.sh eks-distro-prow-jobs '.*' $NEW_TAG BUILDER_BASE_TAG_FILE
 ${SCRIPT_ROOT}/../pr-scripts/create_pr.sh eks-distro-prow-jobs '*.yaml'
 
 ${SCRIPT_ROOT}/../pr-scripts/update_local_branch.sh eks-anywhere-prow-jobs

--- a/builder-base/update_shasums.sh
+++ b/builder-base/update_shasums.sh
@@ -40,6 +40,9 @@ for TARGETARCH in arm64 amd64; do
     echo "${yq_checksums_ar[*]}"
     sha256="${yq_checksums_ar[$yq_checksum_index]}"
     echo "$sha256  yq_linux_$TARGETARCH" > yq-$TARGETARCH-checksum
+
+    # AMAZON_ECR_CRED_HELPER
+    curl -sSL --retry 5 $AMAZON_ECR_CRED_HELPER_CHECKSUM_URL -o amazon-ecr-cred-helper-$TARGETARCH-checksum
 done
 
 # BUILDKIT
@@ -75,6 +78,3 @@ echo "$(curl -sSL --retry 5 $HUGO_CHECKSUM_URL | grep -r $HUGO_FILENAME | cut -d
 # BASH
 sha256=$(curl -sSL --retry 5 $BASH_DOWNLOAD_URL | sha256sum | awk '{print $1}')
 echo "$sha256  bash-$OVERRIDE_BASH_VERSION.tar.gz" > bash-checksum
-
-# AMAZON_ECR_CRED_HELPER
-curl -sSL --retry 5 $AMAZON_ECR_CRED_HELPER_CHECKSUM_URL -o amazon-ecr-cred-helper-$TARGETARCH-checksum

--- a/pr-scripts/update_image_tag.sh
+++ b/pr-scripts/update_image_tag.sh
@@ -44,11 +44,3 @@ pwd
 for FILE in $(find ./ -type f -name "$FILEPATH"); do
     $SED -i "s,${OLD_TAG},${NEW_TAG}," $FILE
 done
-if [ $REPO = "eks-distro-prow-jobs" ]; then
-    if [ "$JOB_TYPE" = "presubmit" ]; then
-        $SED -i "s,.*,${PULL_PULL_SHA}," ./BUILDER_BASE_TAG_FILE
-    else
-        $SED -i "s,.*,${PULL_BASE_SHA}," ./BUILDER_BASE_TAG_FILE
-    fi
-fi
-


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Forgot to update the shasum script to get aws ecr helper arm checksum
- Fix update of BUILDER_BASE_TAG_FILE files in eks-distro-prow-jobs

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
