### PR TITLE
distro-base: Various improvements to al22

### DIFF
--- a/eks-distro-base/Dockerfile.minimal-base
+++ b/eks-distro-base/Dockerfile.minimal-base
@@ -32,7 +32,13 @@ COPY scripts/ /usr/bin
 ENV DOWNLOAD_DIR /tmp/download
 
 ENV NEWROOT /
+
 RUN set -x && \
+    if grep -q "2022" "/etc/os-release"; then \
+        yum install -y dnf-plugin-release-notification && \
+        NEW_RELEASE=$(yum check-release-update 2>&1 | grep 'dnf update --releasever' | tail -n 1) && \
+        [ -n "${NEW_RELEASE}" ] && ${NEW_RELEASE} -y; \
+    fi && \
     yum upgrade -y && \
     yum update -y && \
     clean_install "binutils cpio findutils shadow-utils yum-utils" && \

--- a/eks-distro-base/Dockerfile.minimal-base-csi
+++ b/eks-distro-base/Dockerfile.minimal-base-csi
@@ -36,11 +36,18 @@ COPY scripts/ /usr/bin
 RUN set -x && \
     export OUTPUT_DEBUG_LOG=${OUTPUT_DEBUG_LOG} && \
     # manually "install" systemd to avoid installing the entire dep tree
-    clean_install systemd true true && \
+    if_al2 clean_install systemd true true && \
+    # in al22 some of the exec depend on a common systemd lib which is included
+    # in the systemd package. Installing systemd completely bloats the image
+    # using install_binary to limit what is pulled from systemd and dependencies
+    if_al2022 install_binary /usr/lib/systemd/libsystemd-shared-250.so && \
+    # libdb is needed by some of the libs pulled in above but not a direct dep
+    # of any bins so its not pulled in automatically
+    if_al2022 install_rpm libdb && \
     # some of the install scriptlets need coreutils but the dep ordering
     # doesnt reflect, install manually to make sure its first
     clean_install coreutils && \
     if_al2022 clean_install pcre2 && \
     clean_install "e2fsprogs nfs-utils util-linux xfsprogs" && \
-    remove_package systemd true && \
+    if_al2 remove_package systemd true && \
     cleanup "csi"

--- a/eks-distro-base/Dockerfile.minimal-base-git
+++ b/eks-distro-base/Dockerfile.minimal-base-git
@@ -83,7 +83,7 @@ RUN set -x && \
     cp -rf /usr/local/include/git2* $NEWROOT/usr/include && \
     cd / && \
     rm -rf /tmp/sources && \
-    yum erase -y $BUILD_DEPS && \
+    yum erase -y --setopt=protected_packages=False $BUILD_DEPS && \
     clean_yum
 
 # Copy scripts in every variant since we do not rebuild the base

--- a/eks-distro-base/Dockerfile.minimal-base-git
+++ b/eks-distro-base/Dockerfile.minimal-base-git
@@ -91,10 +91,10 @@ RUN set -x && \
 # built it has the latest scripts in the builder
 COPY scripts/ /usr/bin
 
-# cyrus-sasl-lib is installed for the libs, but it also includes these bins
+# cyrus-sasl-lib is installed for the libs, but it also includes these bins sasldblistusers2 saslpasswd2 libsasldb cyrusbdb2current
 # which are not needed
 # /etc/krb5.conf.d/crypto-policies is a broken symlink which is not needed
-ENV CLEANUP_UNNECESSARY_FILES="/usr/sbin/sasldblistusers2 /usr/sbin/saslpasswd2 /usr/lib64/sasl2/libsasldb* /usr/lib64/libkrad* /etc/krb5.conf.d/crypto-policies /usr/lib64/libsystemd.so.*"
+ENV CLEANUP_UNNECESSARY_FILES="/usr/sbin/sasldblistusers2 /usr/sbin/saslpasswd2 /usr/lib64/sasl2/libsasldb* /usr/bin/cyrusbdb2current /usr/lib64/libkrad* /etc/krb5.conf.d/crypto-policies /usr/lib64/libsystemd.so.*"
 
 RUN set -x && \
     export OUTPUT_DEBUG_LOG=${OUTPUT_DEBUG_LOG} && \

