### PR TITLE
Fix 2022 base images

### DIFF
--- a/EKS_DISTRO_TAG_FILE.yaml
+++ b/EKS_DISTRO_TAG_FILE.yaml
@@ -17,8 +17,8 @@ al2022:
   eks-distro-minimal-base-glibc: 2022-03-09-1646784337.2022
   eks-distro-minimal-base-iptables: 2022-03-09-1646784337.2022
   eks-distro-minimal-base-docker-client: 2022-03-09-1646784337.2022
-  eks-distro-minimal-base-csi: 2022-03-09-1646784337.20222
-  eks-distro-minimal-base-haproxy: rebuild
-  eks-distro-minimal-base-kind: rebuild
+  eks-distro-minimal-base-csi: 2022-03-11-1647025257.2022
+  eks-distro-minimal-base-haproxy: 2022-03-11-1647025257.2022
+  eks-distro-minimal-base-kind: 2022-02-12-1644681699.2022
   eks-distro-minimal-base-nginx: 2022-03-09-1646784337.2022
   eks-distro-minimal-base-git: 2022-03-09-1646784337.2022


### PR DESCRIPTION
This is probably wrong, but closer. I assume I'm supposed to generate these, but I just got the latest tags I think are right.
