### PR TITLE
distro-base: Use seperate message for other repos

### DIFF
--- a/pr-scripts/create_pr.sh
+++ b/pr-scripts/create_pr.sh
@@ -58,8 +58,13 @@ else
         PR_TITLE="Update deck image tag in ${CHANGED_FILE}"
         PR_BODY=$(cat ${SCRIPT_ROOT}/../pr-scripts/prow_deck_pr_body)
     else
-        $SED -i "s,in .* with,in ${CHANGED_FILE} with," ${SCRIPT_ROOT}/../pr-scripts/eks_distro_base_pr_body
-        cp ${SCRIPT_ROOT}/../pr-scripts/eks_distro_base_pr_body ${SCRIPT_ROOT}/../pr-scripts/${REPO}_pr_body
+        PR_BODY_FILE=${SCRIPT_ROOT}/../pr-scripts/eks_distro_base_other_repo_pr_body
+        if [ $REPO = "eks-distro-build-tooling" ]; then
+            PR_BODY_FILE=${SCRIPT_ROOT}/../pr-scripts/eks_distro_base_pr_body
+        fi
+        cp $PR_BODY_FILE ${SCRIPT_ROOT}/../pr-scripts/${REPO}_pr_body
+        $SED -i "s,in .* with,in ${CHANGED_FILE} with," ${SCRIPT_ROOT}/../pr-scripts/${REPO}_pr_body
+        
         
         for FILE in $(find ${SCRIPT_ROOT}/../eks-distro-base-updates -type f -name "update_packages*" ); do
             UPDATE_PACKAGES="$(cat ${FILE})"

--- a/pr-scripts/eks_distro_base_other_repo_pr_body
+++ b/pr-scripts/eks_distro_base_other_repo_pr_body
@@ -1,1 +1,1 @@
-This PR updates the base image tag in CHANGED_FILE with the tag of the newly-built EKS Distro base image.
+This PR updates the base image tag in CHANGED_FILE with the tag of the newly-built EKS Distro base image and/or its minimal variants.

--- a/pr-scripts/eks_distro_base_other_repo_pr_body
+++ b/pr-scripts/eks_distro_base_other_repo_pr_body
@@ -1,0 +1,1 @@
+This PR updates the base image tag in CHANGED_FILE with the tag of the newly-built EKS Distro base image.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

I updated the message recently, but didnt think about how it was used for both PRs to this repo and to other repos. For ex: 
https://github.com/aws/eks-anywhere-build-tooling/pull/942 is not ideal

This adds a different body file for the other repos.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
