### PR TITLE
distro-base: bail out early if a update PR already exists

### DIFF
--- a/eks-distro-base/Makefile
+++ b/eks-distro-base/Makefile
@@ -200,11 +200,15 @@ create-pr: $(CREATE_PR_TARGETS)
 	$(MAKE_ROOT)/../pr-scripts/create_pr.sh eks-distro-build-tooling 'EKS_DISTRO*_TAG_FILE*'
 
 .PHONY: update
-update: buildkit-check $(UPDATE_TARGETS)
+update: buildkit-check open-pr-check $(UPDATE_TARGETS)
 
 .PHONY: update-base-image-other-repos
 update-base-image-other-repos:
 	./update_base_image_other_repos.sh
+
+.PHONY: open-pr-check
+open-pr-check:
+	$(MAKE_ROOT)/../pr-scripts/open_pr_check.sh eks-distro-build-tooling
 
 .PHONY: all
 all: release

--- a/pr-scripts/open_pr_check.sh
+++ b/pr-scripts/open_pr_check.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+set -e
+set -o pipefail
+set -x
+
+REPO="$1"
+
+SCRIPT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+
+if [ "$JOB_TYPE" != "periodic" ]; then
+    exit 0
+fi
+
+if [ $REPO_OWNER = "aws" ]; then
+    ORIGIN_ORG="eks-distro-pr-bot"
+else
+    ORIGIN_ORG=$REPO_OWNER
+fi
+
+cd ${SCRIPT_ROOT}/../../../${ORIGIN_ORG}/${REPO}
+
+PR_BRANCH="image-tag-update"
+
+gh auth login --with-token < /secrets/github-secrets/token
+
+PR_EXISTS=$(gh pr list | grep -c "${PR_BRANCH}" || true)
+if [ $PR_EXISTS -eq 1 ]; then
+    echo "There is an existing PR already open, please merge/close before building new images!"
+    exit 1
+fi


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

To avoid building new images day after day if an update PR is missed and left open, bail out if the PR already exists.  This happened the last time we had a periodic update and the images were built twice, 2 days in a row, because we did not merge the PR in time.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
