### PR TITLE
first pass at kOps patch + build

### DIFF
--- a/projects/kubernetes/kops/Makefile
+++ b/projects/kubernetes/kops/Makefile
@@ -5,8 +5,13 @@ CLONED_REPO_DIRECTORY:=$(PROJECT_DIRECTORY)/kops
 KOPS_VERSION_TAG?="v1.23.2"
 KOPS_REPO_URL?="https://github.com/kubernetes/kops.git"
 
+ARTIFACTS_BUCKET?=""
+
 .PHONY: build
-build: clone-kops patch-nodeup build-nodeup pull-binaries pull-images copy-nodeup-binaries
+build: clone-kops patch-nodeup build-nodeup pull-binaries pull-images move-nodeup-binaries
+
+.PHONY: release
+release: build sync-artifacts-to-s3
 
 .PHONY: clone-kops
 clone-kops:
@@ -29,9 +34,18 @@ pull-binaries:
 pull-images:
 	source $(PROJECT_DIRECTORY)/kops_artifacts_management_tools.sh && fetch_kops_images
 
-.PHONY: copy-nodeup-binaries
-copy-nodeup-binaries:
-	source $(PROJECT_DIRECTORY)/kops_artifacts_management_tools.sh && copy_nodeup_binaries
+.PHONY: move-nodeup-binaries
+move-nodeup-binaries:
+	source $(PROJECT_DIRECTORY)/kops_artifacts_management_tools.sh && move_nodeup_binaries
+
+.PHONY: sync-artifacts-to-s3-dry-run
+sync-artifacts-to-s3-dry-run:
+	source $(PROJECT_DIRECTORY)/kops_artifacts_management_tools.sh && sync_artifacts_to_s3 $(ARTIFACTS_BUCKET) $(PROJECT_DIRECTORY)/output/kops kops false true
+
+
+.PHONY: sync-artifacts-to-s3
+sync-artifacts-to-s3:
+	source $(PROJECT_DIRECTORY)/kops_artifacts_management_tools.sh && sync_artifacts_to_s3 $(ARTIFACTS_BUCKET) $(PROJECT_DIRECTORY)/output/kops kops false false
 
 .PHONY: clean
 clean:

--- a/projects/kubernetes/kops/Makefile
+++ b/projects/kubernetes/kops/Makefile
@@ -4,7 +4,6 @@ CLONED_REPO_DIRECTORY:=$(PROJECT_DIRECTORY)/kops
 
 KOPS_VERSION_TAG?="v1.23.2"
 KOPS_REPO_URL?="https://github.com/kubernetes/kops.git"
-NODEUP_FLANNEL_PLUGIN_PATCH="0001-remove-hardcoded-requierment-on-flannel-plugin.patch"
 
 .PHONY: build
 build: clone-kops patch-nodeup build-nodeup pull-binaries pull-images copy-nodeup-binaries

--- a/projects/kubernetes/kops/Makefile
+++ b/projects/kubernetes/kops/Makefile
@@ -6,7 +6,7 @@ KOPS_VERSION_TAG?="v1.23.2"
 KOPS_REPO_URL?="https://github.com/kubernetes/kops.git"
 NODEUP_FLANNEL_PLUGIN_PATCH="0001-remove-hardcoded-requierment-on-flannel-plugin.patch"
 
-.PHONY build:
+.PHONY: build
 build: clone-kops patch-nodeup build-nodeup pull-binaries pull-images copy-nodeup-binaries
 
 .PHONY: clone-kops

--- a/projects/kubernetes/kops/Makefile
+++ b/projects/kubernetes/kops/Makefile
@@ -5,10 +5,8 @@ CLONED_REPO_DIRECTORY:=$(PROJECT_DIRECTORY)/kops
 KOPS_VERSION_TAG?="v1.23.2"
 KOPS_REPO_URL?="https://github.com/kubernetes/kops.git"
 
-ARTIFACTS_BUCKET?=""
-
 .PHONY: build
-build: clone-kops patch-nodeup build-nodeup pull-binaries pull-images move-nodeup-binaries sync-artifacts-to-s3-dry-run
+build: check-env clone-kops patch-nodeup build-nodeup pull-binaries pull-images move-nodeup-binaries sync-artifacts-to-s3-dry-run
 
 .PHONY: release
 release: build sync-artifacts-to-s3
