### PR TITLE
use correct sync path for Golang make release target; add readme

### DIFF
--- a/projects/golang/go/1.15/READEME.md
+++ b/projects/golang/go/1.15/READEME.md
@@ -1,0 +1,6 @@
+## Golang 1.15.15 Build for EKS
+### Patches
+The patches in `./patches` include relevant security fixes for go `v1.15.15` which have been released since `v1.15.15` left support. 
+
+### Spec
+The RPM spec file in `./rpmbuild/SPECS` is sourced from the go `v1.15.14` SRPM available on Amazon Linux 2, and modified to include the relevant patches and build the `v1.15.15` source.

--- a/projects/golang/go/Makefile
+++ b/projects/golang/go/Makefile
@@ -51,7 +51,7 @@ clean:
 
 .PHONY: install-deps
 install-deps:
-	yum update -y && yum install -y which git rpmdevtools rpm-build golang-1.15.14-1.amzn2.0.1 pcre-devel glibc-static hostname procps-ng
+	yum update -y && yum install -y which git rpmdevtools awscli rpm-build golang-1.15.14-1.amzn2.0.1 pcre-devel glibc-static hostname procps-ng
 
 .PHONY: check-env
 check-env:

--- a/projects/golang/go/Makefile
+++ b/projects/golang/go/Makefile
@@ -47,13 +47,13 @@ endif
 
 .PHONY: sync-artifacts-to-s3-dry-run
 sync-artifacts-to-s3-dry-run: check-env-release
-	source $(BASE_DIRECTORY)/scripts/sync_to_s3.sh && sync_artifacts_to_s3 $(ARTIFACTS_BUCKET) $(VERSION_DIRECTORY)/rpmbuild/X86_64 golang/go/$(GIT_TAG)/RPMS/X86_64 true true
-	source $(BASE_DIRECTORY)/scripts/sync_to_s3.sh && sync_artifacts_to_s3 $(ARTIFACTS_BUCKET) $(VERSION_DIRECTORY)/rpmbuild/noarch golang/go/$(GIT_TAG)/RPMS/noarch true true
+	source $(BASE_DIRECTORY)/scripts/sync_to_s3.sh && sync_artifacts_to_s3 $(ARTIFACTS_BUCKET) $(VERSION_DIRECTORY)/rpmbuild/X86_64/ golang/go/$(GIT_TAG)/RPMS/X86_64/ true true
+	source $(BASE_DIRECTORY)/scripts/sync_to_s3.sh && sync_artifacts_to_s3 $(ARTIFACTS_BUCKET) $(VERSION_DIRECTORY)/rpmbuild/noarch/ golang/go/$(GIT_TAG)/RPMS/noarch/ true true
 
 .PHONY: sync-artifacts-to-s3
 sync-artifacts-to-s3: check-env-release
-	source $(BASE_DIRECTORY)/scripts/sync_to_s3.sh && sync_artifacts_to_s3 $(ARTIFACTS_BUCKET) $(VERSION_DIRECTORY)/rpmbuild/X86_64 golang/go/$(GIT_TAG)/RPMS/X86_64 true false
-	source $(BASE_DIRECTORY)/scripts/sync_to_s3.sh && sync_artifacts_to_s3 $(ARTIFACTS_BUCKET) $(VERSION_DIRECTORY)/rpmbuild/noarch golang/go/$(GIT_TAG)/RPMS/noarch true false
+	source $(BASE_DIRECTORY)/scripts/sync_to_s3.sh && sync_artifacts_to_s3 $(ARTIFACTS_BUCKET) $(VERSION_DIRECTORY)/rpmbuild/X86_64/ golang/go/$(GIT_TAG)/RPMS/X86_64/ true false
+	source $(BASE_DIRECTORY)/scripts/sync_to_s3.sh && sync_artifacts_to_s3 $(ARTIFACTS_BUCKET) $(VERSION_DIRECTORY)/rpmbuild/noarch/ golang/go/$(GIT_TAG)/RPMS/noarch/ true false
 
 .PHONY: clean
 clean:

--- a/projects/golang/go/Makefile
+++ b/projects/golang/go/Makefile
@@ -11,7 +11,10 @@ GITHUB_EMAIL?="prow@amazonaws.com"
 GITHUB_USER?="Prow Bot"
 
 .PHONY: build
