### PR TITLE
distro-base: makes it easier to run minimal image smoke tests

### DIFF
--- a/eks-distro-base/Makefile
+++ b/eks-distro-base/Makefile
@@ -94,7 +94,7 @@ open-pr-check:
 
 ##@ Image Targets
 
-.PHONY: standard-images minimal-images-% builder-minimal-images-% final-minimal-images-% packages-export-minimal-images-% validate-minimal-images-%
+.PHONY: standard-images minimal-images-% builder-minimal-images-% final-minimal-images-% packages-export-minimal-images-% validate-minimal-images-% test-minimal-images-%
 
 # There is no local images target since the minimal images build on each other we need a registry to push to
 # in prow we run a docker registry as a sidecar
@@ -132,14 +132,14 @@ standard-images:
 # use an eval to "hardcode" the target and prereqs instead
 # $1 - Variant
 define MINIMAL_IMAGE_TARGET
-	minimal-images-$(1): builder-minimal-images-$(1) final-minimal-images-$(1) packages-export-minimal-images-$(1) validate-minimal-images-$(1)
+	minimal-images-$(1): builder-minimal-images-$(1) final-minimal-images-$(1) packages-export-minimal-images-$(1) validate-minimal-images-$(1) test-minimal-images-$(1)
 
 endef
 
 $(eval $(foreach variant, $(MINIMAL_VARIANTS), $(call MINIMAL_IMAGE_TARGET,$(variant))))
 
-builder-minimal-images-% final-minimal-images-% packages-export-minimal-images-% validate-minimal-images-%: VARIANT=minimal-$*
-builder-minimal-images-% final-minimal-images-% packages-export-minimal-images-% validate-minimal-images-%: IMAGE_NAME=eks-distro-$(VARIANT)
+builder-minimal-images-% final-minimal-images-% packages-export-minimal-images-% validate-minimal-images-% test-minimal-images-%: VARIANT=minimal-$*
+builder-minimal-images-% final-minimal-images-% packages-export-minimal-images-% validate-minimal-images-% test-minimal-images-%: IMAGE_NAME=eks-distro-$(VARIANT)
 builder-minimal-images-% final-minimal-images-%: DOCKERFILE=Dockerfile.$(VARIANT)
 
 builder-minimal-images-%: IMAGE_TARGET=builder
@@ -162,6 +162,9 @@ packages-export-minimal-images-%: IMAGE_OUTPUT=dest=$(IMAGE_OUTPUT_DIR)
 packages-export-minimal-images-%: DOCKERFILE=Dockerfile.minimal-helpers
 packages-export-minimal-images-%:
 	$(call BUILDCTL)
+	if [ -f $(IMAGE_OUTPUT_DIR)/$(VARIANT_SHORT_NAME) ]; then \
+		mv $(IMAGE_OUTPUT_DIR)/$(VARIANT_SHORT_NAME)* $(IMAGE_OUTPUT_DIR)/$(subst /,_,$(PLATFORMS))/; \
+	fi
 
 validate-minimal-images-%: IMAGE_TARGET=validate
 validate-minimal-images-%: IMAGE_OUTPUT_TYPE=local
@@ -170,6 +173,11 @@ validate-minimal-images-%: DOCKERFILE=Dockerfile.minimal-helpers
 validate-minimal-images-%:
 	$(call BUILDCTL)
 
+test-minimal-images-%:
+	if command -v docker &> /dev/null && docker info > /dev/null 2>&1 ; then \
+		$(MAKE_ROOT)/tests/run_tests.sh $(IMAGE_REPO) $(IMAGE_TAG) $(AL_TAG) check_$*; \
+	fi
+
 
 # These vars are all to make sure we pull the public images from ecr vs building locally
 # for use when periodic does not properly update packages and we want to update them manually
@@ -177,6 +185,13 @@ validate-minimal-images-%:
 packages-export-all-minimal-images: IMAGE_REPO=public.ecr.aws/eks-distro-build-tooling
 packages-export-all-minimal-images: IMAGE_TAG=$(BUILT_IMAGE_TAG_FROM_FILE)
 packages-export-all-minimal-images: $(addprefix packages-export-minimal-images-, $(MINIMAL_VARIANTS))