@@ -39,15 +37,20 @@ move-nodeup-binaries:
 	source $(PROJECT_DIRECTORY)/kops_artifacts_management_tools.sh && move_nodeup_binaries
 
 .PHONY: sync-artifacts-to-s3-dry-run
-sync-artifacts-to-s3-dry-run:
+sync-artifacts-to-s3-dry-run: check-env
 	source $(PROJECT_DIRECTORY)/kops_artifacts_management_tools.sh && sync_artifacts_to_s3 $(ARTIFACTS_BUCKET) $(PROJECT_DIRECTORY)/output/kops kops false true
 
-
 .PHONY: sync-artifacts-to-s3
-sync-artifacts-to-s3:
+sync-artifacts-to-s3: check-env
 	source $(PROJECT_DIRECTORY)/kops_artifacts_management_tools.sh && sync_artifacts_to_s3 $(ARTIFACTS_BUCKET) $(PROJECT_DIRECTORY)/output/kops kops false false
 
 .PHONY: clean
 clean:
 	rm -rf $(CLONED_REPO_DIRECTORY)
 	rm -rf $(PROJECT_DIRECTORY)/output
+
+.PHONY: check-env
+check-env:
+ifndef ARTIFACTS_BUCKET
+$(error environment variable ARTIFACTS_BUCKET is undefined)
+endif

--- a/projects/kubernetes/kops/Makefile
+++ b/projects/kubernetes/kops/Makefile
@@ -8,7 +8,7 @@ KOPS_REPO_URL?="https://github.com/kubernetes/kops.git"
 ARTIFACTS_BUCKET?=""
 
 .PHONY: build
-build: clone-kops patch-nodeup build-nodeup pull-binaries pull-images move-nodeup-binaries
+build: clone-kops patch-nodeup build-nodeup pull-binaries pull-images move-nodeup-binaries sync-artifacts-to-s3-dry-run
 
 .PHONY: release
 release: build sync-artifacts-to-s3
@@ -20,7 +20,7 @@ clone-kops:
 .PHONY: patch-nodeup
 patch-nodeup:
 	git -C $(CLONED_REPO_DIRECTORY) checkout $(KOPS_VERSION_TAG)