-build: check-env setup-rpm-tree fetch-golang-source-archive copy-sources-to-rpmbuild-tree copy-patches-to-rpmbuild-tree build-golang-rpm
+build: check-env setup-rpm-tree fetch-golang-source-archive copy-sources-to-rpmbuild-tree copy-patches-to-rpmbuild-tree build-golang-rpm sync-artifacts-to-s3-dry-run
+
+.PHONY: release
+release: build sync-artifacts-to-s3
 
 .PHONY: fetch-golang-source-archive
 fetch-golang-source-archive:
@@ -42,6 +45,14 @@ ifeq (, $(shell which rpmbuild))
 endif
 	rpmbuild -ba $(VERSION_DIRECTORY)/rpmbuild/SPECS/golang.spec --define "_rpmdir $(VERSION_DIRECTORY)/rpmbuild"
 
+.PHONY: sync-artifacts-to-s3-dry-run
+sync-artifacts-to-s3-dry-run: check-env-release
+	source $(BASE_DIRECTORY)/scripts/sync_to_s3.sh && sync_artifacts_to_s3 $(ARTIFACTS_BUCKET) $(VERSION_DIRECTORY)/rpmbuild/RPMS golang/go/$(GIT_TAG)/RPMS true true
+
+.PHONY: sync-artifacts-to-s3
+sync-artifacts-to-s3: check-env-release
+	source $(BASE_DIRECTORY)/scripts/sync_to_s3.sh && sync_artifacts_to_s3 $(ARTIFACTS_BUCKET) $(VERSION_DIRECTORY)/rpmbuild/RPMS golang/go/$(GIT_TAG)/RPMS true false
+
 .PHONY: clean
 clean:
 	rm -rf $(CLONED_REPO_DIRECTORY)
@@ -52,6 +63,12 @@ clean:
 .PHONY: install-deps
 install-deps:
 	yum update -y && yum install -y which git rpmdevtools awscli rpm-build golang-1.15.14-1.amzn2.0.1 pcre-devel glibc-static hostname procps-ng
+
+.PHONY: check-env-release
+check-env-release:
+ifndef ARTIFACTS_BUCKET
+$(error environment variable ARTIFACTS_BUCKET is undefined)
+endif
 
 .PHONY: check-env
 check-env:

--- a/projects/golang/go/Makefile
+++ b/projects/golang/go/Makefile
@@ -47,11 +47,13 @@ endif
 
 .PHONY: sync-artifacts-to-s3-dry-run
 sync-artifacts-to-s3-dry-run: check-env-release
-	source $(BASE_DIRECTORY)/scripts/sync_to_s3.sh && sync_artifacts_to_s3 $(ARTIFACTS_BUCKET) $(VERSION_DIRECTORY)/rpmbuild/RPMS golang/go/$(GIT_TAG)/RPMS true true
+	source $(BASE_DIRECTORY)/scripts/sync_to_s3.sh && sync_artifacts_to_s3 $(ARTIFACTS_BUCKET) $(VERSION_DIRECTORY)/rpmbuild/X86_64 golang/go/$(GIT_TAG)/RPMS/X86_64 true true
+	source $(BASE_DIRECTORY)/scripts/sync_to_s3.sh && sync_artifacts_to_s3 $(ARTIFACTS_BUCKET) $(VERSION_DIRECTORY)/rpmbuild/noarch golang/go/$(GIT_TAG)/RPMS/noarch true true
 
 .PHONY: sync-artifacts-to-s3
 sync-artifacts-to-s3: check-env-release
-	source $(BASE_DIRECTORY)/scripts/sync_to_s3.sh && sync_artifacts_to_s3 $(ARTIFACTS_BUCKET) $(VERSION_DIRECTORY)/rpmbuild/RPMS golang/go/$(GIT_TAG)/RPMS true false
+	source $(BASE_DIRECTORY)/scripts/sync_to_s3.sh && sync_artifacts_to_s3 $(ARTIFACTS_BUCKET) $(VERSION_DIRECTORY)/rpmbuild/X86_64 golang/go/$(GIT_TAG)/RPMS/X86_64 true false
+	source $(BASE_DIRECTORY)/scripts/sync_to_s3.sh && sync_artifacts_to_s3 $(ARTIFACTS_BUCKET) $(VERSION_DIRECTORY)/rpmbuild/noarch golang/go/$(GIT_TAG)/RPMS/noarch true false
 
 .PHONY: clean
 clean:

