### PR TITLE
distro-base: support updating al22 images if new releasever

### DIFF
--- a/eks-distro-base/Makefile
+++ b/eks-distro-base/Makefile
@@ -317,18 +317,18 @@ packages-export-minimal-images-base-kind: ## Export packages included in kind mi
 packages-export-minimal-images-base-nsenter: ## Export packages included in nsenter minimal images
 
 standard-update:  ## Check for out of date packages on standard full base image and push new
-minimal-base-update: ## Check for out of date packages on minimal base image and push new
-minimal-base-nonroot-update: ## Check for out of date packages on minimal nonroot base image and push new
-minimal-base-glibc-update: ## Check for out of date packages on minimal glibc base image and push new
-minimal-base-iptables-update: ## Check for out of date packages on minimal iptables base image and push new
-minimal-base-csi-update: ## Check for out of date packages on minimal csi base image and push new
-minimal-base-csi-ebs-update: ## Check for out of date packages on minimal ebs csi base image and push new
-minimal-base-git-update: ## Check for out of date packages on minimal git base image and push new
-minimal-base-docker-client-update: ## Check for out of date packages on minimal docker client base image and push new
-minimal-base-nginx: ## Check for out of date packages on minimal nginx base image and push new
-minimal-base-haproxy: ## Check for out of date packages on minimal haproxy base image and push new
-minimal-base-kind: ## Check for out of date packages on minimal kind base image and push new
-minimal-base-nsenter-update: ## Check for out of date packages on minimal nsenter base image and push new
+minimal-update-base: ## Check for out of date packages on minimal base image and push new
+minimal-update-base-nonroot: ## Check for out of date packages on minimal nonroot base image and push new
+minimal-update-base-glibc: ## Check for out of date packages on minimal glibc base image and push new
+minimal-update-base-iptables: ## Check for out of date packages on minimal iptables base image and push new
+minimal-update-base-csi: ## Check for out of date packages on minimal csi base image and push new
+minimal-update-base-csi-ebs: ## Check for out of date packages on minimal ebs csi base image and push new
+minimal-update-base-git: ## Check for out of date packages on minimal git base image and push new
+minimal-update-base-docker-client: ## Check for out of date packages on minimal docker client base image and push new
+minimal-update-base-nginx: ## Check for out of date packages on minimal nginx base image and push new
+minimal-update-base-haproxy: ## Check for out of date packages on minimal haproxy base image and push new
+minimal-update-base-kind: ## Check for out of date packages on minimal kind base image and push new
+minimal-update-base-nsenter: ## Check for out of date packages on minimal nsenter base image and push new
 
 standard-create-pr:  ## Update standard base image tag if pushed
 minimal-base-create-pr: ## Update minimal base image tag if pushed


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

AL22 uses `releasever` which is different than al2.  Currently during their beta period, whenever they release a new build of al22 they are bumping the releasever and all new packages are under this version.  I think the best thing to do here is when there is a new releasever from al22 we should rebuild our images.  I want to watch what happens when they go ga and how often they are bumping new releasevers.

If they are going to be bumping the releasever more often than wed like to rebuild our minimal base images, the approach we can take is to get the latest releasever and pass that to `yum check --security --releasever=<>`. Well wait to see what happens post ga to do this.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