+
+# These vars are all to make sure we pull the public images from ecr vs building locally
+# for use to validate newly built images which have been pushed by the postsubmit
+.PHONY: test-all-minimal-images
+test-all-minimal-images: IMAGE_REPO=public.ecr.aws/eks-distro-build-tooling
+test-all-minimal-images: IMAGE_TAG=$(BUILT_IMAGE_TAG_FROM_FILE)
+test-all-minimal-images: $(addprefix test-minimal-images-, $(MINIMAL_VARIANTS))
 
 ##@ Update targets
 

--- a/eks-distro-base/tests/Dockerfile
+++ b/eks-distro-base/tests/Dockerfile
@@ -1,7 +1,8 @@
 ARG BASE_IMAGE
+ARG AL_TAG
 FROM ${BASE_IMAGE} as base
 
-FROM public.ecr.aws/amazonlinux/amazonlinux:2 as builder
+FROM public.ecr.aws/amazonlinux/amazonlinux:${AL_TAG} as builder
 
 WORKDIR /var/app
 
@@ -22,8 +23,8 @@ COPY --from=base /usr/include/git2.h /usr/include
 COPY --from=base /usr/include/git2 /usr/include/git2
 COPY --from=base /usr/lib64/libgit2* /usr/lib64
 COPY --from=base /usr/lib64/libssh2* /usr/lib64
-
-RUN go get github.com/libgit2/git2go/v31
+RUN ldd /usr/lib64/libgit2.so
+RUN go get github.com/libgit2/git2go/v33
 RUN CGO_ENABLED=1 go build -o check-git ./check_git.go 
 
 FROM ${BASE_IMAGE} as check-base

--- a/eks-distro-base/tests/check_git.go
+++ b/eks-distro-base/tests/check_git.go
@@ -22,7 +22,7 @@ import (
 	"log"
 	"os"
 
-	git "github.com/libgit2/git2go/v31"
+	git "github.com/libgit2/git2go/v33"
 )
 
 func credentialsMemoryCallback(url string, username string, allowedTypes git.CredType) (*git.Credential, error) {
@@ -52,13 +52,13 @@ func credentialsFileCallback(url string, username string, allowedTypes git.CredT
 }
 
 // Made this one just return 0 during troubleshooting...
-func certificateCheckCallback(cert *git.Certificate, valid bool, hostname string) git.ErrorCode {
-	return 0
+func certificateCheckCallback(cert *git.Certificate, valid bool, hostname string) error {
+	return nil
 }
 
 func main() {
 	cloneOptions := &git.CloneOptions{
-		FetchOptions: &git.FetchOptions{
+		FetchOptions: git.FetchOptions{
 			RemoteCallbacks: git.RemoteCallbacks{
 				CredentialsCallback:      credentialsMemoryCallback,
 				CertificateCheckCallback: certificateCheckCallback,
@@ -75,7 +75,7 @@ func main() {
 	}
 
 	cloneOptions = &git.CloneOptions{
-		FetchOptions: &git.FetchOptions{
+		FetchOptions: git.FetchOptions{
 			RemoteCallbacks: git.RemoteCallbacks{
 				CredentialsCallback:      credentialsFileCallback,
 				CertificateCheckCallback: certificateCheckCallback,

--- a/pr-scripts/eks_distro_base_pr_body
+++ b/pr-scripts/eks_distro_base_pr_body
@@ -1,1 +1,10 @@
 This PR updates the base image tag in CHANGED_FILE with the tag of the newly-built EKS Distro base image.
+
+
+**Note**
+
+Merging this PR may trigger SNS messages, tickets being cut and PRs being opened by the bot across various repos.
+
+Do not merge without:
+- carefully reviewing the package and file changes in the files under `eks-distro-base-minimal-packages`
+- checking out the PR locally and running `make test-all-minimal-images` to ensure newly built images pass smoke tests


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

The tests will now automatically run if docker is available after a build of one of the minimal images.  There is also a new target to make it easier to run the tests against the already built/published images to validate after automated updates.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
