### PR TITLE
Change apiextensions to use v1 api

### DIFF
--- a/release/config/crds/releasechannels.distro.eks.amazonaws.com-v1alpha1.yaml
+++ b/release/config/crds/releasechannels.distro.eks.amazonaws.com-v1alpha1.yaml
@@ -14,28 +14,12 @@
 
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  annotations:
-    controller-gen.kubebuilder.io/version: v0.2.5
   creationTimestamp: null
   name: releasechannels.distro.eks.amazonaws.com
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .spec.snsTopicARN
-    description: The SNS Topic ARN for this release channel
-    name: TopicARN
-    type: string
-  - JSONPath: .status.active
-    description: Indicates if this channel is active
-    name: Active
-    type: boolean
-  - JSONPath: .status.latestRelease
-    description: The latest release of this channel
-    format: int32
-    name: Latest Release
-    type: integer
   group: distro.eks.amazonaws.com
   names:
     kind: ReleaseChannel
@@ -43,44 +27,57 @@ spec:
     plural: releasechannels
     singular: releasechannel
   scope: Namespaced
-  subresources: {}
-  validation:
-    openAPIV3Schema:
-      description: ReleaseChannel is the Schema for the releasechannels API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: ReleaseChannelSpec defines the desired state of ReleaseChannel
-          properties:
-            snsTopicARN:
-              type: string
-          type: object
-        status:
-          description: ReleaseChannelStatus defines the observed state of ReleaseChannel
-          properties:
-            active:
-              type: boolean
-            latestRelease:
-              minimum: 1
-              type: integer
-          type: object
-      type: object
-  version: v1alpha1
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - description: The SNS Topic ARN for this release channel
+      jsonPath: .spec.snsTopicARN
+      name: TopicARN
+      type: string
+    - description: Indicates if this channel is active
+      jsonPath: .status.active
+      name: Active
+      type: boolean
+    - description: The latest release of this channel
+      format: int32
+      jsonPath: .status.latestRelease
+      name: Latest Release
+      type: integer
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ReleaseChannel is the Schema for the releasechannels API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ReleaseChannelSpec defines the desired state of ReleaseChannel
+            properties:
+              snsTopicARN:
+                type: string
+            type: object
+          status:
+            description: ReleaseChannelStatus defines the observed state of ReleaseChannel
+            properties:
+              active:
+                type: boolean
+              latestRelease:
+                minimum: 1
+                type: integer
+            type: object
+        type: object
     served: true
     storage: true
+    subresources: {}
 status:
   acceptedNames:
     kind: ""

--- a/release/config/crds/releases.distro.eks.amazonaws.com-v1alpha1.yaml
+++ b/release/config/crds/releases.distro.eks.amazonaws.com-v1alpha1.yaml
@@ -14,28 +14,12 @@
 
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  annotations:
-    controller-gen.kubebuilder.io/version: v0.2.5
   creationTimestamp: null
   name: releases.distro.eks.amazonaws.com
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .spec.channel
-    description: The release channel
-    name: Release Channel
-    type: string
-  - JSONPath: .spec.number
-    description: Release number
-    name: Release
-    type: integer
-  - JSONPath: .status.date
-    description: The date the release was published
-    format: date-time
-    name: Release Date
-    type: string
   group: distro.eks.amazonaws.com
   names:
     kind: Release
@@ -45,114 +29,128 @@ spec:
     - rel
     singular: release
   scope: Namespaced
