### PR TITLE
distro-base: check in updates file for use in pr creation

### DIFF
--- a/eks-distro-base/Makefile
+++ b/eks-distro-base/Makefile
@@ -199,7 +199,7 @@ endif
 
 .PHONY: create-pr
 create-pr: $(CREATE_PR_TARGETS)
-	$(MAKE_ROOT)/../pr-scripts/create_pr.sh eks-distro-build-tooling 'EKS_DISTRO*_TAG_FILE*' 'eks-distro-base-minimal-packages/.'
+	$(MAKE_ROOT)/../pr-scripts/create_pr.sh eks-distro-build-tooling 'EKS_DISTRO*_TAG_FILE*'
 
 .PHONY: update
 update: buildkit-check $(UPDATE_TARGETS)

--- a/pr-scripts/create_pr.sh
+++ b/pr-scripts/create_pr.sh
@@ -20,7 +20,6 @@ set -x
 
 REPO="$1"
 FILEPATH="$2"
-ADDITIONAL_GIT_ADD="${3:-}"
 
 SED=sed
 if [[ "$(uname -s)" == "Darwin" ]]; then
@@ -91,8 +90,9 @@ fi
 for FILE in $(find ./ -type f -name "$FILEPATH" ); do
     git add $FILE
 done
-if [ ! -z "${ADDITIONAL_GIT_ADD}" ]; then
-    git add $ADDITIONAL_GIT_ADD
+
+if [ $REPO = "eks-distro-build-tooling" ]; then
+    git add ./eks-distro-base-minimal-packages/. ./eks-distro-base-updates/.
 fi
 if [ $REPO = "eks-distro-prow-jobs" ]; then
     git add ./BUILDER_BASE_TAG_FILE


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The last periodic job that update the distro base images did not check in the updates file which tracks the packages that were changed.  This meant that when the other PRs were opened, the message showed the previous updated packages instead of the latest.  This should fix that.

I took a simple approach here... the ADDITIONAL_GIT_ADD was only used in this one spot and the quotes around multiple were messing up the git add.  Instead of improving that for one case and since this script is already hardcoding cases for different repos, I took this approach.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
