### PR TITLE
Set dry-run flag to false for Sinker

### DIFF
--- a/helm-charts/Makefile
+++ b/helm-charts/Makefile
@@ -18,7 +18,7 @@ publish: prepare-prow-control-plane
 
 release: install-toolchain publish
 
-clean:
+clean: clean-test-infra
 	rm -rf ${CHART_ROOT}/build/
 
 help:

--- a/helm-charts/Prow.mk
+++ b/helm-charts/Prow.mk
@@ -26,3 +26,6 @@ $(GIT_PATCH_TARGET): $(GIT_CHECKOUT_TARGET)
 # Copy only template files we care about from upstream into place
 prepare-prow-control-plane: $(GIT_PATCH_TARGET)
 	rsync -a $(PROW_UPSTREAM_REPO)/config/prow/cluster --files-from=$(CHART_ROOT)/scripts/prow-control-plane-upstream-template-files $(CHART_ROOT)/stable/prow-control-plane/templates
+
+clean-test-infra:
+	rm -rf $(CHART_ROOT)/$(PROW_UPSTREAM_REPO)

--- a/helm-charts/patches/prow-control-plane/0001-EKS-D-changes-to-helm-control-plane-chart.patch
+++ b/helm-charts/patches/prow-control-plane/0001-EKS-D-changes-to-helm-control-plane-chart.patch
@@ -2,7 +2,7 @@ From 77f5ccfc298b963d34d048dfe4c920c911d0f46e Mon Sep 17 00:00:00 2001
 From: Jackson West <jgw@amazon.com>
 Date: Fri, 25 Feb 2022 12:37:01 -0600
 Subject: [PATCH] EKS-D changes to helm control plane chart
-
+ 
 Signed-off-by: Jackson West <jgw@amazon.com>
 Signed-off-by: Prow Bot <prow@amazonaws.com>
 ---
@@ -19,14 +19,14 @@ Signed-off-by: Prow Bot <prow@amazonaws.com>
  config/prow/cluster/horologium_rbac.yaml      |   6 +-
  .../prow_controller_manager_deployment.yaml   |  70 ++++++++----
  .../cluster/prow_controller_manager_rbac.yaml |  41 ++-----
- config/prow/cluster/sinker_deployment.yaml    |  63 ++++++-----
+ config/prow/cluster/sinker_deployment.yaml    |  64 ++++++-----
  config/prow/cluster/sinker_rbac.yaml          |  39 ++-----
  .../cluster/statusreconciler_deployment.yaml  |  30 ++++--
  .../prow/cluster/statusreconciler_rbac.yaml   |   6 +-
  config/prow/cluster/tide_deployment.yaml      |  38 +++++--
  config/prow/cluster/tide_rbac.yaml            |   8 +-
  config/prow/cluster/tide_service.yaml         |  11 +-
- 20 files changed, 350 insertions(+), 378 deletions(-)
+ 20 files changed, 351 insertions(+), 378 deletions(-)
 
 diff --git a/config/prow/cluster/crier_deployment.yaml b/config/prow/cluster/crier_deployment.yaml
 index b11bc0d729..70c9233295 100644
@@ -1081,7 +1081,7 @@ index 1cace54354..5329eff3bf 100644
 -  namespace: default
 +  namespace: {{ .Release.Namespace }}
 diff --git a/config/prow/cluster/sinker_deployment.yaml b/config/prow/cluster/sinker_deployment.yaml
-index 06478745c6..1d4a89a55e 100644
+index 06478745c6..d707f54b13 100644
 --- a/config/prow/cluster/sinker_deployment.yaml
 +++ b/config/prow/cluster/sinker_deployment.yaml
 @@ -1,7 +1,6 @@
@@ -1092,7 +1092,7 @@ index 06478745c6..1d4a89a55e 100644
    name: sinker
    labels:
      app: sinker
-@@ -12,49 +11,65 @@ spec:
+@@ -12,49 +11,66 @@ spec:
        app: sinker
    template:
      metadata:
@@ -1128,6 +1128,7 @@ index 06478745c6..1d4a89a55e 100644
 -        ports:
 -        - name: metrics
 -          containerPort: 9090
++        - --dry-run={{ .Values.dryRun }}
 +        image: {{ .Values.sinker.image }}
          volumeMounts:
 -        - mountPath: /etc/kubeconfig

--- a/helm-charts/stable/prow-control-plane/Chart.yaml
+++ b/helm-charts/stable/prow-control-plane/Chart.yaml
@@ -29,7 +29,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.30
+version: 1.0.31
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.


### PR DESCRIPTION
Not setting this caused Sinker to run in dry-run mode where it did not delete any pods although logs claimed it was.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
