### PR TITLE
distro-base: Adds new install_binary scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 
 .PHONY: run-buildkit-and-registry
 run-buildkit-and-registry:
-	docker run -d --name buildkitd --net host --privileged moby/buildkit:v0.9.3-rootless
+	docker run -d --name buildkitd --net host --privileged moby/buildkit:v0.10.3-rootless
 	docker run -d --name registry  --net host registry:2
 
 .PHONY: stop-buildkit-and-registry

--- a/eks-distro-base/Dockerfile.minimal-base-git
+++ b/eks-distro-base/Dockerfile.minimal-base-git
@@ -42,7 +42,8 @@ RUN set -x && \
     # do not need openssh, just the clients for git to fork (ssh)
     # rpm comes from openlbdap/nss but we only need the libs
     clean_install "less openssh rpm systemd" true true && \
-    clean_install "git-core libssh2 libgit2 openssh-clients openssl-libs gnupg" && \
+    clean_install "git-core libssh2 openssh-clients openssl-libs gnupg" && \
+    install_if_al2022 "libgit2" && \
     remove_package "less openssh rpm systemd" true && \
     # we are keeping bash on this image since downstream images use to exec git
     remove_package "coreutils findutils gawk grep info sed" && \

--- a/eks-distro-base/Dockerfile.minimal-helpers
+++ b/eks-distro-base/Dockerfile.minimal-helpers
@@ -33,12 +33,17 @@ RUN set -x && \
     find . -type f -follow -printf '%s\t/%P\n' | numfmt --field=1 --to=iec-i --padding=8 --suffix=B | sort -k 2 > /tmp/packages/$VARIANT-files
 
 FROM scratch as export
