### PR TITLE
distro-base: fix validate_libraries

### DIFF
--- a/eks-distro-base/Dockerfile.minimal-base-haproxy
+++ b/eks-distro-base/Dockerfile.minimal-base-haproxy
@@ -52,7 +52,7 @@ RUN set -x && \
     # manually "install" systemd to avoid installing the entire dep tree
     clean_install systemd true true && \
     install_if_al2 libcrypt && \
-    install_if_al2022 "libxcrypt-compat pcre2" && \
+    install_if_al2022 "libxcrypt-compat libselinux pcre2 pcre" && \
     # libacl is needed for cp + mkdir
     clean_install "libacl $HAPROXY_DEPS" && \
     # remove unncessary utils and other binary deps that are not needed by haproxy during runtime

--- a/eks-distro-base/scripts/eks-d-common
+++ b/eks-distro-base/scripts/eks-d-common
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+declare -A PROVIDES_CACHE=()
+
+NEWROOT_LD_LIBRARY_PATH="$NEWROOT/lib64:$NEWROOT/usr/lib64" 
+for sub_dir in $(find $NEWROOT/usr/lib64 $NEWROOT/lib64 $NEWROOT/usr/lib -mindepth 1 -maxdepth 1 -type d); do
+    NEWROOT_LD_LIBRARY_PATH="$sub_dir:$NEWROOT_LD_LIBRARY_PATH"
+done
+NEWROOT_LD_LIBRARY_PATH=$NEWROOT_LD_LIBRARY_PATH
+
+pushd () {
+    command pushd "$@" > /dev/null
+}
+
+popd () {
+    command popd "$@" > /dev/null
+}
+
+# From: https://github.com/kubernetes-sigs/kind/blob/main/images/haproxy/stage-binary-and-deps.sh 
+# returns list of libs required by a dynamic binary
+function build::common::binary_to_libraries() {
+    # see: https://man7.org/linux/man-pages/man1/ldd.1.html
+    LD_LIBRARY_PATH=$NEWROOT_LD_LIBRARY_PATH ldd "${1}" \
+    `# strip the leading '${name} => ' if any so only '/lib-foo.so (0xf00)' remains` \
+    | sed -E 's#.* => /#/#' \
+    `# we want only the path remaining, not the (0x${LOCATION})` \
+    | awk '{print $1}' \
+    `# linux-vdso.so.1 is a special virtual shared object from the kernel` \
+    `# see: http://man7.org/linux/man-pages/man7/vdso.7.html` \
+    | grep -v 'linux-vdso.so.1'
+
+}
+
+function build::common::is_dynamic_binary() {
+    local -r bin="$1"
+    if [ ! -x "$bin" ] || \
+        [ "$(build::common::binary_to_libraries $bin)" = "not" ] || [ "$(build::common::binary_to_libraries $bin)" = "statically" ]; then
+        return 1
+    fi
+    return 0
+}
+
+function build::common::dep_exists() {
+    local -r dep="$1"
+
+    # ldd return the dep that exists in the newroot folder, nothing to do
+    if [[ $dep = $NEWROOT/* ]] && [ -f "$dep" ]; then
+        return 0
+    fi
+
+    # the dep also exists in the newroot folder, nothing to do
+    if [ -f "$NEWROOT$dep" ]; then
+        return 0
+    fi
+
+    return 1
+}

--- a/eks-distro-base/scripts/validate_libraries
+++ b/eks-distro-base/scripts/validate_libraries
@@ -16,44 +16,24 @@
 set -e
 set -o pipefail
 
-NEWROOT_LD_LIBRARY_PATH="/newroot/lib64:/newroot/usr/lib64" 
-for sub_dir in $(find /newroot/usr/lib64 /newroot/lib64 -mindepth 1 -maxdepth 1 -type d); do
-    NEWROOT_LD_LIBRARY_PATH="$sub_dir:$NEWROOT_LD_LIBRARY_PATH"
-done
-
-# From: https://github.com/kubernetes-sigs/kind/blob/main/images/haproxy/stage-binary-and-deps.sh 
-binary_to_libraries() {
-    # see: https://man7.org/linux/man-pages/man1/ldd.1.html
-    LIBS=$(LD_LIBRARY_PATH=$NEWROOT_LD_LIBRARY_PATH ldd "${1}") 
-    echo $LIBS \
-    `# strip the leading '${name} => ' if any so only '/lib-foo.so (0xf00)' remains` \
-    | sed -E 's#.* => /#/#' \
-    `# we want only the path remaining, not the (0x${LOCATION})` \
-    | awk '{print $1}' \
-    `# linux-vdso.so.1 is a special virtual shared object from the kernel` \
-    `# see: http://man7.org/linux/man-pages/man7/vdso.7.html` \
-    | grep -v 'linux-vdso.so.1'
-
-}
+SCRIPT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+source "${SCRIPT_ROOT}/eks-d-common"
 
 r_val=0
-for bin in $(find /newroot -executable -type f -not -name "*.so*"); do
-    if [ ! -f "${bin}" ] || [ ! -x "${bin}" ] || \
-        [ "$(binary_to_libraries $bin)" = "not" ] || [ "$(binary_to_libraries $bin)" = "statically" ]; then
+for bin in $(find $NEWROOT -executable -type f -not -name "*.so*"); do
+    if ! build::common::is_dynamic_binary $bin; then
         continue
     fi
-    echo "----- Checking $bin   -----"
+
+    echo "----- Checking $bin   -----"    
     while IFS= read -r c_dep; do
-        if [ "${c_dep}" != "not" ] && [ "${c_dep}" != "statically" ]; then
-            if [[ $c_dep = /newroot/* ]] && [ -f "${c_dep}" ]; then
+            if build::common::dep_exists "${c_dep}"; then
                 continue
             fi
-            if [ ! -f "/newroot${c_dep}" ] && [ ! -f "/newroot/usr${c_dep}" ]; then
-                echo "Missing DEP!!! ${c_dep}"
-                r_val=1
-            fi
-        fi
-    done < <(binary_to_libraries "${bin}")
+            echo "Missing DEP!!! ${c_dep}"
+            r_val=1
+           
+    done < <(build::common::binary_to_libraries "$bin")
     echo "----------------------------"
 done
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

validate_libraries is meant to ensure for every exec in the image, the necessary dynamic libs are present.  This uses ldd to figure this out.  The current version has a bug where this was only checking the first lib returned from ldd, this pr fixes this to the expected behavior.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
