### PR TITLE
Added channel to cni

### DIFF
--- a/release/pkg/assets_cni.go
+++ b/release/pkg/assets_cni.go
@@ -25,7 +25,7 @@ import (
 // GetCniComponent returns the Component for CNI plugins
 func (r *ReleaseConfig) GetCniComponent(spec distrov1alpha1.ReleaseSpec) (*distrov1alpha1.Component, error) {
 	projectSource := "projects/containernetworking/plugins"
-	tagFile := filepath.Join(r.BuildRepoSource, projectSource, "GIT_TAG")
+	tagFile := filepath.Join(r.BuildRepoSource, projectSource, spec.Channel, "GIT_TAG")
 	gitTag, err := readTag(tagFile)
 	if err != nil {
 		return nil, errors.Cause(err)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* Fix for failed `cat: ../../projects/containernetworking/plugins/GIT_TAG: No such file or directory ` in post submit build (see [example](https://prow.eks.amazonaws.com/view/s3/prowdataclusterstack-316434458-prowbucket7c73355c-1n9f9v93wpjcm/logs/build-1-20-postsubmit/1554617167037599744#2:build-container-build-log.txt%3A878)) due to this change creating release branches https://github.com/aws/eks-distro/pull/1157

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
