### PR TITLE
builder-base: install go-licenses with 1.17 too

### DIFF
--- a/builder-base/install.sh
+++ b/builder-base/install.sh
@@ -216,7 +216,9 @@ rm -rf packer_${PACKER_VERSION}_linux_$TARGETARCH.zip
 # to symlink to the one in /root/sdk due to ensure go-licenses gets built
 # with goroot pointed to /root/sdk/go... instead of /usr/local/go to its able
 # to properly find core go packages
-GO111MODULE=on go get github.com/google/go-licenses@v1.0.0
+# we currently will use 1.17 or 1.16 so install for both
+GO111MODULE=on /go/go1.16/bin/go get github.com/google/go-licenses@v1.0.0
+GO111MODULE=on /go/go1.17/bin/go get github.com/google/go-licenses@v1.0.0 
 
 # linuxkit is used by tinkerbell/hook for building an operating system installation environment (osie)
 # We need a higher version of linuxkit hence we do go get of a particular commit


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Projects are now depending on 1.17 syntax which 1.16 can not parse.  I ran into this updating the kustomize-controller. The exact error is:

`github.com/hashicorp/vault/sdk/version: vendor/github.com/hashicorp/vault/sdk/helper/pluginutil/run_config.go:13:2: //go:build comment without // +build comment`

We have been always using go 1.16 when running go list and gather-licenses because of the way go-licenses finds the dependencies it needs to be installed via the version of go that is currently highest in the path when running.  Now that we have projects using 1.17 we need to support using go-licenses installed with both 1.16 and 1.17.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