-	git -C $(CLONED_REPO_DIRECTORY) am ../patches/*
+	git -C $(CLONED_REPO_DIRECTORY) am $(PROJECT_DIRECTORY)/patches/*
 
 .PHONY: build-nodeup
 build-nodeup:

--- a/projects/kubernetes/kops/Makefile
+++ b/projects/kubernetes/kops/Makefile
@@ -5,6 +5,9 @@ CLONED_REPO_DIRECTORY:=$(PROJECT_DIRECTORY)/kops
 KOPS_VERSION_TAG?="v1.23.2"
 KOPS_REPO_URL?="https://github.com/kubernetes/kops.git"
 
+GITHUB_EMAIL?="prow@amazonaws.com"
+GITHUB_USER?="Prow Bot"
+
 .PHONY: build
 build: check-env clone-kops patch-nodeup build-nodeup pull-binaries pull-images move-nodeup-binaries sync-artifacts-to-s3-dry-run
 
@@ -17,8 +20,10 @@ clone-kops:
 
 .PHONY: patch-nodeup
 patch-nodeup:
+	git -C $(CLONED_REPO_DIRECTORY) config user.email $(GITHUB_EMAIL)
+	git -C $(CLONED_REPO_DIRECTORY) config user.name $(GITHUB_USER)
 	git -C $(CLONED_REPO_DIRECTORY) checkout $(KOPS_VERSION_TAG)
-	git -C $(CLONED_REPO_DIRECTORY) am $(PROJECT_DIRECTORY)/patches/*
+	git -C $(CLONED_REPO_DIRECTORY) am --committer-date-is-author-date $(PROJECT_DIRECTORY)/patches/*
 
 .PHONY: build-nodeup
 build-nodeup:

--- a/projects/kubernetes/kops/Makefile
+++ b/projects/kubernetes/kops/Makefile
@@ -16,7 +16,7 @@ clone-kops:
 .PHONY: patch-nodeup
 patch-nodeup:
 	git -C $(CLONED_REPO_DIRECTORY) checkout $(KOPS_VERSION_TAG)
-	git -C $(CLONED_REPO_DIRECTORY) am ../patches/$(NODEUP_FLANNEL_PLUGIN_PATCH)
+	git -C $(CLONED_REPO_DIRECTORY) am ../patches/*
 
 .PHONY: build-nodeup
 build-nodeup:

--- a/projects/kubernetes/kops/Makefile
+++ b/projects/kubernetes/kops/Makefile
@@ -1,0 +1,40 @@
+BASE_DIRECTORY:=$(shell git rev-parse --show-toplevel)
+PROJECT_DIRECTORY:=$(BASE_DIRECTORY)/projects/kubernetes/kops
+CLONED_REPO_DIRECTORY:=$(PROJECT_DIRECTORY)/kops
+
+KOPS_VERSION_TAG?="v1.23.2"
+KOPS_REPO_URL?="https://github.com/kubernetes/kops.git"
+NODEUP_FLANNEL_PLUGIN_PATCH="0001-remove-hardcoded-requierment-on-flannel-plugin.patch"
+
+.PHONY build:
+build: clone-kops patch-nodeup build-nodeup pull-binaries pull-images copy-nodeup-binaries
+
+.PHONY: clone-kops
+clone-kops:
+	git clone $(KOPS_REPO_URL)
+
+.PHONY: patch-nodeup
+patch-nodeup:
+	git -C $(CLONED_REPO_DIRECTORY) checkout $(KOPS_VERSION_TAG)
+	git -C $(CLONED_REPO_DIRECTORY) am ../patches/$(NODEUP_FLANNEL_PLUGIN_PATCH)
+
+.PHONY: build-nodeup
+build-nodeup:
+	(cd $(CLONED_REPO_DIRECTORY) && make crossbuild-nodeup)
+
+.PHONY: pull-binaries
+pull-binaries:
+	source $(PROJECT_DIRECTORY)/kops_artifacts_management_tools.sh && fetch_kops_binaries
+
+.PHONY: pull-images
+pull-images:
+	source $(PROJECT_DIRECTORY)/kops_artifacts_management_tools.sh && fetch_kops_images
+
+.PHONY: copy-nodeup-binaries
+copy-nodeup-binaries:
+	source $(PROJECT_DIRECTORY)/kops_artifacts_management_tools.sh && copy_nodeup_binaries
+
+.PHONY: clean
+clean:
+	rm -rf $(CLONED_REPO_DIRECTORY)
+	rm -rf $(PROJECT_DIRECTORY)/output

--- a/projects/kubernetes/kops/kops_artifacts_management_tools.sh
+++ b/projects/kubernetes/kops/kops_artifacts_management_tools.sh
@@ -81,7 +81,7 @@ move_nodeup_binaries() {
       local binary_upload_path="$OUTPUT_DIR/$KOPS_VERSION_TAG/$PLATFORM/$ARCH/nodeup"
       cp "$binary_path" "$binary_upload_path"
       # While we're in here, we generate the checksums for the nodeup binaries and output them to the output dir
-      shasum -a 256 "$binary_path" | cut -d " " -f 1 >> "${binary_upload_path}${SHA_SUFFIX}"
+      sha256sum "$binary_path" | cut -d " " -f 1 >> "${binary_upload_path}${SHA_SUFFIX}"
     done
   done
 }

--- a/projects/kubernetes/kops/kops_artifacts_management_tools.sh
+++ b/projects/kubernetes/kops/kops_artifacts_management_tools.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+set -o pipefail
+set -x
+
+BASE_DIRECTORY="$(git rev-parse --show-toplevel)"
+PROJECT_DIRECTORY="$BASE_DIRECTORY/projects/kubernetes/kops"
+
+OUTPUT_DIR="$PROJECT_DIRECTORY/output/kops"
+
+KOPS_VERSION_TAG="1.23.2"
+
+KOPS_BINARIES_BASE_URL="https://artifacts.k8s.io/binaries/kops"
+CHANNELS_BINARY="channels"
+PROTOKUBE_BINARY="protokube"
+KOPS_BINARIES=("$CHANNELS_BINARY" "$PROTOKUBE_BINARY")
+
+DNS_CONTROLLER="dns-controller"
+KOPS_CONTROLLER="kops-controller"
+KUBE_APISERVER_HEALTHCHECK="kube-apiserver-healthcheck"
+KOPS_IMAGES=("$DNS_CONTROLLER" "$KOPS_CONTROLLER" "$KUBE_APISERVER_HEALTHCHECK")
+
+SUPPORTED_ARCHS=("arm64" "amd64")
+SUPPORTED_PLATFORMS=("linux")
+
+SHA_SUFFIX=".sha256"
+TARBALL_SUFFIX=".tar.gz"
+
+fetch_kops_binaries() {
+  for BINARY in "${KOPS_BINARIES[@]}"
+  do
+    for ARCH in "${SUPPORTED_ARCHS[@]}"
+    do
+      for PLATFORM in "${SUPPORTED_PLATFORMS[@]}"
+      do
+          local kops_artifacts_output_dir="$OUTPUT_DIR/$KOPS_VERSION_TAG/$PLATFORM/$ARCH"
+          local release_artifact_url="$KOPS_BINARIES_BASE_URL/$KOPS_VERSION_TAG/$PLATFORM/$ARCH/$BINARY"
+          local release_artifact_checksum_url="${release_artifact_url}${SHA_SUFFIX}"
+          curl -L --create-dirs -o "$kops_artifacts_output_dir/$BINARY" "$release_artifact_url"
+          curl -L --create-dirs -o "$kops_artifacts_output_dir/${BINARY}${SHA_SUFFIX}" "$release_artifact_checksum_url"
+      done
+    done
+  done
+}
+
+fetch_kops_images() {
+  for IMAGE in "${KOPS_IMAGES[@]}"
+  do
+      for ARCH in "${SUPPORTED_ARCHS[@]}"
+      do
+        local image_name="$IMAGE-{$ARCH}{$TARBALL_SUFFIX}"
+        local image_output_dir="$OUTPUT_DIR/$KOPS_VERSION_TAG/images"
+        local image_url="$KOPS_BINARIES_BASE_URL/$KOPS_VERSION_TAG/images/$image_name"
+        local image_checksum_url="${image_url}${SHA_SUFFIX}"
+        curl -L --create-dirs -o "$image_output_dir/$image_name" "$image_url"
+        curl -L --create-dirs -o "$image_output_dir/${image_name}${SHA_SUFFIX}" "$image_checksum_url"
+      done
+  done
+}
+
+move_nodeup_binaries() {
+  for ARCH in "${SUPPORTED_ARCHS[@]}"
+  do
+    for PLATFORM in "${SUPPORTED_PLATFORMS[@]}"
+    do
+      local binary_path="$PROJECT_DIRECTORY/kops/.build/dist/$PLATFORM/$ARCH/nodeup"
+      local binary_upload_path="$OUTPUT_DIR/$KOPS_VERSION_TAG/$PLATFORM/$ARCH/nodeup"
+      cp "$binary_path" "$binary_upload_path"
+      # While we're in here, we generate the checksums for the nodeup binaries and output them to the output dir
+      shasum -a 256 "$binary_path" | cut -d " " -f 1 >> "${binary_upload_path}${SHA_SUFFIX}"
+    done
+  done
+}

--- a/projects/kubernetes/kops/kops_artifacts_management_tools.sh
+++ b/projects/kubernetes/kops/kops_artifacts_management_tools.sh
@@ -117,14 +117,14 @@ sync_artifacts_to_s3() {
     echo "this is not a dry run!"
   fi
 
-  public_acl_argument=" "
+  public_acl_argument=""
   if [ "$public_read" = "true" ]; then
-    public_acl_argument=" --acl public-read "
+    public_acl_argument="--acl public-read"
   fi
 
   if [ "$dry_run" = "true" ]; then
-  aws s3 cp $src_dir s3://${artifact_bucket}/${dest_dir}${public_acl_argument}--recursive --dryrun
+  aws s3 cp $src_dir s3://${artifact_bucket}/${dest_dir} --recursive --dryrun ${public_acl_argument}
     else
-  aws s3 sync $src_dir s3://${artifact_bucket}/${dest_dir}${public_acl_argument}
+  aws s3 sync $src_dir s3://${artifact_bucket}/${dest_dir} ${public_acl_argument}
 fi
 }

--- a/projects/kubernetes/kops/kops_artifacts_management_tools.sh
+++ b/projects/kubernetes/kops/kops_artifacts_management_tools.sh
@@ -62,7 +62,7 @@ fetch_kops_images() {
   do
       for ARCH in "${SUPPORTED_ARCHS[@]}"
       do
-        local image_name="$IMAGE-{$ARCH}{$TARBALL_SUFFIX}"
+        local image_name="$IMAGE-${ARCH}${TARBALL_SUFFIX}"
         local image_output_dir="$OUTPUT_DIR/$KOPS_VERSION_TAG/images"
         local image_url="$KOPS_BINARIES_BASE_URL/$KOPS_VERSION_TAG/images/$image_name"
         local image_checksum_url="${image_url}${SHA_SUFFIX}"
@@ -84,4 +84,47 @@ move_nodeup_binaries() {
       shasum -a 256 "$binary_path" | cut -d " " -f 1 >> "${binary_upload_path}${SHA_SUFFIX}"
     done
   done
+}
+
+sync_artifacts_to_s3() {
+  local artifact_bucket=$1
+  local src_dir=$2
+  local dest_dir=$3
+  local public_read=$4
+  local dry_run=$5
+
+  if [ $# -le 3 ] ; then
+    echo "not enough parameters supplied!"
+  fi
+
+  if [ -z "$1" ] ; then
+    echo "first parameter, target artifacts s3 bucket, is required!" && exit 1;
+  fi
+
+  if [ -z "$2" ] ; then
+    echo "second parameter source directory is required!" && exit 1;
+  fi
+
+  if [ -z "$3" ] ; then
+    echo "third parameter destination directory is required!" && exit 1;
+  fi
+
+  if [ -z "$4" ] ; then
+    echo "fourth parameter, public read for s3, is required" && exit 1;
+  fi
+
+  if [ -z "$5" ] ; then
+    echo "this is not a dry run!"
+  fi
+
+  public_acl_argument=" "
+  if [ "$public_read" = "true" ]; then
+    public_acl_argument=" --acl public-read "
+  fi
+
+  if [ "$dry_run" = "true" ]; then
+  aws s3 cp $src_dir s3://${artifact_bucket}/${dest_dir}${public_acl_argument}--recursive --dryrun
+    else
+  aws s3 sync $src_dir s3://${artifact_bucket}/${dest_dir}${public_acl_argument}
+fi
 }

--- a/projects/kubernetes/kops/patches/0001-remove-hardcoded-requierment-on-flannel-plugin.patch
+++ b/projects/kubernetes/kops/patches/0001-remove-hardcoded-requierment-on-flannel-plugin.patch
@@ -1,0 +1,28 @@
+From 2ec5afbedada5688c13aa8e8d9ac9ffba3ae4511 Mon Sep 17 00:00:00 2001
+From: Daniel Budris <budris@amazon.com>
+Date: Wed, 3 Aug 2022 11:50:10 -0400
+Subject: [PATCH] remove hardcoded requierment on flannel plugin
+
+In CNI v1.0.0 the flannel plugin was removed; so, when building EKS Distro 1.23
+or greater the plugin is not present and cannot be loaded.
+However, EKS Distro does not use the flannel plugin in any cases
+and the requierment hard-coded in kOps can be safely removed.
+
+---
+ nodeup/pkg/model/networking/common.go | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/nodeup/pkg/model/networking/common.go b/nodeup/pkg/model/networking/common.go
+index a7a08cb235..4d78eb4836 100644
+--- a/nodeup/pkg/model/networking/common.go
++++ b/nodeup/pkg/model/networking/common.go
+@@ -34,7 +34,6 @@ func (b *CommonBuilder) Build(c *fi.ModelBuilderContext) error {
+ 	assets := []string{
+ 		"bridge",
+ 		"dhcp",
+-		"flannel",
+ 		"host-device",
+ 		"host-local",
+ 		"ipvlan",
+--
+2.30.1 (Apple Git-130)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
first steps for a project build to patch and build `nodeup` and fetch all of the other kOps binaries + images. if you run `make build` it will:
- clone kOps
- checkout out target version
- apply the patch to remove the flannel dependency to nodeup
- crossbuild nodeup
- pull all the kOps artifacts (binaries + imagse + checksums) for our target platforms + arches from artifacts.k8s.io 
-  generate a checksum for nodeup and copy it into the output dir

the next step here is going to be uploading these artifacts to an S3 bucket so we can source them from kOps, will be in another PR, just wanted to get some eyes on this.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
