### PR TITLE
Add list of build log regexes for highlighting

### DIFF
--- a/helm-charts/stable/prow-control-plane/Chart.yaml
+++ b/helm-charts/stable/prow-control-plane/Chart.yaml
@@ -29,7 +29,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.29
+version: 1.0.30
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/helm-charts/stable/prow-control-plane/templates/config-ConfigMap.yaml
+++ b/helm-charts/stable/prow-control-plane/templates/config-ConfigMap.yaml
@@ -55,6 +55,42 @@ data:
           - ^artifacts/filtered\.html$
         - lens:
             config:
+              highlight_regexes:
+              - Automatic merge failed
+              - cannot convert.+to type
+              - "cannot use.+as.+(type|value)"
+              - cannot find package
+              - Command failed
+              - curl.+Failed to connect
+              - curl.+no URL specified
+              - ^E\d{4} \d\d:\d\d:\d\d\.\d+
+              - ERR
+              - "(Error|ERROR|error)s?:"
+              - Error is not recoverable
+              - exit (status)?
+              - failed|FAILED"
+              - failed to solve
+              - (FAIL|Failure \[)\b
+              - fatal|FATAL
+              - Traceback
+              - got.+want
+              - imported but not used
+              - "make:.+Error"
+              - Merge conflict
+              - No such file or directory
+              - panic\b
+              - Process did not finish before.+timeout
+              - sha256sum.+did NOT match
+              - Something went wrong
+              - too few arguments
+              - too many errors
+              - "[Tt]imed out"
+              - timeout
+              - type.+has no field
+              - "undefined:"
+              - Unable to connect to the server
+              - "[Uu]nexpected error"
+              - want.+got
             name: buildlog
           required_files:
           - build-log.txt


### PR DESCRIPTION
This will make it easier to spot the errors in Prow build logs in Spyglass.

This list includes error messages across different scenarios such as Go compilation, unit tests, bash scripts, shasum checks, git workflows and other generic formats.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
