### PR TITLE
prow: mirror other images into ecr by introducing build

### DIFF
--- a/pr-scripts/create_pr.sh
+++ b/pr-scripts/create_pr.sh
@@ -91,6 +91,7 @@ for FILE in $(find ./ -type f -name "$FILEPATH" ); do
     git add $FILE
 done
 
+cd ${SCRIPT_ROOT}/../../../${ORIGIN_ORG}/${REPO}
 if [ $REPO = "eks-distro-build-tooling" ]; then
     git add ./eks-distro-base-minimal-packages/. ./eks-distro-base-updates/.
 fi

--- a/projects/kubernetes/test-infra/Makefile
+++ b/projects/kubernetes/test-infra/Makefile
@@ -4,45 +4,92 @@ AWS_REGION?=us-west-2
 IMAGE_TAG?=$(shell cat IMAGE_TAG)
 
 BASE_IMAGE_REPO?=gcr.io
-BASE_IMAGE_NAME?=k8s-prow/deck
-BASE_IMAGE=$(BASE_IMAGE_REPO)/$(BASE_IMAGE_NAME):$(IMAGE_TAG)
 
+BASE_IMAGE=$(BASE_IMAGE_REPO)/$(BASE_IMAGE_NAME):$(IMAGE_TAG)
+BASE_IMAGE_NAME?=k8s-prow/$(IMAGE_NAME:prow-%=%)
 IMAGE_REPO?=$(AWS_ACCOUNT_ID).dkr.ecr.$(AWS_REGION).amazonaws.com
-IMAGE_NAME?=prow-deck
+
 IMAGE?=$(IMAGE_REPO)/$(IMAGE_NAME):$(IMAGE_TAG)
 
-BUILDKIT_OUTPUT=type=image,oci-mediatypes=true,name=$(IMAGE),push=true
-BUILDKIT_PLATFORMS=linux/amd64,linux/arm64
-
 MAKE_ROOT=$(shell cd "$(shell dirname "${BASH_SOURCE[0]}")" && pwd -P)
+
+IMAGE_NAMES=prow-deck prow-clonerefs prow-crier prow-entrypoint prow-ghproxy prow-hook \
+	prow-horologium prow-initupload prow-controller-manager prow-sidecar prow-sinker prow-statusreconciler prow-tide
+
+VALUES_YAML_PATHS=deck.image utility_images.clonerefs crier.image utility_images.entrypoint ghproxy.image hook.image \
+	horologium.image utility_images.initupload prowControllerManager.image utility_images.sidecar sinker.image statusreconciler.image tide.image
+
+LOCAL_IMAGE_TARGETS=$(foreach image,$(IMAGE_NAMES),$(image)/images/amd64)
+IMAGE_TARGETS=$(foreach image,$(IMAGE_NAMES),$(image)/images/push)
+
+
+prow-controller-manager/images/%: BASE_IMAGE_NAME=k8s-prow/prow-controller-manager
+
+prow-statusreconciler/images/%: BASE_IMAGE_NAME=k8s-prow/status-reconciler
+
+prow-deck/images/%: DOCKERFILE_FOLDER?=./docker/linux/deck
 
 .PHONY: buildkit-check
 buildkit-check:
 	$(MAKE_ROOT)/../../../scripts/buildkit_check.sh
 
 .PHONY: local-images
-local-images: BUILDKIT_OUTPUT=type=tar,dest=/tmp/prow-deck.tar
-local-images: BUILDKIT_PLATFORMS=linux/amd64
-local-images: images
+local-images: buildkit-check $(LOCAL_IMAGE_TARGETS)
 	
 .PHONY: images
-images: buildkit-check
-	buildctl \
-		build \
-		--frontend dockerfile.v0 \
-		--opt platform=$(BUILDKIT_PLATFORMS) \
-		--opt build-arg:BASE_IMAGE=$(BASE_IMAGE) \
-		--local dockerfile=./docker/linux \
-		--local context=. \
-		--progress plain \
-		--output $(BUILDKIT_OUTPUT)
-	./update_deck_image.sh $(IMAGE)
+images: buildkit-check $(IMAGE_TARGETS)	
+
+.PHONY: update-helm-chart
+update-helm-chart:
+	./update_helm_images.sh "$(foreach image,$(IMAGE_NAMES),$(IMAGE_REPO)/$(image):$(IMAGE_TAG))" "$(VALUES_YAML_PATHS)"
 
 .PHONY: build
 build: local-images
 
 .PHONY: release
-release: images
+release: images update-helm-chart
 
 .PHONY: all
 all: release