--- a/eks-distro-base/check_update.sh
+++ b/eks-distro-base/check_update.sh
@@ -35,16 +35,16 @@ FROM $BASE_IMAGE AS base_image
 
 FROM public.ecr.aws/amazonlinux/amazonlinux:$AL_TAG as builder
 
-RUN rm -rf /var/lib/rpm
-COPY --from=base_image /var/lib/rpm /var/lib/rpm
-COPY --from=base_image /etc/yum.repos.d /etc/yum.repos.d
-
 RUN set -x && \
     if grep -q "2022" "/etc/os-release"; then \
         yum install -y dnf-plugin-release-notification && \
         yum check-release-update &> /tmp/new-release && \
         if grep "A newer release" /tmp/new-release; then echo "100" > ./return_value; fi \
     fi
+
+RUN rm -rf /var/lib/rpm
+COPY --from=base_image /var/lib/rpm /var/lib/rpm
+COPY --from=base_image /etc/yum.repos.d /etc/yum.repos.d
 
 RUN set -x && \
     if [ -f ./return_value ] && [ "\$(cat ./return_value)" = "100" ]; then \

--- a/eks-distro-base/scripts/eks-d-common
+++ b/eks-distro-base/scripts/eks-d-common
@@ -376,6 +376,15 @@ function build::common::clean_install() {
     local -r force=${4:-}
     local -r extract_dir="${5:-$NEWROOT}"
     
+
+    if [ ! $shallow ]; then
+        echo "Installing $packages and dependencies using yum"
+        
+        yum --installroot $NEWROOT install -y $packages
+
+        return
+    fi
+
     if [ $just_db ]; then
         just_db="--justdb"
     else
@@ -393,72 +402,66 @@ function build::common::clean_install() {
 
     local -r rpms=(${packages// / })
     for rpm in "${rpms[@]}"; do
-        if [ ! $shallow ]; then
-            echo "Installing $rpm and dependencies using yum"
-            
-            yum --installroot $NEWROOT install -y $rpm
-        else
-            if ! ls -d -- $DOWNLOAD_DIR/$rpm-[0-9]*.rpm 1> /dev/null 2>&1; then
-                echo "Downloading $rpm"
-                yumdownloader --destdir=$DOWNLOAD_DIR -x "*.i686" $rpm > /dev/null 2>&1
-                echo "$rpm downloaded"
-            fi
-
-            # Multiple RPMs may be downloaded in the case that the package we want is a prefix to another
-            # only get the specific one by looking for the version directly after the rpm name
-            # ex: util-linux and util-linux-core
-            local rpm_file=$(ls -d -- $DOWNLOAD_DIR/$rpm-[0-9]*.rpm)
-        
-            local log_file=$(mktemp)
-            # if installed already skip
-            if ! rpm --root $NEWROOT -q --quiet $rpm ; then
-                if [[ -n $just_db ]]; then
-                    echo "Installing $rpm to rpm database only"
-                else
-                    echo "Shallow installing $rpm using the rpm directly"
-                    build::common::setup_default_utils_for_rpm_scriptlets
-
-                    local -r rpm_sanitized="$(echo ${rpm} | sed 's/\+/PLUS/g; s/\./_/g; s/\-/_/g;')"
-                    local -r reqs_var_name="${rpm_sanitized^^}_SCRIPTLET_REQS"
-                    local -r reqs="${!reqs_var_name:-}"
-
-                    build::common::cp_common_utils_for_rpm_scriptlets "${reqs}"
-                fi
-                env -u BASH_XTRACEFD rpm -ivvh --nodeps --root $NEWROOT $just_db $rpm_file &> $log_file
-                
-                # not all packages run ldconfig as part of their postinstall scriptlet (they should)
-                # since we are relying on ldconfig now we need this to be refreshed
-                build::common::update_ldconfig
-
-                echo "$rpm installed"
-            fi            
-            
-            local -r sanitized_rpm="$(echo ${rpm} | sed 's/\+/PLUS/g; s/\./_/g; s/\-/_/g;')"
-            local -r var_name="${sanitized_rpm^^}_IGNORE_SCRIPTLET_ERRORS"
-
-            if [[ -z "${!var_name:-}" ]] && grep -q "scriptlet failed\|command not found" $log_file; then
-                local rpm_name=$(basename $rpm_file | sed -e 's/^[0-9]\+://' | sed -e 's/\-[0-9].*$//')
-
-                if [[ ${EXPECTED_RPM_SCRIPTLET_FAILURES:-""} != *"$rpm_name"* ]]; then
-                    echo "******************************************************"
-                    echo "Preinstall script failed for $rpm_file:"
-                    echo "$(rpm -qp --scripts $rpm_file)"
-                    cat $log_file
-                    echo "******************************************************"
-                    exit 1
-                fi
-            fi
-            
-            if [ $force ] && [ ! -d $extract_dir ]; then                
-                echo "Extracting $rpm directly to $extract_dir"
-                mkdir -p $extract_dir
-                pushd $extract_dir
-                rpm2cpio $rpm_file | cpio -idm >> $DEBUG_LOG_FILE 2>&1
-                popd
-            fi
-
-            rm $log_file
+        if ! ls -d -- $DOWNLOAD_DIR/$rpm-[0-9]*.rpm 1> /dev/null 2>&1; then
+            echo "Downloading $rpm"
+            yumdownloader --destdir=$DOWNLOAD_DIR -x "*.i686" $rpm > /dev/null 2>&1
+            echo "$rpm downloaded"
         fi
+
+        # Multiple RPMs may be downloaded in the case that the package we want is a prefix to another
+        # only get the specific one by looking for the version directly after the rpm name
+        # ex: util-linux and util-linux-core
+        local rpm_file=$(ls -d -- $DOWNLOAD_DIR/$rpm-[0-9]*.rpm)
+    
+        local log_file=$(mktemp)
+        # if installed already skip
+        if ! rpm --root $NEWROOT -q --quiet $rpm ; then
+            if [[ -n $just_db ]]; then
+                echo "Installing $rpm to rpm database only"
+            else
+                echo "Shallow installing $rpm using the rpm directly"
+                build::common::setup_default_utils_for_rpm_scriptlets
+
+                local -r rpm_sanitized="$(echo ${rpm} | sed 's/\+/PLUS/g; s/\./_/g; s/\-/_/g;')"
+                local -r reqs_var_name="${rpm_sanitized^^}_SCRIPTLET_REQS"
+                local -r reqs="${!reqs_var_name:-}"
+
+                build::common::cp_common_utils_for_rpm_scriptlets "${reqs}"
+            fi
+            env -u BASH_XTRACEFD rpm -ivvh --nodeps --root $NEWROOT $just_db $rpm_file &> $log_file
+            
+            # not all packages run ldconfig as part of their postinstall scriptlet (they should)
+            # since we are relying on ldconfig now we need this to be refreshed
+            build::common::update_ldconfig
+
+            echo "$rpm installed"
+        fi            
+        
+        local -r sanitized_rpm="$(echo ${rpm} | sed 's/\+/PLUS/g; s/\./_/g; s/\-/_/g;')"
+        local -r var_name="${sanitized_rpm^^}_IGNORE_SCRIPTLET_ERRORS"
+
+        if [[ -z "${!var_name:-}" ]] && grep -q "scriptlet failed\|command not found" $log_file; then
+            local rpm_name=$(basename $rpm_file | sed -e 's/^[0-9]\+://' | sed -e 's/\-[0-9].*$//')
+
+            if [[ ${EXPECTED_RPM_SCRIPTLET_FAILURES:-""} != *"$rpm_name"* ]]; then
+                echo "******************************************************"
+                echo "Preinstall script failed for $rpm_file:"
+                echo "$(rpm -qp --scripts $rpm_file)"
+                cat $log_file
+                echo "******************************************************"
+                exit 1
+            fi
+        fi
+        
+        if [ $force ] && [ ! -d $extract_dir ]; then                
+            echo "Extracting $rpm directly to $extract_dir"
+            mkdir -p $extract_dir
+            pushd $extract_dir
+            rpm2cpio $rpm_file | cpio -idm >> $DEBUG_LOG_FILE 2>&1
+            popd
+        fi
+
+        rm $log_file        
     done
 }
 

--- a/eks-distro-base/scripts/eks-d-common
+++ b/eks-distro-base/scripts/eks-d-common
@@ -32,7 +32,7 @@ function build::common::yum_provides() {
         echo "Finding yum package for ${bin}"
         PROVIDES_CACHE[$bin]=$(yum provides "${bin}" 2>&1 || true)
         # al22 is not as forgiving when searching
-        [[ ${PROVIDES_CACHE[$bin]} == *"No matches found"* ]] && PROVIDES_CACHE[$bin]=$(yum provides "*/${bin}" 2>&1)
+        [[ ${PROVIDES_CACHE[$bin]} == *"No matches found"* ]] && PROVIDES_CACHE[$bin]=$(yum provides "*/$(basename ${bin})" 2>&1)
         PROVIDES_CACHE[$bin]=$(echo "${PROVIDES_CACHE[$bin]}" | sed "s/'//g")
     fi
 
@@ -341,7 +341,11 @@ function build::common::update_ldconfig(){
 
 function build::common::rm_common_utils_for_rpm_scriptlets() {
     local -r fakeroot="$NEWROOT/fakeroot"
-
+    
+    if [ ! -d "${fakeroot}" ]; then
+        return
+    fi
+    
     for file in $(find $fakeroot -type f); do
         local util="${file/\/fakeroot/}"  
         if [ -L $util ] && [[ "$(readlink $util)" = /fakeroot/* ]]; then
@@ -380,7 +384,7 @@ function build::common::clean_install() {
     if [ ! $shallow ]; then
         echo "Installing $packages and dependencies using yum"
         
-        yum --installroot $NEWROOT install -y $packages
+        yum --installroot $NEWROOT install -y --setopt=install_weak_deps=False $packages
 
         return
     fi

--- a/eks-distro-base/update_base_image_other_repos.sh
+++ b/eks-distro-base/update_base_image_other_repos.sh
@@ -33,6 +33,11 @@ do
     image=${image:2} # strip leading - space
     BASE_IMAGE_TAG_FILE="$(echo ${image^^} | tr '-' '_')_TAG_FILE"
     IMAGE_TAG=$(yq e ".al$AL_TAG.$image" $SCRIPT_ROOT/../EKS_DISTRO_TAG_FILE.yaml)
+    # we will set the tag to null to trigger new builds. we dont want PRs being open setting
+    # tag file values to null
+    if [[ "${IMAGE_TAG}" = "null" ]]; then
+        continue
+    fi
     for repo in "${REPOS[@]}"; do
         ${SCRIPT_ROOT}/../pr-scripts/update_image_tag.sh "$repo" '.*' $IMAGE_TAG $BASE_IMAGE_TAG_FILE
     done


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- AL22 images were not actually being built from the latest. The way al22 works with this releasever stuff is that yum upgrade doesnt actually get to the latest, if we do not set the new releasever.  This meant unless the AL22 team published new container images, which they do not always do, for each releasever would constantly rebuild our images because check update was correct but build was not.
- I found the above due to a build failure in the al22 postsubmit for the git variant.  This was due to the fact that a newer package from al22 had been released and what I tested with was on an image with an older releasever and therefore an older package.  A new bin had been added which we do not need so its been added to the unnecessary files list.
- Improve check_update a bit by installing the dnf plugin before copying the yum db from the minimal image
- Move the yum install perf improvement from the python branch, these changes are just indention changes no real code change other than moving the if !shallow up.
- Changed the update other repos pr script to skip updates where the new tag is `null`, which is what we typically do to trigger new builds.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
