### PR TITLE
Changed make controller-gen to use go install

### DIFF
--- a/release/Makefile
+++ b/release/Makefile
@@ -57,7 +57,7 @@ ifeq (, $(shell which controller-gen))
 	CONTROLLER_GEN_TMP_DIR=$$(mktemp -d) ;\
 	cd $$CONTROLLER_GEN_TMP_DIR ;\
 	go mod init tmp ;\
-	go get sigs.k8s.io/controller-tools/cmd/controller-gen@v0.2.5 ;\
+	go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.2.5 ;\
 	rm -rf $$CONTROLLER_GEN_TMP_DIR ;\
 	}
 CONTROLLER_GEN=$(GOBIN)/controller-gen


### PR DESCRIPTION
Fix for error `/bin/sh: /home/prow/go/bin/controller-gen: No such file or directory` ([example](https://prow.eks.amazonaws.com/view/s3/prowpresubmitsdataclusterstack-prowbucket7c73355c-vfwwxd2eb4gp/pr-logs/pull/aws_eks-distro-build-tooling/445/eks-distro-release-tooling-presubmit/1554648215024832512#2:build-log.txt%3A51)) on eks-distro-release-tooling-presubmit jobs. This was caused by a recent [change](https://github.com/aws/eks-distro-build-tooling/commit/576b89eaf1edd40780fcbbf671ff6e66ca4163d8#diff-39c1d094a91b87c4c07eb89e6199ee313c46cebf77b8973080521046c3e0bfb6) to update Go from v1.16.15 to v1.18.4 in `builder-base/versions.sh`. According to the [Golang docs](https://go.dev/doc/go-get-install-deprecation), 
> Starting in Go 1.17, installing executables with go get is deprecated. go install may be used instead. 
>
> In Go 1.18, go get will no longer build packages; it will only be used to add, update, or remove dependencies in go.mod."

This PR changes  `go get` to `go install`. 

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
