### PR TITLE
distro-base: Runs tests for all platforms built/pulled

### DIFF
--- a/eks-distro-base/Makefile
+++ b/eks-distro-base/Makefile
@@ -179,7 +179,7 @@ validate-minimal-images-%:
 
 test-minimal-images-%:
 	if command -v docker &> /dev/null && docker info > /dev/null 2>&1 ; then \
-		$(MAKE_ROOT)/tests/run_tests.sh $(IMAGE_REPO) $(IMAGE_TAG) $(AL_TAG) check_$*; \
+		$(MAKE_ROOT)/tests/run_tests.sh $(IMAGE_REPO) $(IMAGE_TAG) $(AL_TAG) $(PLATFORMS) check_$*; \
 	fi
 
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

I have been trying to run the tests manually after new images are built by prow. This changes the test code to use buildctl instead of docker so we can build for all platforms and run tests for all.  For the most part this works out well.

There is one gotcha with the nft tests. For some reason when running the image for a different arch than the host, it will fail to load. The current arch will load just fine. I have run these tests on both an amd and an arm instance to confirm both images pass the test.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
