### PR TITLE
Add tuftool to builder-base

### DIFF
--- a/builder-base/Dockerfile
+++ b/builder-base/Dockerfile
@@ -19,20 +19,13 @@ ARG GOPROXY
 ARG TARGETARCH
 
 ENV GOPATH /go
-ENV PATH="/go/bin/:$PATH"
+ENV CARGO_HOME /root/.cargo
+ENV RUSTUP_HOME /root/.rustup
+ENV PATH="/go/bin/:/root/.cargo/bin:$PATH"
 
-COPY *-checksum *.sh /
-
-# attribution generation support
-COPY generate-attribution/package*.json \
-    generate-attribution/generate-attribution \
-    generate-attribution/generate-attribution-file.js \
-    generate-attribution/LICENSE-2.0.txt \ 
-    /opt/generate-attribution/
+COPY *-checksum *.sh generate-attribution /
 
 RUN export GOPROXY=${GOPROXY} && \
     export TARGETARCH=${TARGETARCH} && \
     bash /install.sh && \
     rm /install.sh /*-checksum
-
-WORKDIR /go/src/github.com/aws/eks-distro

--- a/builder-base/versions.sh
+++ b/builder-base/versions.sh
@@ -42,10 +42,10 @@ PACKER_CHECKSUM_URL="https://releases.hashicorp.com/packer/$PACKER_VERSION/packe
 NODEJS_VERSION="${NODEJS_VERSION:-v15.11.0}"
 if [ $TARGETARCH == 'amd64' ]; then 
     NODEJS_FILENAME="node-$NODEJS_VERSION-linux-x64.tar.gz"
-    NDOEJS_FOLDER="node-$NODEJS_VERSION-linux-x64"
+    NODEJS_FOLDER="node-$NODEJS_VERSION-linux-x64"
 else
     NODEJS_FILENAME="node-$NODEJS_VERSION-linux-arm64.tar.gz"
-    NDOEJS_FOLDER="node-$NODEJS_VERSION-linux-arm64"
+    NODEJS_FOLDER="node-$NODEJS_VERSION-linux-arm64"
 fi
 NODEJS_DOWNLOAD_URL="https://nodejs.org/dist/$NODEJS_VERSION/$NODEJS_FILENAME"
 NODEJS_CHECKSUM_URL="https://nodejs.org/dist/$NODEJS_VERSION/SHASUMS256.txt"
@@ -80,3 +80,5 @@ YQ_CHECKSUM_ORDER_URL="https://github.com/mikefarah/yq/releases/download/${YQ_VE
 AMAZON_ECR_CRED_HELPER_VERSION="${AMAZON_ECR_CRED_HELPER_VERSION:-0.6.0}"
 AMAZON_ECR_CRED_HELPER_DOWNLOAD_URL="https://amazon-ecr-credential-helper-releases.s3.us-east-2.amazonaws.com/${AMAZON_ECR_CRED_HELPER_VERSION}/linux-$TARGETARCH/docker-credential-ecr-login"
 AMAZON_ECR_CRED_HELPER_CHECKSUM_URL="${AMAZON_ECR_CRED_HELPER_DOWNLOAD_URL}.sha256"
+
+RUSTUP_DOWNLOAD_URL="https://sh.rustup.rs"


### PR DESCRIPTION
Installing tuftool in builder base so it's readily available during builds.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
