### PR TITLE
distro-base: Add conntrack-tools to iptables and allow rpm download i…

### DIFF
--- a/eks-distro-base/Dockerfile.minimal-base
+++ b/eks-distro-base/Dockerfile.minimal-base
@@ -34,7 +34,11 @@ ENV DOWNLOAD_DIR /tmp/download
 ENV NEWROOT /
 
 RUN set -x && \
-    clean_install "binutils cpio findutils shadow-utils yum-utils" && \
+    clean_install binutils \
+        cpio \
+        findutils \
+        shadow-utils \
+        yum-utils && \
     # restorecon is needed for the filesystem scriptlet, but it comes from
     # policycoreutils which bloats the builder image, just pull the bin and the necessary libs instead
     install_binary /usr/sbin/restorecon && \

--- a/eks-distro-base/Dockerfile.minimal-base-csi
+++ b/eks-distro-base/Dockerfile.minimal-base-csi
@@ -48,6 +48,9 @@ RUN set -x && \
     # doesnt reflect, install manually to make sure its first
     clean_install coreutils && \
     if_al2022 clean_install pcre2 && \
-    clean_install "e2fsprogs nfs-utils util-linux xfsprogs" && \
+    clean_install e2fsprogs \
+        nfs-utils \
+        util-linux \
+        xfsprogs && \
     if_al2 remove_package systemd true && \
     cleanup "csi"

--- a/eks-distro-base/Dockerfile.minimal-base-git
+++ b/eks-distro-base/Dockerfile.minimal-base-git
@@ -98,13 +98,13 @@ ENV CLEANUP_UNNECESSARY_FILES="/usr/sbin/sasldblistusers2 /usr/sbin/saslpasswd2 
 
 RUN set -x && \
     export OUTPUT_DEBUG_LOG=${OUTPUT_DEBUG_LOG} && \
-    # we are keeping bash on this image since downstream images use to exec git
-    install_rpm bash ncurses-base \
-        git-core \
+    install_rpm git-core \
         openssh-clients \
         openssl-libs \
         gnupg2 && \
     # ensure all lib deps for the built libssh and libgit are included
     install_deps_for_binary $NEWROOT/usr/lib64/libssh2.so \
         $NEWROOT/usr/lib64/libgit2.so && \    
+    # we are keeping bash on this image since downstream images use to exec git
+    install_rpm bash && \
     cleanup "git"

--- a/eks-distro-base/Dockerfile.minimal-base-iptables
+++ b/eks-distro-base/Dockerfile.minimal-base-iptables
@@ -33,11 +33,12 @@ RUN set -x && \
     export OUTPUT_DEBUG_LOG=${OUTPUT_DEBUG_LOG} && \
     if_al2 install_rpm chkconfig && \
     if_al2022 install_rpm alternatives && \
-    install_rpm ipset \
+    install_rpm conntrack-tools \
+        ipset \
         kmod \
         iptables-nft && \
-    if_al2 install_rpm iptables conntrack-tools ebtables && \
-    if_al2022 install_rpm iptables-legacy ebtables-legacy libnetfilter_conntrack libnfnetlink && \
+    if_al2 install_rpm iptables ebtables && \
+    if_al2022 install_rpm iptables-legacy ebtables-legacy && \
     # AL2 doesn't setup the ip6tables alternative the same as ubuntu/debian
     # which is what the iptables-wrapper script provided by kubernetes expects
     # since kind's entrypoint assumes this adding the alternative

--- a/eks-distro-base/Dockerfile.minimal-base-nginx
+++ b/eks-distro-base/Dockerfile.minimal-base-nginx
@@ -40,7 +40,7 @@ RUN set -x && \
         nginx && \
     if_al2022 install_rpm nginx-core nginx-mimetypes && \
     # TODO: remove these when changes can be coordinated in eks-a-build-tooling
-    install_rpm bash ncurses-base \
+    install_rpm bash \
         coreutils && \
     install_binary /usr/bin/envsubst && \
     cleanup "nginx"

--- a/eks-distro-base/Dockerfile.minimal-base-python
+++ b/eks-distro-base/Dockerfile.minimal-base-python
@@ -37,15 +37,13 @@ COPY scripts/ /usr/bin
 
 RUN set -x && \
     export OUTPUT_DEBUG_LOG=${OUTPUT_DEBUG_LOG} && \
-    install_rpm bash \
-        bzip2-libs \
+    install_rpm bzip2-libs \
         # libc-bin - in glibc
         libdb \
         expat \
         xz-libs \
         sqlite \
         libuuid \
