### PR TITLE
release: kube generate image tags like all other container images

### DIFF
--- a/release/pkg/assets_k8s.go
+++ b/release/pkg/assets_k8s.go
@@ -150,10 +150,12 @@ func (r *ReleaseConfig) GetKubernetesComponent(spec distrov1alpha1.ReleaseSpec) 
 			OS:          "linux",
 			Arch:        []string{"amd64", "arm64"},
 			Image: &distrov1alpha1.AssetImage{
-				URI: fmt.Sprintf("%s/kubernetes/%s:%s",
+				URI: fmt.Sprintf("%s/kubernetes/%s:%s-eks-%s-%d",
 					r.ContainerImageRepository,
 					binary,
-					kgv.KubeGitVersion,
+					gitTag,
+					spec.Channel,
+					spec.Number,
 				),
 			},
 		})


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

In https://github.com/aws/eks-distro/pull/753 I am looking to change the KUBE_GET_VERSION in the version file the release tooling uses to generate the final release yaml.  Image tags and binary versions will not match on the kubernetes components.  This change uses the same process to generate the image tags as all the other components in the release tooling. 

At this point the only thing the release tooling will be pulling from the version file is the git commit hash.

/hold
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
