### PR TITLE
update to recently build al2022 image tags

### DIFF
--- a/EKS_DISTRO_TAG_FILE.yaml
+++ b/EKS_DISTRO_TAG_FILE.yaml
@@ -11,14 +11,14 @@ al2:
   eks-distro-minimal-base-nginx: 2022-03-09-1646784337.2
   eks-distro-minimal-base-git: 2022-03-09-1646784337.2
 al2022:
-  eks-distro-base: 2022-02-11-1644621179.2022
-  eks-distro-minimal-base: 2022-02-11-1644621179.2022
-  eks-distro-minimal-base-nonroot: 2022-02-11-1644621179.2022
-  eks-distro-minimal-base-glibc: 2022-02-11-1644621179.2022
-  eks-distro-minimal-base-iptables: 2022-02-11-1644621179.2022
-  eks-distro-minimal-base-docker-client: 2022-02-11-1644621179.2022
-  eks-distro-minimal-base-csi: 2022-02-11-1644621179.2022
-  eks-distro-minimal-base-haproxy: 2022-02-11-1644621179.2022
-  eks-distro-minimal-base-kind: 2022-02-12-1644681699.2022
-  eks-distro-minimal-base-nginx: 2022-02-11-1644621179.2022
-  eks-distro-minimal-base-git: 2022-02-11-1644621179.2022
+  eks-distro-base: 2022-03-09-1646784337.2022
+  eks-distro-minimal-base: 2022-03-09-1646784337.2022
+  eks-distro-minimal-base-nonroot: 2022-03-09-1646784337.2022
+  eks-distro-minimal-base-glibc: 2022-03-09-1646784337.2022
+  eks-distro-minimal-base-iptables: 2022-03-09-1646784337.2022
+  eks-distro-minimal-base-docker-client: 2022-03-09-1646784337.2022
+  eks-distro-minimal-base-csi: 2022-03-09-1646784337.20222
+  eks-distro-minimal-base-haproxy: rebuild
+  eks-distro-minimal-base-kind: rebuild
+  eks-distro-minimal-base-nginx: 2022-03-09-1646784337.2022
+  eks-distro-minimal-base-git: 2022-03-09-1646784337.2022


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The build timed out building all the images.  This updates the ones that did build and changes the tag for the ones that didnt to force them to build during the next periodic.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