+
+
+# From Common.mk in other build tooling repos
+
+define BUILDCTL
+	buildctl \
+		build \
+		--frontend dockerfile.v0 \
+		--opt platform=$(IMAGE_PLATFORMS) \
+		--opt build-arg:BASE_IMAGE=$(BASE_IMAGE) \
+		--progress plain \
+		--local dockerfile=$(DOCKERFILE_FOLDER) \
+		--local context=$(IMAGE_CONTEXT_DIR) \
+		--opt target=$(IMAGE_TARGET) \
+		--output type=$(IMAGE_OUTPUT_TYPE),oci-mediatypes=true,\"name=$(IMAGE)\",$(IMAGE_OUTPUT)	
+endef 
+
+
+.PHONY: %/images/push %/images/amd64 %/images/arm64
+%/images/push %/images/amd64 %/images/arm64: IMAGE_NAME=$*
+%/images/push %/images/amd64 %/images/arm64: DOCKERFILE_FOLDER?=./docker/linux
+%/images/push %/images/amd64 %/images/arm64: IMAGE_CONTEXT_DIR?=.
+%/images/push %/images/amd64 %/images/arm64: IMAGE_BUILD_ARGS?=
+
+# Build image using buildkit for all platforms, by default pushes to registry defined in IMAGE_REPO.
+%/images/push: IMAGE_PLATFORMS?=linux/amd64,linux/arm64
+%/images/push: IMAGE_OUTPUT_TYPE?=image
+%/images/push: IMAGE_OUTPUT?=push=true
+%/images/push:
+	$(BUILDCTL)
+
+# Build image using buildkit only builds linux/amd64 oci and saves to local tar.
+%/images/amd64: IMAGE_PLATFORMS?=linux/amd64
+
+# Build image using buildkit only builds linux/arm64 oci and saves to local tar.
+%/images/arm64: IMAGE_PLATFORMS?=linux/arm64
+
+%/images/amd64 %/images/arm64: IMAGE_OUTPUT_TYPE?=oci
+%/images/amd64 %/images/arm64: IMAGE_OUTPUT?=dest=/dev/null
+
+%/images/amd64:
+	$(BUILDCTL)

--- a/projects/kubernetes/test-infra/Makefile
+++ b/projects/kubernetes/test-infra/Makefile
@@ -44,7 +44,7 @@ update-helm-chart:
 	./update_helm_images.sh "$(foreach image,$(IMAGE_NAMES),$(IMAGE_REPO)/$(image):$(IMAGE_TAG))" "$(VALUES_YAML_PATHS)"
 
 .PHONY: build
-build: local-images
+build: local-images update-helm-chart
 
 .PHONY: release
 release: images update-helm-chart

--- a/projects/kubernetes/test-infra/docker/linux/Dockerfile
+++ b/projects/kubernetes/test-infra/docker/linux/Dockerfile
@@ -1,9 +1,3 @@
-ARG BASE_IMAGE #gcr.io/k8s-prow/deck:v20200924-369a496323 
+ARG BASE_IMAGE #gcr.io/k8s-prow/<image>:v20200924-369a496323 
 
 FROM $BASE_IMAGE
-
-RUN find /template -type f -iname '*.html' -exec sed -i -e 's,https://code.getmdl.io/1.3.0/,/static/,g' {} \;
-RUN find /lenses/podinfo -type f -iname '*.html' -exec sed -i -e 's,https://code.getmdl.io/1.3.0/,/static/,g' {} \;
-
-RUN wget https://code.getmdl.io/1.3.0/material.min.js -P /static
-RUN wget https://code.getmdl.io/1.3.0/material.indigo-pink.min.css -P /static

--- a/projects/kubernetes/test-infra/docker/linux/deck/Dockerfile
+++ b/projects/kubernetes/test-infra/docker/linux/deck/Dockerfile
@@ -1,0 +1,9 @@
+ARG BASE_IMAGE #gcr.io/k8s-prow/deck:v20200924-369a496323 
+
+FROM $BASE_IMAGE
+
+RUN find /template -type f -iname '*.html' -exec sed -i -e 's,https://code.getmdl.io/1.3.0/,/static/,g' {} \;
+RUN find /lenses/podinfo -type f -iname '*.html' -exec sed -i -e 's,https://code.getmdl.io/1.3.0/,/static/,g' {} \;
+
+RUN wget https://code.getmdl.io/1.3.0/material.min.js -P /static
+RUN wget https://code.getmdl.io/1.3.0/material.indigo-pink.min.css -P /static

--- a/projects/kubernetes/test-infra/update_helm_images.sh
+++ b/projects/kubernetes/test-infra/update_helm_images.sh
@@ -20,8 +20,16 @@ set -x
 
 SCRIPT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 
-IMAGE=${1?Specify first argument - Image to be replaced in Helm values}
+IMAGES=${1?Specify first argument - Images to be replaced in Helm values}
+VALUE_PATHS=${2?Specify second argument - Path to var in values.yaml to update, ex: deck.image}
+
+IMAGES=(${IMAGES// / })
+VALUE_PATHS=(${VALUE_PATHS// / })
 
 ${SCRIPT_ROOT}/../../../pr-scripts/update_local_branch.sh eks-distro-build-tooling
-${SCRIPT_ROOT}/update_helm_chart.sh $IMAGE
+	
+for (( i=0; i<${#IMAGES[*]}; ++i)); do \
+    ${SCRIPT_ROOT}/update_helm_chart.sh "${IMAGES[$i]}" "${VALUE_PATHS[$i]}" $(( $i==${#IMAGES[*]} - 1 )); \
+done
+
 ${SCRIPT_ROOT}/../../../pr-scripts/create_pr.sh eks-distro-build-tooling 'helm-charts/stable/prow-control-plane/*.yaml'


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
We were already pushing the deck image into ecr since we were "patching" it.   This brings over some of the common.mk patterns to "build" the other images, these builds are just a simple mirror at this point.

The update script is updated to update all the prow image names.

TODO:

- [ ] cdk changes to add new ecr repos

/hold

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
