### PR TITLE
Add pod-level permissions to Prow Sinker role

### DIFF
--- a/helm-charts/patches/prow-control-plane/0001-EKS-D-changes-to-helm-control-plane-chart.patch
+++ b/helm-charts/patches/prow-control-plane/0001-EKS-D-changes-to-helm-control-plane-chart.patch
@@ -20,13 +20,13 @@ Signed-off-by: Prow Bot <prow@amazonaws.com>
  .../prow_controller_manager_deployment.yaml   |  70 ++++++++----
  .../cluster/prow_controller_manager_rbac.yaml |  41 ++-----
  config/prow/cluster/sinker_deployment.yaml    |  63 ++++++-----
- config/prow/cluster/sinker_rbac.yaml          |  37 +------
+ config/prow/cluster/sinker_rbac.yaml          |  39 ++-----
  .../cluster/statusreconciler_deployment.yaml  |  30 ++++--
  .../prow/cluster/statusreconciler_rbac.yaml   |   6 +-
  config/prow/cluster/tide_deployment.yaml      |  38 +++++--
  config/prow/cluster/tide_rbac.yaml            |   8 +-
  config/prow/cluster/tide_service.yaml         |  11 +-
- 20 files changed, 345 insertions(+), 381 deletions(-)
+ 20 files changed, 350 insertions(+), 378 deletions(-)
 
 diff --git a/config/prow/cluster/crier_deployment.yaml b/config/prow/cluster/crier_deployment.yaml
 index b11bc0d729..70c9233295 100644
@@ -1182,7 +1182,7 @@ index 06478745c6..1d4a89a55e 100644
 +          defaultMode: 0644
 +          secretName: kubeconfig
 diff --git a/config/prow/cluster/sinker_rbac.yaml b/config/prow/cluster/sinker_rbac.yaml
-index 70eb9b52bc..d8d6842e19 100644
+index 70eb9b52bc..87f30fe1d2 100644
 --- a/config/prow/cluster/sinker_rbac.yaml
 +++ b/config/prow/cluster/sinker_rbac.yaml
 @@ -1,13 +1,13 @@
@@ -1201,21 +1201,24 @@ index 70eb9b52bc..d8d6842e19 100644
    name: "sinker"
  rules:
    - apiGroups:
-@@ -51,40 +51,9 @@ rules:
+@@ -50,41 +50,18 @@ rules:
+     - events
      verbs:
      - create
- ---
+----
 -kind: Role
 -apiVersion: rbac.authorization.k8s.io/v1
 -metadata:
 -  namespace: test-pods
 -  name: "sinker"
 -rules:
--  - apiGroups:
+   - apiGroups:
 -      - ""
--    resources:
++    - ""
+     resources:
 -      - pods
--    verbs:
++    - pods
+     verbs:
 -      - delete
 -      - list
 -      - watch
@@ -1234,7 +1237,10 @@ index 70eb9b52bc..d8d6842e19 100644
 -subjects:
 -- kind: ServiceAccount
 -  name: "sinker"
-----
++    - get
++    - list
++    - watch
+ ---
  kind: RoleBinding
  apiVersion: rbac.authorization.k8s.io/v1
  metadata:
@@ -1242,7 +1248,7 @@ index 70eb9b52bc..d8d6842e19 100644
    name: "sinker"
  roleRef:
    apiGroup: rbac.authorization.k8s.io
-@@ -93,4 +62,4 @@ roleRef:
+@@ -93,4 +70,4 @@ roleRef:
  subjects:
  - kind: ServiceAccount
    name: "sinker"

--- a/helm-charts/stable/prow-control-plane/Chart.yaml
+++ b/helm-charts/stable/prow-control-plane/Chart.yaml
@@ -29,7 +29,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.27
+version: 1.0.28
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.


### PR DESCRIPTION
The Controlplane sinker role needs these permissions to delete pods on the dataplane clusters.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