--- a/projects/golang/go/Makefile
+++ b/projects/golang/go/Makefile
@@ -47,13 +47,13 @@ endif
 
 .PHONY: sync-artifacts-to-s3-dry-run
 sync-artifacts-to-s3-dry-run: check-env-release
-	source $(BASE_DIRECTORY)/scripts/sync_to_s3.sh && sync_artifacts_to_s3 $(ARTIFACTS_BUCKET) $(VERSION_DIRECTORY)/rpmbuild/X86_64/ golang/go/$(GIT_TAG)/RPMS/X86_64/ true true
-	source $(BASE_DIRECTORY)/scripts/sync_to_s3.sh && sync_artifacts_to_s3 $(ARTIFACTS_BUCKET) $(VERSION_DIRECTORY)/rpmbuild/noarch/ golang/go/$(GIT_TAG)/RPMS/noarch/ true true
+	source $(BASE_DIRECTORY)/scripts/sync_to_s3.sh && sync_artifacts_to_s3 $(ARTIFACTS_BUCKET) $(VERSION_DIRECTORY)/rpmbuild/x86_64 golang/go/$(GIT_TAG)/RPMS/x86_64 true true
+	source $(BASE_DIRECTORY)/scripts/sync_to_s3.sh && sync_artifacts_to_s3 $(ARTIFACTS_BUCKET) $(VERSION_DIRECTORY)/rpmbuild/noarch golang/go/$(GIT_TAG)/RPMS/noarch true true
 
 .PHONY: sync-artifacts-to-s3
 sync-artifacts-to-s3: check-env-release
-	source $(BASE_DIRECTORY)/scripts/sync_to_s3.sh && sync_artifacts_to_s3 $(ARTIFACTS_BUCKET) $(VERSION_DIRECTORY)/rpmbuild/X86_64/ golang/go/$(GIT_TAG)/RPMS/X86_64/ true false
-	source $(BASE_DIRECTORY)/scripts/sync_to_s3.sh && sync_artifacts_to_s3 $(ARTIFACTS_BUCKET) $(VERSION_DIRECTORY)/rpmbuild/noarch/ golang/go/$(GIT_TAG)/RPMS/noarch/ true false
+	source $(BASE_DIRECTORY)/scripts/sync_to_s3.sh && sync_artifacts_to_s3 $(ARTIFACTS_BUCKET) $(VERSION_DIRECTORY)/rpmbuild/x86_64 golang/go/$(GIT_TAG)/RPMS/x86_64 true false
+	source $(BASE_DIRECTORY)/scripts/sync_to_s3.sh && sync_artifacts_to_s3 $(ARTIFACTS_BUCKET) $(VERSION_DIRECTORY)/rpmbuild/noarch golang/go/$(GIT_TAG)/RPMS/noarch true false
 
 .PHONY: clean
 clean:

--- a/scripts/sync_to_s3.sh
+++ b/scripts/sync_to_s3.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+set -o pipefail
+set -x
+
+sync_artifacts_to_s3() {
+  local artifact_bucket=$1
+  local src_dir=$2
+  local dest_dir=$3
+  local public_read=$4
+  local dry_run=$5
+
+  if [ $# -le 3 ] ; then
+    echo "not enough parameters supplied!"
+  fi
+
+  if [ -z "$1" ] ; then
+    echo "first parameter, target artifacts s3 bucket, is required!" && exit 1;
+  fi
+
+  if [ -z "$2" ] ; then
+    echo "second parameter source directory is required!" && exit 1;
+  fi
+
+  if [ -z "$3" ] ; then
+    echo "third parameter destination directory is required!" && exit 1;
+  fi
+
+  if [ -z "$4" ] ; then
+    echo "fourth parameter, public read for s3, is required" && exit 1;
+  fi
+
+  if [ -z "$5" ] ; then
+    echo "this is not a dry run!"
+  fi
+
+  public_acl_argument=""
+  if [ "$public_read" = "true" ]; then
+    public_acl_argument="--acl public-read"
+  fi
+
+  if [ "$dry_run" = "true" ]; then
+  aws s3 cp $src_dir s3://${artifact_bucket}/${dest_dir} --recursive --dryrun ${public_acl_argument}
+    else
+  aws s3 sync $src_dir s3://${artifact_bucket}/${dest_dir} ${public_acl_argument}
+fi
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Update the make target to correctly upload the necessary artifacts to the post-submit bucket when we run 'release'.

Add simple README for go 1.15. 

This PR is primarily intended to trigger and test the presubmits and post-submits, and the readme will be expanded over time.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