-        ncurses-base \ 
         ncurses-libs \
         # libtinfo5 -> in ncurses-libs
         zlib \
@@ -65,6 +63,8 @@ RUN set -x && \
         openssl-libs && \
     if_al2022 install_rpm libxcrypt sqlite-libs && \
     if_al2 install_rpm libcrypt && \
+    # python depends on bash for shell execs
+    install_rpm bash && \
     cleanup "python-base"
 
 

--- a/eks-distro-base/Makefile
+++ b/eks-distro-base/Makefile
@@ -215,7 +215,7 @@ $(ALL_VALIDATE_IMAGES_MINIMAL_TARGETS):
 $(ALL_TEST_MINIMAL_IMAGES_TARGETS): VARIANT_SHORT_NAME=$(@:test-minimal-images-%=%)
 $(ALL_TEST_MINIMAL_IMAGES_TARGETS):
 	if command -v docker &> /dev/null && docker info > /dev/null 2>&1 ; then \
-		$(MAKE_ROOT)/tests/run_tests.sh $(IMAGE_REPO) $(IMAGE_TAG) $(AL_TAG) $(PLATFORMS) check_$(VARIANT_SHORT_NAME); \
+		$(MAKE_ROOT)/tests/run_tests.sh $(IMAGE_REPO) $(call ADD_VERSIONED_TO_TAG,$(IMAGE_TAG)) $(AL_TAG) $(PLATFORMS) check_$(VARIANT_SHORT_NAME); \
 	fi
 
 

--- a/eks-distro-base/scripts/clean_install
+++ b/eks-distro-base/scripts/clean_install
@@ -13,12 +13,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 set -eE
 set -o nounset
 set -o pipefail
 
 PACKAGES=$1
+
+if [ -n "${2:-}" ] && [[ "$2" != "true" ]] && [[ "$2" != "false" ]]; then
+    # If the second arg is not a bool value, lets assume its the list of packages
+    # which allows the simple case of just installing packages to have a cleaner ux
+    PACKAGES="$@"
+    for arg; do
+        shift
+    done
+fi
+
 SHALLOW=${2:-}
 JUSTDB=${3:-}
 FORCE=${4:-}

