### PR TITLE
Append job logs link to bot-authored PR descriptions

### DIFF
--- a/pr-scripts/builder_base_pr_body
+++ b/pr-scripts/builder_base_pr_body
@@ -1,3 +1,1 @@
 This PR updates the base image tag in the Tag file and in all the prowjobs with the tag of the most recently built builder-base image. The Codebuild projects will also be updated to use this same tag by a periodic Lambda.
-
-By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

--- a/pr-scripts/prow_deck_pr_body
+++ b/pr-scripts/prow_deck_pr_body
@@ -1,3 +1,1 @@
 This PR updates the Prow deck image URI in the Prow controlplane Helm chart values file with tag from the latest build.
-
-By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


### PR DESCRIPTION
This PR adds a Prowjob logs link to the description of PRs that are opened by the eks-distro-pr-bot. This improves traceability of the PR automation.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
