### PR TITLE
distro-base: fix update_packges and update image tag

### DIFF
--- a/eks-distro-base/update_base_image.sh
+++ b/eks-distro-base/update_base_image.sh
@@ -27,4 +27,4 @@ OLD_TAG="$(yq e ".al$AL_TAG.$IMAGE_NAME" $SCRIPT_ROOT/../EKS_DISTRO_TAG_FILE.yam
 BASE_IMAGE_TAG_FILE="$(echo ${IMAGE_NAME^^} | tr '-' '_')_TAG_FILE"
 
 ${SCRIPT_ROOT}/../pr-scripts/update_local_branch.sh eks-distro-build-tooling
-${SCRIPT_ROOT}/../pr-scripts/update_image_tag.sh eks-distro-build-tooling "$IMAGE_NAME: $OLD_TAG" "$IMAGE_NAME: $IMAGE_TAG" "EKS_DISTRO_TAG_FILE.yaml"
+${SCRIPT_ROOT}/../pr-scripts/update_image_tag.sh eks-distro-build-tooling $OLD_TAG ".al$AL_TAG.$IMAGE_NAME |= \"$IMAGE_TAG\"" "EKS_DISTRO_TAG_FILE.yaml" true

--- a/pr-scripts/update_image_tag.sh
+++ b/pr-scripts/update_image_tag.sh
@@ -22,6 +22,7 @@ REPO="$1"
 OLD_TAG="$2"
 NEW_TAG="$3"
 FILEPATH="$4"
+USE_YQ="$5"
 
 SED=sed
 if [[ "$(uname -s)" == "Darwin" ]]; then
@@ -38,9 +39,14 @@ fi
 
 REPO_PATH=${SCRIPT_ROOT}/../../../${ORIGIN_ORG}/${REPO}
 cp -rf ${SCRIPT_ROOT}/../eks-distro-base-minimal-packages $REPO_PATH
+cp -rf ${SCRIPT_ROOT}/../eks-distro-base-updates $REPO_PATH
 cd $REPO_PATH
 pwd
 
-for FILE in $(find ./ -type f -name "$FILEPATH"); do
-    $SED -i "s,${OLD_TAG},${NEW_TAG}," $FILE
-done
+if [ "$USE_YQ" = "true" ]; then
+    yq -i e "$NEW_TAG" EKS_DISTRO_TAG_FILE.yaml   
+else
+    for FILE in $(find ./ -type f -name "$FILEPATH"); do
+        $SED -i "s,${OLD_TAG},${NEW_TAG}," $FILE
+    done
+fi


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
In the last periodic build a couple things happened.

- the update_packages were not being checked in so the PR messages in other repos were still wrong
- the update base image tag script was also updating al2022 when it should have only been updating the al2 ones. This is because the image tags are the same between the two.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