--- a/eks-distro-base/scripts/eks-d-common
+++ b/eks-distro-base/scripts/eks-d-common
@@ -163,9 +163,9 @@ function build::common::binary_to_libraries() {
     # If no needed libraries, cache result to avoid future ldd checks
     if [ -z "${needed_libraries}" ]; then
         LIBRARIES_CACHE[$binary]=1
-        [[ ! $binary == *".so"* ]] && echo "No libraries for ${binary}"
+        [[ ! $binary == *".so"* ]] && echo "No missing libraries for ${binary}"
     else
-        [[ ! $binary == *".so"* ]] && echo "Found ${needed_libraries//$'\n'/ } libraries for ${binary}"
+        [[ ! $binary == *".so"* ]] && echo "Found ${needed_libraries//$'\n'/ } libraries needed for ${binary}"
     fi
 
     eval $__resultvar="'${needed_libraries}'"
@@ -286,7 +286,11 @@ function build::common::cp_common_utils_for_rpm_scriptlets() {
     local -r fakeroot="$NEWROOT/fakeroot"
 
     echo "Copying ${reqs} to fakeroot for RPM scriptlets"
-
+    
+    # hide finding libraries output
+    exec 4<&1
+    exec 1> /tmp/out
+    
     for util in ${utils[@]}; do
         local copied_util=$fakeroot$util
         local linked_util=$NEWROOT$util
@@ -328,7 +332,11 @@ function build::common::cp_common_utils_for_rpm_scriptlets() {
             done < <(echo "${__libraries}")
         done
     done
-
+    
+    # restore stdout
+    exec 1<&4
+    rm /tmp/out
+    
     echo "RPM scriptlet prereqs copied"
 }
 
@@ -374,12 +382,25 @@ function build::common::extract_rpm() {
 }
 
 function build::common::clean_install() {
-    local -r packages="$1"
+    local packages="$1"
     local -r shallow=${2:-}
     local just_db=${3:-}
     local -r force=${4:-}
     local -r extract_dir="${5:-$NEWROOT}"
     
+    if [ $just_db ]; then
+        just_db="--justdb"
+    else
+        just_db=""
+
+        # if install bash, there is a transitive dependency, ncurses-base which
+        # is a dependecy of ncurses-libs, which can be installed during previous install_binary/rpm calls
+        # since ncurses-base does not provide .so files, it will not be picked up and it is easy to miss
+        # force installing it to be safe
+        if [[ "$packages" = *"bash"* ]]; then
+            packages+=" ncurses-base"
+        fi
+    fi
 
     if [ ! $shallow ]; then
         echo "Installing $packages and dependencies using yum"
@@ -387,12 +408,6 @@ function build::common::clean_install() {
         yum --installroot $NEWROOT install -y --setopt=install_weak_deps=False $packages
 
         return
-    fi
-
-    if [ $just_db ]; then
-        just_db="--justdb"
-    else
-        just_db=""
     fi
 
     # when the `filesystem` rpm installs it expects these to not exist
@@ -408,7 +423,14 @@ function build::common::clean_install() {
     for rpm in "${rpms[@]}"; do
         if ! ls -d -- $DOWNLOAD_DIR/$rpm-[0-9]*.rpm 1> /dev/null 2>&1; then
             echo "Downloading $rpm"
-            yumdownloader --destdir=$DOWNLOAD_DIR -x "*.i686" $rpm > /dev/null 2>&1
+            local url_regex='(https?|ftp|file)://[-[:alnum:]\+&@#/%?=~_|!:,.;]+'
+            if [[ $rpm =~ $url_regex ]]; then
+                mkdir -p $DOWNLOAD_DIR               
+                curl -sSL $rpm -o $DOWNLOAD_DIR/$(basename $rpm)
+                rpm=$(basename $rpm | sed -e 's/\-[0-9].*$//')
+            else
+                yumdownloader --destdir=$DOWNLOAD_DIR -x "*.i686" $rpm > /dev/null 2>&1
+            fi
             echo "$rpm downloaded"
         fi
 
@@ -426,9 +448,9 @@ function build::common::clean_install() {
                 echo "Shallow installing $rpm using the rpm directly"
                 build::common::setup_default_utils_for_rpm_scriptlets
 
-                local -r rpm_sanitized="$(echo ${rpm} | sed 's/\+/PLUS/g; s/\./_/g; s/\-/_/g;')"
-                local -r reqs_var_name="${rpm_sanitized^^}_SCRIPTLET_REQS"
-                local -r reqs="${!reqs_var_name:-}"
+                local rpm_sanitized="$(echo ${rpm} | sed 's/\+/PLUS/g; s/\./_/g; s/\-/_/g;')"
+                local reqs_var_name="${rpm_sanitized^^}_SCRIPTLET_REQS"
+                local reqs="${!reqs_var_name:-}"
 
                 build::common::cp_common_utils_for_rpm_scriptlets "${reqs}"
             fi
@@ -441,8 +463,8 @@ function build::common::clean_install() {
             echo "$rpm installed"
         fi            
         
-        local -r sanitized_rpm="$(echo ${rpm} | sed 's/\+/PLUS/g; s/\./_/g; s/\-/_/g;')"
-        local -r var_name="${sanitized_rpm^^}_IGNORE_SCRIPTLET_ERRORS"
+        local sanitized_rpm="$(echo ${rpm} | sed 's/\+/PLUS/g; s/\./_/g; s/\-/_/g;')"
+        local var_name="${sanitized_rpm^^}_IGNORE_SCRIPTLET_ERRORS"
 
         if [[ -z "${!var_name:-}" ]] && grep -q "scriptlet failed\|command not found" $log_file; then
             local rpm_name=$(basename $rpm_file | sed -e 's/^[0-9]\+://' | sed -e 's/\-[0-9].*$//')

--- a/eks-distro-base/scripts/install_binary
+++ b/eks-distro-base/scripts/install_binary
@@ -45,11 +45,14 @@ function build::install::binary() {
     # download/extract rpm and add to the final rpm db which will be included in the final image
     build::common::extract_rpm $__rpm_package $extract_dir
 
-    local -r extracted_bin=$extract_dir$__expected_filename
+    local extracted_bin=$extract_dir$__expected_filename
 
     if [ ! -f "$extracted_bin" ]; then
-        echo "Error: Filename not included in RPM!"
-        exit 1
+        extracted_bin=$extract_dir${__expected_filename#/usr}
+        if [ ! -f "$extracted_bin" ]; then
+            echo "Error: Filename not included in RPM!"
+            exit 1
+        fi
     fi
 
     # copy desired binary into newroot folder path


### PR DESCRIPTION
…nstall

*Issue #, if available:*

*Description of changes:*

- Rework the ux of the clean_install script a bit to allow multiple packages without quotes, if not passing any additional flags.
- Allow install rpms via url, this will be used by a new image for another team
- al22 added conntrack-tools, adding these to the iptables image
- switched to clean_install for bash to avoid the extra ncurses-base handling
- 
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