-  subresources: {}
-  validation:
-    openAPIV3Schema:
-      description: Release is the Schema for the releases API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: ReleaseSpec defines the desired state of Release
-          properties:
-            buildRepoCommit:
-              type: string
-            channel:
-              type: string
-            number:
-              description: Monotonically increasing release number
-              minimum: 1
-              type: integer
-          type: object
-        status:
-          description: ReleaseStatus defines the observed state of Release
-          properties:
-            components:
-              items:
-                description: A component of a release
-                properties:
-                  assets:
-                    items:
-                      properties:
-                        arch:
-                          description: Architectures of the asset
-                          items:
-                            type: string
-                          type: array
-                        archive:
-                          properties:
-                            sha256:
-                              description: The sha256 of the asset, only applies for
-                                'file' store
-                              type: string
-                            sha512:
-                              description: The sha512 of the asset, only applies for
-                                'file' store
-                              type: string
-                            uri:
-                              description: The URI where the asset is located
-                              type: string
-                          type: object
-                        description:
-                          type: string
-                        image:
-                          properties:
-                            imageDigest:
-                              description: SHA256 digest for the image
-                              type: string
-                            uri:
-                              description: The image repository, name, and tag
-                              type: string
-                          type: object
-                        name:
-                          description: The asset name
-                          type: string
-                        os:
-                          description: Operating system of the asset
-                          enum:
-                          - linux
-                          - darwin
-                          - windows
-                          type: string
-                        type:
-                          description: The type of the asset
-                          enum:
-                          - Archive
-                          - Image
-                          type: string
-                      type: object
-                    type: array
-                  gitCommit:
-                    description: Git commit the component is built from, before any
-                      patches
-                    type: string
-                  gitTag:
-                    description: Git tag the component is built from, before any patches
-                    type: string
-                  name:
-                    type: string
-                type: object
-              type: array
-            date:
-              format: date-time
-              type: string
-          type: object
-      type: object
-  version: v1alpha1
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - description: The release channel
+      jsonPath: .spec.channel
+      name: Release Channel
+      type: string
+    - description: Release number
+      jsonPath: .spec.number
+      name: Release
+      type: integer
+    - description: The date the release was published
+      format: date-time
+      jsonPath: .status.date
+      name: Release Date
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Release is the Schema for the releases API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ReleaseSpec defines the desired state of Release
+            properties:
+              buildRepoCommit:
+                type: string
+              channel:
+                type: string
+              number:
+                description: Monotonically increasing release number
+                minimum: 1
+                type: integer
+            type: object
+          status:
+            description: ReleaseStatus defines the observed state of Release
+            properties:
+              components:
+                items:
+                  description: A component of a release
+                  properties:
+                    assets:
+                      items:
+                        properties:
+                          arch:
+                            description: Architectures of the asset
+                            items:
+                              type: string
+                            type: array
+                          archive:
+                            properties:
+                              sha256:
+                                description: The sha256 of the asset, only applies
+                                  for 'file' store
+                                type: string
+                              sha512:
+                                description: The sha512 of the asset, only applies
+                                  for 'file' store
+                                type: string
+                              uri:
+                                description: The URI where the asset is located
+                                type: string
+                            type: object
+                          description:
+                            type: string
+                          image:
+                            properties:
+                              imageDigest:
+                                description: SHA256 digest for the image
+                                type: string
+                              uri:
+                                description: The image repository, name, and tag
+                                type: string
+                            type: object
+                          name:
+                            description: The asset name
+                            type: string
+                          os:
+                            description: Operating system of the asset
+                            enum:
+                            - linux
+                            - darwin
+                            - windows
+                            type: string
+                          type:
+                            description: The type of the asset
+                            enum:
+                            - Archive
+                            - Image
+                            type: string
+                        type: object
+                      type: array
+                    gitCommit:
+                      description: Git commit the component is built from, before
+                        any patches
+                      type: string
+                    gitTag:
+                      description: Git tag the component is built from, before any
+                        patches
+                      type: string
+                    name:
+                      type: string
+                  type: object
+                type: array
+              date:
+                format: date-time
+                type: string
+            type: object
+        type: object
     served: true
     storage: true
+    subresources: {}
 status:
   acceptedNames:
     kind: ""


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
1.22 deprecates v1beta1 apiextensions: https://kubernetes.io/docs/reference/using-api/deprecation-guide/#v1-22

Made changes by applying the crd on a 1.21 cluster and retrieving the v1 version of it so it would automatically convert it for me.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
