### PR TITLE
Bump patch versions for Go 1.17 and 1.18

### DIFF
--- a/builder-base/install.sh
+++ b/builder-base/install.sh
@@ -185,8 +185,8 @@ setupgo() {
     ln -s /root/sdk/go${version}/bin/gofmt ${GOPATH}/go${majorversion}/bin/gofmt
 }
 
-setupgo "${GOLANG117_VERSION:-1.17.10}"
-setupgo "${GOLANG118_VERSION:-1.18.2}"
+setupgo "${GOLANG117_VERSION:-1.17.11}"
+setupgo "${GOLANG118_VERSION:-1.18.3}"
 
 if [ $TARGETARCH == 'arm64' ]; then
     exit


### PR DESCRIPTION
Bump patch versions for Go 1.17 and 1.18 to the latest available at https://go.dev/dl/

/hold


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
