### PR TITLE
Upgrade node version in builder-base to `v16.17.1`

### DIFF
--- a/builder-base/versions.sh
+++ b/builder-base/versions.sh
@@ -39,7 +39,7 @@ PACKER_VERSION="${PACKER_VERSION:-1.7.2}"
 PACKER_DOWNLOAD_URL="https://releases.hashicorp.com/packer/$PACKER_VERSION/packer_${PACKER_VERSION}_linux_$TARGETARCH.zip"
 PACKER_CHECKSUM_URL="https://releases.hashicorp.com/packer/$PACKER_VERSION/packer_${PACKER_VERSION}_SHA256SUMS"
 
-NODEJS_VERSION="${NODEJS_VERSION:-v15.11.0}"
+NODEJS_VERSION="${NODEJS_VERSION:-v16.17.1}"
 if [ $TARGETARCH == 'amd64' ]; then 
     NODEJS_FILENAME="node-$NODEJS_VERSION-linux-x64.tar.gz"
     NODEJS_FOLDER="node-$NODEJS_VERSION-linux-x64"


### PR DESCRIPTION
*Description of changes:*
builder-base currently has `v15.11.0` which is EOL
Upgrading to the latest stable node version to `v16.17.1`

https://nodejs.org/dist/v16.17.1/
https://nodejs.org/en/

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
