### PR TITLE
1.15 binary patch fix

### DIFF
--- a/projects/golang/go/1.15/patches/0022-go-1.15.15-eks-archive-tar-limit-size-of-head.patch
+++ b/projects/golang/go/1.15/patches/0022-go-1.15.15-eks-archive-tar-limit-size-of-head.patch
@@ -13,7 +13,8 @@ EKS Patch Source Commit: https://github.com/aws/eks-distro-build-tooling/commit/
 
 For building an internal version of go1.15, we removed the binary
 information from this patch caused by ./src/archive/tar/pax-bad-hdr-large.tar.bz2
-it was added to the repo:
+The file itself was added directly to the repository.
+This was done due to fact that `diff`, used by RPMs for patch application, does not support binary diffs.
 https://github.com/aws/eks-distro-build-tooling/projects/golang/go/1.15/rpmbuild/SOURCE/pax-bad-hdr-large.tar.bz2
 
 # Originial Information

--- a/projects/golang/go/1.15/patches/0022-go-1.15.15-eks-archive-tar-limit-size-of-head.patch
+++ b/projects/golang/go/1.15/patches/0022-go-1.15.15-eks-archive-tar-limit-size-of-head.patch
@@ -1,8 +1,7 @@
-From e429b5038a364cbe0c9737cf6d21fba2c37a5b1c Mon Sep 17 00:00:00 2001
+From 18bab2267ddb865bbff5f778bf60a115b145bd74 Mon Sep 17 00:00:00 2001
 From: Damien Neil <dneil@google.com>
 Date: Fri, 2 Sep 2022 20:45:18 -0700
-Subject: [PATCH] [go-1.15.15-eks] archive/tar: limit size of
- headers
+Subject: [PATCH] [release-branch.go1.18] archive/tar: limit size of headers
 
 # AWS EKS
 Backported To: go-1.15.15-eks
@@ -11,6 +10,11 @@ Backported By: rcrozean@amazon.com
 Backported From: release-branch.go1.15
 Source Commit: https://github.com/golang/go/commit/0a723816cd205576945fa57fbdde7e6532d59d08
 EKS Patch Source Commit: 
+
+For building an internal version of go1.15, we removed the binary
+information from this patch caused by ./src/archive/tar/pax-bad-hdr-large.tar.bz2
+it was added to the repo:
+https://github.com/aws/eks-distro-build-tooling/projects/golang/go/1.15/rpmbuild/SOURCE/pax-bad-hdr-large.tar.bz2
 
 # Originial Information
 
@@ -66,7 +70,7 @@ index cfe24a5e1d..6642364de1 100644
  
  // blockPadding computes the number of bytes needed to pad offset up to the
 diff --git a/src/archive/tar/reader.go b/src/archive/tar/reader.go
-index 4f9135b791..d964c3b6b3 100644
+index 4f9135b791..a776e0be28 100644
 --- a/src/archive/tar/reader.go
 +++ b/src/archive/tar/reader.go
 @@ -104,7 +104,7 @@ func (tr *Reader) next() (*Header, error) {
@@ -142,10 +146,6 @@ index f153b668de..c68a859ad8 100644
  				hdrs    []*Header
  				chksums []string
  				rdbuf   = make([]byte, 8)
-diff --git a/src/archive/tar/testdata/pax-bad-hdr-large.tar.bz2 b/src/archive/tar/testdata/pax-bad-hdr-large.tar.bz2
-new file mode 100644
-index 0000000000..06bf710d3a
-Binary files /dev/null and b/src/archive/tar/testdata/pax-bad-hdr-large.tar.bz2 differ
 diff --git a/src/archive/tar/writer.go b/src/archive/tar/writer.go
 index e80498d03e..893eac00ae 100644
 --- a/src/archive/tar/writer.go
@@ -161,7 +161,7 @@ index e80498d03e..893eac00ae 100644
  			return err // Global headers return here
  		}
 diff --git a/src/archive/tar/writer_test.go b/src/archive/tar/writer_test.go
-index 30556d27d0..4bd69fd548 100644
+index 30556d27d0..cbf6a85525 100644
 --- a/src/archive/tar/writer_test.go
 +++ b/src/archive/tar/writer_test.go
 @@ -1007,6 +1007,33 @@ func TestIssue12594(t *testing.T) {

--- a/projects/golang/go/1.15/patches/0022-go-1.15.15-eks-archive-tar-limit-size-of-head.patch
+++ b/projects/golang/go/1.15/patches/0022-go-1.15.15-eks-archive-tar-limit-size-of-head.patch
@@ -1,7 +1,7 @@
 From 18bab2267ddb865bbff5f778bf60a115b145bd74 Mon Sep 17 00:00:00 2001
 From: Damien Neil <dneil@google.com>
 Date: Fri, 2 Sep 2022 20:45:18 -0700
-Subject: [PATCH] [release-branch.go1.18] archive/tar: limit size of headers
+Subject: [PATCH] [go-1.15.15-eks] archive/tar: limit size of headers
 
 # AWS EKS
 Backported To: go-1.15.15-eks
@@ -9,7 +9,7 @@ Backported On: Wed, 5 Oct 2022
 Backported By: rcrozean@amazon.com
 Backported From: release-branch.go1.15
 Source Commit: https://github.com/golang/go/commit/0a723816cd205576945fa57fbdde7e6532d59d08
-EKS Patch Source Commit: 
+EKS Patch Source Commit: https://github.com/aws/eks-distro-build-tooling/commit/1de4158fdca55859eb7cc47dccc9aacbfc0697ed
 
 For building an internal version of go1.15, we removed the binary
 information from this patch caused by ./src/archive/tar/pax-bad-hdr-large.tar.bz2

--- a/projects/golang/go/1.15/patches/0022-go-1.15.15-eks-archive-tar-limit-size-of-head.patch
+++ b/projects/golang/go/1.15/patches/0022-go-1.15.15-eks-archive-tar-limit-size-of-head.patch
@@ -12,7 +12,7 @@ Source Commit: https://github.com/golang/go/commit/0a723816cd205576945fa57fbdde7
 EKS Patch Source Commit: https://github.com/aws/eks-distro-build-tooling/commit/1de4158fdca55859eb7cc47dccc9aacbfc0697ed
 
 For building an internal version of go1.15, we removed the binary
-information from this patch caused by ./src/archive/tar/pax-bad-hdr-large.tar.bz2
+information from this patch, describing ./src/archive/tar/pax-bad-hdr-large.tar.bz2
 The file itself was added directly to the repository.
 This was done due to fact that `diff`, used by RPMs for patch application, does not support binary diffs.
 https://github.com/aws/eks-distro-build-tooling/projects/golang/go/1.15/rpmbuild/SOURCE/pax-bad-hdr-large.tar.bz2


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
There was an issue with applying the patch with git on a local branch after the --no-binary flag was used. Instead I updated the header to describe the removal of the file from the patch (since during the build the binary would still be an issue if included) and it's location in the repo.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
