### PR TITLE
go 1.15 patch to support TestTicker test on overloaded systems

### DIFF
--- a/projects/golang/go/1.15/patches/0104-time-fallback-to-slower-TestTicker-test-after-one-fa.patch
+++ b/projects/golang/go/1.15/patches/0104-time-fallback-to-slower-TestTicker-test-after-one-fa.patch
@@ -1,4 +1,4 @@
-From 4ffa2f1c23d5d43be18c4ebf74ca553119683670 Mon Sep 17 00:00:00 2001
+From 64a9dea455e63bf62c206dc6740dd64a02ec107b Mon Sep 17 00:00:00 2001
 From: Damien Neil <dneil@google.com>
 Date: Wed, 4 Aug 2021 16:07:28 -0700
 Subject: [PATCH] time: fallback to slower TestTicker test after one failure
@@ -26,7 +26,7 @@ Reviewed-by: Ian Lance Taylor <iant@golang.org>
  1 file changed, 17 insertions(+), 6 deletions(-)
 
 diff --git a/src/time/tick_test.go b/src/time/tick_test.go
-index b5d0a189bc..d8cd59228f 100644
+index c0c6e76b53..8be358173f 100644
 --- a/src/time/tick_test.go
 +++ b/src/time/tick_test.go
 @@ -15,10 +15,11 @@ func TestTicker(t *testing.T) {
@@ -43,7 +43,7 @@ index b5d0a189bc..d8cd59228f 100644
 +	baseDelta := 20 * Millisecond
  
  	// On Darwin ARM64 the tick frequency seems limited. Issue 35692.
- 	if (runtime.GOOS == "darwin" || runtime.GOOS == "ios") && runtime.GOARCH == "arm64" {
+ 	if runtime.GOOS == "darwin" && runtime.GOARCH == "arm64" {
 @@ -27,8 +28,8 @@ func TestTicker(t *testing.T) {
  		// Since tick frequency is limited on Darwin ARM64, use even
  		// number to give the ticks more time to let the test pass.
@@ -75,5 +75,5 @@ index b5d0a189bc..d8cd59228f 100644
  		t0 := Now()
  		for i := 0; i < count/2; i++ {
 -- 
-2.30.1 (Apple Git-130)
+2.37.1
 

--- a/projects/golang/go/1.15/patches/0104-time-fallback-to-slower-TestTicker-test-after-one-fa.patch
+++ b/projects/golang/go/1.15/patches/0104-time-fallback-to-slower-TestTicker-test-after-one-fa.patch
@@ -1,0 +1,79 @@
+From 4ffa2f1c23d5d43be18c4ebf74ca553119683670 Mon Sep 17 00:00:00 2001
+From: Damien Neil <dneil@google.com>
+Date: Wed, 4 Aug 2021 16:07:28 -0700
+Subject: [PATCH] time: fallback to slower TestTicker test after one failure
+
+TestTicker is sensitive to overloaded or slow systems, where a 20ms
+ticker running for 10 ticks has a total run time out of the range
+[110ms, 290ms]. To counter this flakiness, it tries five times to
+get a successful result. This is insufficient--an overloaded test
+machine can introduce more than 100ms of delay across the test.
+
+Reduce the five attempts to two, but use a 1s ticker for 8 ticks
+in the second attempt.
+
+Updates #46474.
+Updates #35692.
+
+Change-Id: Ibd5187b00ccceeb981b652f2af9a1c3766357b78
+Reviewed-on: https://go-review.googlesource.com/c/go/+/339892
+Trust: Damien Neil <dneil@google.com>
+Run-TryBot: Damien Neil <dneil@google.com>
+TryBot-Result: Go Bot <gobot@golang.org>
+Reviewed-by: Ian Lance Taylor <iant@golang.org>
+---
+ src/time/tick_test.go | 23 +++++++++++++++++------
+ 1 file changed, 17 insertions(+), 6 deletions(-)
+
+diff --git a/src/time/tick_test.go b/src/time/tick_test.go
+index b5d0a189bc..d8cd59228f 100644
+--- a/src/time/tick_test.go
++++ b/src/time/tick_test.go
+@@ -15,10 +15,11 @@ func TestTicker(t *testing.T) {
+ 	// We want to test that a ticker takes as much time as expected.
+ 	// Since we don't want the test to run for too long, we don't
+ 	// want to use lengthy times. This makes the test inherently flaky.
+-	// So only report an error if it fails five times in a row.
++	// Start with a short time, but try again with a long one if the
++	// first test fails.
+ 
+-	count := 10
+-	delta := 20 * Millisecond
++	baseCount := 10
++	baseDelta := 20 * Millisecond
+ 
+ 	// On Darwin ARM64 the tick frequency seems limited. Issue 35692.
+ 	if (runtime.GOOS == "darwin" || runtime.GOOS == "ios") && runtime.GOARCH == "arm64" {
+@@ -27,8 +28,8 @@ func TestTicker(t *testing.T) {
+ 		// Since tick frequency is limited on Darwin ARM64, use even
+ 		// number to give the ticks more time to let the test pass.
+ 		// See CL 220638.
+-		count = 6
+-		delta = 100 * Millisecond
++		baseCount = 6
++		baseDelta = 100 * Millisecond
+ 	}
+ 
+ 	var errs []string
+@@ -38,7 +39,17 @@ func TestTicker(t *testing.T) {
+ 		}
+ 	}
+ 
+-	for i := 0; i < 5; i++ {
++	for _, test := range []struct {
++		count int
++		delta Duration
++	}{{
++		count: baseCount,
++		delta: baseDelta,
++	}, {
++		count: 8,
++		delta: 1 * Second,
++	}} {
++		count, delta := test.count, test.delta
+ 		ticker := NewTicker(delta)
+ 		t0 := Now()
+ 		for i := 0; i < count/2; i++ {
+-- 
+2.30.1 (Apple Git-130)
+

--- a/projects/golang/go/1.15/rpmbuild/SPECS/golang.spec
+++ b/projects/golang/go/1.15/rpmbuild/SPECS/golang.spec
@@ -251,6 +251,7 @@ Patch21:       0021-add-method-to-skip-privd-tests-if-required.patch
 Patch22:       0101-Don-t-use-the-bundled-tzdata-at-runtime-except-for-t.patch
 Patch23:       0102-syscall-expose-IfInfomsg.X__ifi_pad-on-s390x.patch
 Patch24:       0103-cmd-go-disable-Google-s-proxy-and-sumdb.patch
+Patch25:       0104-time-fallback-to-slower-TestTicker-test-after-one-fa.patch
 
 # Having documentation separate was broken
 Obsoletes:      %{name}-docs < 1.1-4
@@ -401,6 +402,7 @@ Requires:       %{name} = %{version}-%{release}
 %patch22 -p1
 %patch23 -p1
 %patch24 -p1
+%patch25 -p1
 
 %build
 


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/eks-distro-internal/issues/206

*Description of changes:*
we saw the go 1.15 TestTicker tests failing on the post-submits cluster; this can happen on systems with limited CPU or which are over-loaded. Taking this upstream patch to solve this situation.

failure mode in prow post-submits cluster:
```
--- FAIL: TestTicker (2.47s)
    tick_test.go:79: saw 5 errors
    tick_test.go:37: 10 20ms ticks took 474.499355ms, expected [240ms,360ms]
    tick_test.go:37: 10 20ms ticks took 499.98884ms, expected [240ms,360ms]
    tick_test.go:37: 10 20ms ticks took 499.950458ms, expected [240ms,360ms]
    tick_test.go:37: 10 20ms ticks took 520.10247ms, expected [240ms,360ms]
    tick_test.go:37: 10 20ms ticks took 479.824555ms, expected [240ms,360ms]
FAIL
```

upstream CL fix: https://go-review.googlesource.com/c/go/+/339892/
prow logs: https://prow.eks.amazonaws.com/log?job=golang-1.15-tooling-postsubmit&id=1575238598611963904

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
