### PR TITLE
distro-base: update al2022 tags and fix export

### DIFF
--- a/EKS_DISTRO_TAG_FILE.yaml
+++ b/EKS_DISTRO_TAG_FILE.yaml
@@ -11,14 +11,14 @@ al2:
   eks-distro-minimal-base-nginx: 2022-03-09-1646784337.2
   eks-distro-minimal-base-git: 2022-03-11-1647025246.2
 al2022:
-  eks-distro-base: 2022-03-11-1647025246.2022
+  eks-distro-base: 2022-03-12-1647092610.2022
   eks-distro-minimal-base: 2022-03-09-1646784337.2022
   eks-distro-minimal-base-nonroot: 2022-03-09-1646784337.2022
   eks-distro-minimal-base-glibc: 2022-03-09-1646784337.2022
   eks-distro-minimal-base-iptables: 2022-03-09-1646784337.2022
   eks-distro-minimal-base-docker-client: 2022-03-09-1646784337.2022
-  eks-distro-minimal-base-csi: 2022-03-11-1647025246.20222
-  eks-distro-minimal-base-haproxy: rebuild
-  eks-distro-minimal-base-kind: rebuild
+  eks-distro-minimal-base-csi: 2022-03-12-1647092610.2022
+  eks-distro-minimal-base-haproxy: 2022-03-12-1647092610.2022
+  eks-distro-minimal-base-kind: 2022-03-12-1647092610.2022
   eks-distro-minimal-base-nginx: 2022-03-09-1646784337.2022
-  eks-distro-minimal-base-git: 2022-03-11-1647025246.2022
+  eks-distro-minimal-base-git: 2022-03-12-1647092610.2022

--- a/eks-distro-base/Makefile
+++ b/eks-distro-base/Makefile
@@ -34,8 +34,8 @@ PLATFORMS?=linux/amd64,linux/arm64
 MAKE_ROOT=$(shell cd "$(shell dirname "${BASH_SOURCE[0]}")" && pwd -P)
 
 MINIMAL_VARIANTS=base base-nonroot base-glibc base-iptables base-csi base-git base-docker-client base-nginx base-haproxy base-kind
-IMAGE_TARGETS=base-images $(addprefix minimal-images-, $(MINIMAL_VARIANTS)) export-minimal-images
-UPDATE_TARGETS=base-update $(addprefix minimal-update-, $(MINIMAL_VARIANTS)) export-minimal-images
+IMAGE_TARGETS=base-images $(addprefix minimal-images-, $(MINIMAL_VARIANTS))
+UPDATE_TARGETS=base-update $(addprefix minimal-update-, $(MINIMAL_VARIANTS))
 CREATE_PR_TARGETS=base-create-pr $(addprefix minimal-create-pr-, $(MINIMAL_VARIANTS))
 
 BASE_IMAGE_NAME?=eks-distro-base

--- a/eks-distro-base/Makefile
+++ b/eks-distro-base/Makefile
@@ -37,7 +37,6 @@ MINIMAL_VARIANTS=base base-nonroot base-glibc base-iptables base-csi base-git ba
 IMAGE_TARGETS=base-images $(addprefix minimal-images-, $(MINIMAL_VARIANTS)) export-minimal-images
 UPDATE_TARGETS=base-update $(addprefix minimal-update-, $(MINIMAL_VARIANTS)) export-minimal-images
 CREATE_PR_TARGETS=base-create-pr $(addprefix minimal-create-pr-, $(MINIMAL_VARIANTS))
-EXPORT_TARGETS=$(addprefix export-minimal-images-, $(MINIMAL_VARIANTS))
 
 BASE_IMAGE_NAME?=eks-distro-base
 BUILDER_IMAGE_NAME?=eks-distro-base
@@ -123,6 +122,7 @@ base-%:
 minimal-images-%:
 	$(MAKE) images-minimal-$* VARIANT=minimal-$* IMAGE_TARGET=$* PLATFORMS=$(PLATFORMS)
 	$(MAKE) images-minimal-$*-builder VARIANT=minimal-$* IMAGE_TARGET=$*-builder PLATFORMS=$(PLATFORMS) IMAGE_NAME=eks-distro-minimal-$*-builder 
+	$(MAKE) export-minimal-images-$* VARIANT=minimal-$* IMAGE_TARGET=$* PLATFORMS=$(PLATFORMS)
 
 .PHONY: export-minimal-images-%
 export-minimal-images-%:
@@ -131,8 +131,6 @@ export-minimal-images-%:
 		$(MAKE) images-minimal-$* VARIANT=minimal-$* IMAGE_TARGET=$*-export PLATFORMS=$(PLATFORMS) BUILDKIT_OUTPUT="type=local,dest=$(MAKE_ROOT)/../eks-distro-base-minimal-packages/$(AL_TAG)"; \
 	fi
 
-.PHONY: export-minimal-images
-export-minimal-images: $(EXPORT_TARGETS)
 
 # for local development only
 .PHONY: minimal-base-test


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

In the latest run the export targets ended up triggering full builds even though they should have used cached layers.  I believe now that we have the garbage collecting turned on, these cached layers are getting cleaned up during building other images.  This moves exporting to happen right after building to try and avoid this.

Also updated to the built tags for al2022.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