-COPY --from=prepare-export /tmp/packages/* .
+
+ARG VARIANT
+
+COPY --from=prepare-export /tmp/packages/$VARIANT* .
 
 
 ################ Validate #######################
 ARG BUILT_BUILDER_IMAGE
 FROM --platform=$BUILDPLATFORM ${BUILT_BUILDER_IMAGE} as run_validate
+
+COPY scripts/ /usr/bin
 
 RUN set -x && \
     validate_libraries && \

--- a/eks-distro-base/scripts/clean_docs
+++ b/eks-distro-base/scripts/clean_docs
@@ -24,7 +24,7 @@ mkdir -p $NEWROOT/usr/share/{doc,man}
 for i in {1..2}; do
     find $NEWROOT/usr/share/{doc,man} \( -xtype l -o -type f \) \
         ! \( -iname '*lice*' -o -iname '*copy*' -o -iname '*gpl*' -o -iname '*not*' -o -iname "*credits*" \) \
-        -delete -print
+        -delete
 done
 
 find $NEWROOT/usr/share/{doc,man} -type d -empty -delete

--- a/eks-distro-base/scripts/clean_install
+++ b/eks-distro-base/scripts/clean_install
@@ -22,6 +22,10 @@ PACKAGES=$1
 SHALLOW=${2:false}
 JUSTDB=${3:false}
 FORCE=${4:false}
+EXTRACT_DIR=${5:-"$NEWROOT"}
+
+SCRIPT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+source "${SCRIPT_ROOT}/eks-d-common"
 
 if [ $JUSTDB ]; then
     JUSTDB="--justdb"
@@ -29,14 +33,24 @@ else
     JUSTDB=""
 fi
 
-if [ ! $SHALLOW ]; then
-    yum --installroot $NEWROOT install -y $PACKAGES
-else
-    yumdownloader --destdir=$DOWNLOAD_DIR -x "*.i686" $PACKAGES
-    rpm -ivh --nodeps --root $NEWROOT $JUSTDB $DOWNLOAD_DIR/*.rpm
-    if [ $FORCE ]; then
-        for rpm in $DOWNLOAD_DIR/*.rpm; do rpm2cpio $rpm | cpio -idmv; done
+RPMS=(${PACKAGES// / })
+for rpm in "${RPMS[@]}"; do
+    # if installed already skip
+    if rpm --root $NEWROOT -q --quiet $rpm ; then
+        continue
     fi
-fi
 
-rm -rf $DOWNLOAD_DIR
+    if [ ! $SHALLOW ]; then
+        yum --installroot $NEWROOT install -y $rpm
+    else
+        yumdownloader --destdir=$DOWNLOAD_DIR -x "*.i686" $rpm
+        rpm_file=$(ls $DOWNLOAD_DIR/$rpm-*.rpm)
+        rpm -ivh --nodeps --root $NEWROOT $JUSTDB $rpm_file
+        if [ $FORCE ]; then
+            mkdir -p $EXTRACT_DIR
+            pushd $EXTRACT_DIR
+            rpm2cpio $rpm_file | cpio -idm
+            popd
+        fi
+    fi
+done

--- a/eks-distro-base/scripts/cleanup
+++ b/eks-distro-base/scripts/cleanup
@@ -23,7 +23,7 @@ VARIANT="$1"
 clean_docs $NEWROOT
 
 clean_yum
-rm -rf $DOWNLOAD_DIR $NEWROOT/var/lib/yum
+rm -rf $DOWNLOAD_DIR $NEWROOT/var/lib/yum $NEWROOT/var/log/*.log
 
 # al2202 build includes this folder during some rpm installs, removing since its a bad symlink
 rm -rf $NEWROOT/usr/lib/.build-id

--- a/eks-distro-base/scripts/eks-d-common
+++ b/eks-distro-base/scripts/eks-d-common
@@ -15,11 +15,21 @@
 
 declare -A PROVIDES_CACHE=()
 
-NEWROOT_LD_LIBRARY_PATH="$NEWROOT/lib64:$NEWROOT/usr/lib64" 
+NEWROOT_LD_LIBRARY_PATH="$NEWROOT/lib64:$NEWROOT/usr/lib64:$NEWROOT/usr/lib" 
 for sub_dir in $(find $NEWROOT/usr/lib64 $NEWROOT/lib64 $NEWROOT/usr/lib -mindepth 1 -maxdepth 1 -type d); do
     NEWROOT_LD_LIBRARY_PATH="$sub_dir:$NEWROOT_LD_LIBRARY_PATH"
 done
-NEWROOT_LD_LIBRARY_PATH=$NEWROOT_LD_LIBRARY_PATH
+
+function build::common::yum_provides() {
+    local -r bin=$1  
+    
+    # if key exists, 1 is returned which would resolve to true
+    if [ ! ${PROVIDES_CACHE[$bin]+1} ]; then
+        PROVIDES_CACHE[$bin]=$(yum provides "${bin}" 2>&1)
+    fi
+
+    echo "${PROVIDES_CACHE[$bin]}"
+}
 
 pushd () {
     command pushd "$@" > /dev/null
@@ -33,7 +43,7 @@ popd () {
 # returns list of libs required by a dynamic binary
 function build::common::binary_to_libraries() {
     # see: https://man7.org/linux/man-pages/man1/ldd.1.html
-    LD_LIBRARY_PATH=$NEWROOT_LD_LIBRARY_PATH ldd "${1}" \
+    LD_LIBRARY_PATH=$NEWROOT_LD_LIBRARY_PATH ldd "${1}" 2>&1 \
     `# strip the leading '${name} => ' if any so only '/lib-foo.so (0xf00)' remains` \
     | sed -E 's#.* => /#/#' \
     `# we want only the path remaining, not the (0x${LOCATION})` \
@@ -46,11 +56,54 @@ function build::common::binary_to_libraries() {
 
 function build::common::is_dynamic_binary() {
     local -r bin="$1"
+    local -r ldd_out="$(build::common::binary_to_libraries $bin)"
     if [ ! -x "$bin" ] || \
-        [ "$(build::common::binary_to_libraries $bin)" = "not" ] || [ "$(build::common::binary_to_libraries $bin)" = "statically" ]; then
+        [[ $ldd_out = not* ]] || [[ $ldd_out = statically* ]]; then
         return 1
     fi
     return 0
+}
+
+function build::common::find_actual_file_for_provides() {
+    local -r file="$1"
+    
+    local to_check=()
+    if [[ $file = /* ]]; then
+        # on al22 some libs are at /lib64 but will not return unless passed to yum provides as /usr/lib64
+        to_check+=($(realpath $file));
+    else
+        # on arm, yum provides will not return results when given incomplete file path
+        #which a number of these libs will be since if ldd cant find them, it will return just the filename
+        to_check+=("$file" "/usr/lib64/$file")
+    fi
+    local actual_file=${to_check[0]}
+    for f in ${to_check[@]}; do
+        if build::common::yum_provides "${f}" | tr '\n' ' ' | grep --quiet -vi "No Matches found"; then
+            actual_file=$f
+            break
+        fi
+    done
+
+    echo $actual_file
+}
+
+function build::common::rpm_package_for_binary() {
+    # response from yum will be a list of various versions of the package which provides given file
+    # this list appears to be ordered with most recent at the end
+    # ex:
+    # e2fsprogs-1.42.9-19.amzn2.x86_64 : Utilities for managing ext2, ext3, and ext4 filesystems
+    # Repo        : amzn2-core
+    # Matched from:
+    # Filename    : /usr/sbin/fsck.ext3
+  
+    actual_file="$(build::common::find_actual_file_for_provides $1)"
+    build::common::yum_provides "${actual_file}"| grep "x86_64\|aarch64\|i686 :" | awk '{print $1}' | tail -n 1 | sed -e 's/^[0-9]://' | sed -e 's/\-[0-9].*$//'
+}
+
+function build::common::filename_from_rpm() {
+    # matches filename part of yum provides output to validate supplied filename matches actual
+    actual_file="$(build::common::find_actual_file_for_provides $1)"
+    build::common::yum_provides "${actual_file}" | grep "Filename" | awk '{print $3}' | tail -n 1
 }
 
 function build::common::dep_exists() {

--- a/eks-distro-base/scripts/install_binary
+++ b/eks-distro-base/scripts/install_binary
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+set -o pipefail
+set -x
+
+SCRIPT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+source "${SCRIPT_ROOT}/eks-d-common"
+
+
+function build::install::binary() {
+    local -r file="$1"
+    local __result=$2
+
+    local -r rpm_package=$(build::common::rpm_package_for_binary $file)
+    local -r expected_filename=$(build::common::filename_from_rpm $file)
+
+    if [ -z "$rpm_package" ]; then
+        echo "Error: RPM not found for $file!"
+        exit 1
+    fi
+
+    if [[ "$expected_filename" != "$file" ]]; then
+        echo "Warning: Provided filename does not match actual: $file != $expected_filename"
+    fi
+
+    local -r extract_dir=$DOWNLOAD_DIR/$rpm_package
+
+    echo "Extracting $rpm_package for $file"
+    # download and extract rpm as well as add to the final rpm db which will be included in the final image
+    clean_install $rpm_package true true true $extract_dir
+
+    local -r extracted_bin=$extract_dir$expected_filename
+
+    if [ ! -f "$extracted_bin" ]; then
+        echo "Error: Filename not included in RPM!"
+        exit 1
+    fi
+
+    # copy desired binary into newroot folder path
+    local -r final_bin=$NEWROOT$expected_filename
+    cp $extracted_bin $final_bin
+
+    build::install::configs_and_licenses $extract_dir
+
+    eval $__result="'$final_bin'"
+}
+
+function build::install::configs_and_licenses() {
+    local -r extract_dir="$1"
+
+    # this is probably not perfect, but try and perserve any txt files, like conf files which may be neccessary
+    # for the exec being copied.
+    # also grabs licenses files
+    cp -rf $extract_dir/etc $NEWROOT 2>/dev/null || :
+    cp -rf $extract_dir/usr/share/{doc,man,licenses} $NEWROOT/usr/share 2>/dev/null || :
+}
+
+
+for file in "$@"; do
+    build::install::binary $file installed_bin
+
+    install_deps_for_binary $installed_bin
+done

--- a/eks-distro-base/scripts/install_deps_for_binary
+++ b/eks-distro-base/scripts/install_deps_for_binary
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+set -o pipefail
+set -x
+
+SCRIPT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+source "${SCRIPT_ROOT}/eks-d-common"
+
+function build::install::deps() {
+    local -r bin="$1"
+
+    local installing=1
+    local rpm_package=""
+    while [[ $installing == 1 ]] ; do
+        installing=0
+        while IFS= read -r dep; do
+            if build::common::dep_exists $dep; then
+                continue
+            fi
+            
+            rpm_package=$(build::common::rpm_package_for_binary $dep)
+
+            if [[ -z "$rpm_package" ]]; then
+                echo "Error: No rpm found for $dep!"
+                exit 1
+            fi
+
+            echo "Installing $rpm_package for $dep"
+            # install rpm with but do not install rpm dependencies, library deps will all be picked up
+            # by this ldd parse
+            clean_install $rpm_package true
+
+            installing=1
+
+        done < <(build::common::binary_to_libraries "$bin")
+    done
+}
+
+for installed_bin in "$@"; do
+    if ! build::common::is_dynamic_binary $installed_bin; then
+        continue
+    fi
+
+    build::install::deps $installed_bin
+done


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This PR sets up for future minimal images which are more tailored for the exact use case.  For ex, the ebs csi driver team has asked us to help them with a minimal image for them.  The ebs csi driver has a set of known exec's that it will exec out to and ideally we could build an image with those execs and their required libraries.  We could also look at using this approach for some of our existing images, like nginx + haproxy + docker-client, to clean up those dockerfiles. 

*Note* This PR only includes to the scripts to keep the PR as small as possible and properly document this new approach.  I have tested a ebs csi driver image with the ebs team using these scripts to validate it passes their e2e suite.

To review the existing design: https://github.com/aws/eks-distro-build-tooling/tree/main/eks-distro-base#design

The key new script here `install_binary` which takes one or more binaries as input.  For each binary supplied, `yum provides` is called to determine which yum package we should download to get the binary from.  This method seems fairly consistent, there have been a few gotchas related to needing the full path when calling provides or in some cases needing not a full path, both overall this seems like a reasonable option.

Once the rpm is determined, it is downloaded and extracted to a tmp folder.  The desired binary is then copied into place in the /newroot folder.  `ldd` is run against the binary to determine which libraries are needed in the resulting image.  For each of these libraries, yum provides is again used to determine the correct rpm to install.  These rpms are installed as is, instead of trying to limit them down, since in general lib rpms just have the expected libs.  A future enhancement could be to look at only pulling over the libraries that are needed.

For each rpm, be it fully installed or just certain binaries are pulled out, a record is created in the rpm db which is included in the final image.  By providing this rpm db in the image, scanners such as ECR can correctly identify the packages that make up the image.  

Once the image is created, there is separate "build" that runs which validates the installed binaries in the final image, using a similar ldd process to confirm the needed libraries are included.

EBS CSI: https://github.com/aws/eks-distro-build-tooling/pull/398
Docker client: https://github.com/aws/eks-distro-build-tooling/pull/399
Haproxy: https://github.com/aws/eks-distro-build-tooling/pull/400

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
