### PR TITLE
distro-base-kind: add jq and lockdev

### DIFF
--- a/EKS_DISTRO_TAG_FILE.yaml
+++ b/EKS_DISTRO_TAG_FILE.yaml
@@ -7,7 +7,7 @@ al2:
   eks-distro-minimal-base-docker-client: 2022-03-09-1646784337.2
   eks-distro-minimal-base-csi: 2022-03-16-1647457250.2
   eks-distro-minimal-base-haproxy: 2022-03-16-1647457250.2
-  eks-distro-minimal-base-kind: 2022-03-16-1647457250.2
+  eks-distro-minimal-base-kind: rebuild
   eks-distro-minimal-base-nginx: 2022-03-16-1647457250.2
   eks-distro-minimal-base-git: 2022-03-16-1647457250.2
 al2022:
@@ -19,6 +19,6 @@ al2022:
   eks-distro-minimal-base-docker-client: 2022-03-09-1646784337.2022
   eks-distro-minimal-base-csi: 2022-03-12-1647092610.2022
   eks-distro-minimal-base-haproxy: 2022-03-12-1647092610.2022
-  eks-distro-minimal-base-kind: 2022-03-12-1647092610.2022
+  eks-distro-minimal-base-kind: rebuild
   eks-distro-minimal-base-nginx: 2022-03-09-1646784337.2022
   eks-distro-minimal-base-git: 2022-03-12-1647092610.2022

--- a/eks-distro-base/Dockerfile.minimal-base-kind
+++ b/eks-distro-base/Dockerfile.minimal-base-kind
@@ -45,7 +45,7 @@ RUN set -x && \
     clean_install coreutils && \
     clean_install findutils && \
     install_if_al2 amazon-linux-extras && \    
-    clean_install "containerd curl ethtool hostname iproute nfs-utils pigz procps rsync libseccomp socat systemd tar udev util-linux which yum" && \
+    clean_install "containerd curl ethtool hostname iproute jq lockdev nfs-utils pigz procps rsync libseccomp socat systemd tar util-linux which yum" && \
     cleanup "kind"
 
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Newer version of kind adds jq and removes udev.  lockdev is being added to fix the tmp files cleanup service due a missing user group which the lockdev package creates.

/hold

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
