### PR TITLE
builder-base: use 1.15 from upstream since al2 isnt the latest

### DIFF
--- a/builder-base/install.sh
+++ b/builder-base/install.sh
@@ -325,6 +325,17 @@ ln -s $(pwd)/generate-attribution $USR_BIN/generate-attribution
 npm install
 cd ..
 
+# Installing Tuftool for Bottlerocket downloads
+curl -fsS $RUSTUP_DOWNLOAD_URL | CARGO_HOME=$CARGO_HOME RUSTUP_HOME=$RUSTUP_HOME sh -s -- -y
+find $CARGO_HOME/bin -type f -not -name "cargo" -not -name "rustc" -not -name "rustup" -delete
+$CARGO_HOME/bin/rustup default stable
+CARGO_NET_GIT_FETCH_WITH_CLI=true $CARGO_HOME/bin/cargo install --force --root $CARGO_HOME tuftool
+cp $CARGO_HOME/bin/tuftool $USR_BIN/tuftool
+
+# Cargo cache management tool
+CARGO_NET_GIT_FETCH_WITH_CLI=true $CARGO_HOME/bin/cargo install --force --root $CARGO_HOME tuftool cargo-cache
+cargo-cache  --remove-dir all
+
 # Installing Helm
 curl -O $HELM_DOWNLOAD_URL
 sha256sum -c $BASE_DIR/helm-$TARGETARCH-checksum
@@ -375,15 +386,5 @@ make bin/skopeo
 mv bin/skopeo $USR_BIN/skopeo
 cd ..
 rm -rf skopeo
-
-# Installing Tuftool for Bottlerocket downloads
-curl -fsS $RUSTUP_DOWNLOAD_URL | CARGO_HOME=$CARGO_HOME RUSTUP_HOME=$RUSTUP_HOME sh -s -- -y
-find $CARGO_HOME/bin -type f -not -name "cargo" -not -name "rustc" -not -name "rustup" -delete
-$CARGO_HOME/bin/rustup default stable
-CARGO_NET_GIT_FETCH_WITH_CLI=true $CARGO_HOME/bin/cargo install --force --root $CARGO_HOME tuftool
-cp $CARGO_HOME/bin/tuftool $USR_BIN/tuftool
-
-# Cargo cache management tool
-CARGO_NET_GIT_FETCH_WITH_CLI=true $CARGO_HOME/bin/cargo install --force --root $CARGO_HOME tuftool cargo-cache
 
 build::cleanup

--- a/builder-base/install.sh
+++ b/builder-base/install.sh
@@ -63,7 +63,7 @@ function build::go::install(){
     local version=$1
 
     # AL2 provides a longer supported version of golang, use AL2 package when possible
-    local yum_provided_versions="1.16 1.15 1.13"
+    local yum_provided_versions="1.16 1.13"
     if [ "$IS_AL22" = true ]; then 
         # al22 only includes 1.16
         # TODO: do we want to install 1.15 and 1.13 from al2?


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
