### PR TITLE
builder-base: set root user shell to bash instead of nologin

### DIFF
--- a/builder-base/install.sh
+++ b/builder-base/install.sh
@@ -108,6 +108,14 @@ fi
 
 # Add any additional dependencies we want in the builder-base image here
 
+
+# The base image is the kind-minimal image with a /etc/passwd file
+# based from the minimal base, which is setup manually.  The root
+# user's shell is configured as /sbin/nologin
+# This doesnt work for the builder-base usage in Codebuild which runs 
+# certain commands specifically as root.  We need the shell to be bash.
+usermod --shell /bin/bash root
+
 # directory setup
 mkdir -p /go/src /go/bin /go/pkg /go/src/github.com/aws/eks-distro
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
We ran into an issue yesterday in codebuild where a job tried to switched to the root user and was not able to because the shell was improperly configured.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
