### PR TITLE
release: fix git tag generation for projects which were split

### DIFF
--- a/release/pkg/assets_attacher.go
+++ b/release/pkg/assets_attacher.go
@@ -25,7 +25,7 @@ import (
 // GetAttacherComponent returns the Component for External Attacher
 func (r *ReleaseConfig) GetAttacherComponent(spec distrov1alpha1.ReleaseSpec) (*distrov1alpha1.Component, error) {
 	projectSource := "projects/kubernetes-csi/external-attacher"
-	tagFile := filepath.Join(r.BuildRepoSource, projectSource, "GIT_TAG")
+	tagFile := filepath.Join(r.BuildRepoSource, projectSource, spec.Channel, "GIT_TAG")
 	gitTag, err := readTag(tagFile)
 	if err != nil {
 		return nil, errors.Cause(err)

--- a/release/pkg/assets_livenessprobe.go
+++ b/release/pkg/assets_livenessprobe.go
@@ -25,7 +25,7 @@ import (
 // GetLivenessprobeComponent returns the Component for Liveness Probe
 func (r *ReleaseConfig) GetLivenessprobeComponent(spec distrov1alpha1.ReleaseSpec) (*distrov1alpha1.Component, error) {
 	projectSource := "projects/kubernetes-csi/livenessprobe"
-	tagFile := filepath.Join(r.BuildRepoSource, projectSource, "GIT_TAG")
+	tagFile := filepath.Join(r.BuildRepoSource, projectSource, spec.Channel, "GIT_TAG")
 	gitTag, err := readTag(tagFile)
 	if err != nil {
 		return nil, errors.Cause(err)

--- a/release/pkg/assets_provisioner.go
+++ b/release/pkg/assets_provisioner.go
@@ -25,7 +25,7 @@ import (
 // GetProvisionerComponent returns the Component for External Provisioner
 func (r *ReleaseConfig) GetProvisionerComponent(spec distrov1alpha1.ReleaseSpec) (*distrov1alpha1.Component, error) {
 	projectSource := "projects/kubernetes-csi/external-provisioner"
-	tagFile := filepath.Join(r.BuildRepoSource, projectSource, "GIT_TAG")
+	tagFile := filepath.Join(r.BuildRepoSource, projectSource, spec.Channel, "GIT_TAG")
 	gitTag, err := readTag(tagFile)
 	if err != nil {
 		return nil, errors.Cause(err)

--- a/release/pkg/assets_registrar.go
+++ b/release/pkg/assets_registrar.go
@@ -25,7 +25,7 @@ import (
 // GetRegistrarComponent returns the Component for Node Driver Registrar
 func (r *ReleaseConfig) GetRegistrarComponent(spec distrov1alpha1.ReleaseSpec) (*distrov1alpha1.Component, error) {
 	projectSource := "projects/kubernetes-csi/node-driver-registrar"
-	tagFile := filepath.Join(r.BuildRepoSource, projectSource, "GIT_TAG")
+	tagFile := filepath.Join(r.BuildRepoSource, projectSource, spec.Channel, "GIT_TAG")
 	gitTag, err := readTag(tagFile)
 	if err != nil {
 		return nil, errors.Cause(err)

--- a/release/pkg/assets_resizer.go
+++ b/release/pkg/assets_resizer.go
@@ -25,7 +25,7 @@ import (
 // GetResizerComponent returns the Component for External Resizer
 func (r *ReleaseConfig) GetResizerComponent(spec distrov1alpha1.ReleaseSpec) (*distrov1alpha1.Component, error) {
 	projectSource := "projects/kubernetes-csi/external-resizer"
-	tagFile := filepath.Join(r.BuildRepoSource, projectSource, "GIT_TAG")
+	tagFile := filepath.Join(r.BuildRepoSource, projectSource, spec.Channel, "GIT_TAG")
 	gitTag, err := readTag(tagFile)
 	if err != nil {
 		return nil, errors.Cause(err)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Dev release 1.22 failed due to the changes to the csi projects being release branch'd.  I ran these changes locally to generate the CRD to ensure they fix the issue. I will retrigger the build once this merges.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
