### PR TITLE
Fixes missing yum repo config in al22

### DIFF
--- a/EKS_DISTRO_TAG_FILE.yaml
+++ b/EKS_DISTRO_TAG_FILE.yaml
@@ -14,17 +14,17 @@ al2:
   eks-distro-minimal-base-nsenter: 2022-07-27-1658910674.2
   eks-distro-minimal-base-python3.9: 3.9-2022-10-11-1665514870.2
 al2022:
-  eks-distro-base: 2022-10-13-1665687739.2022
-  eks-distro-minimal-base: 2022-10-13-1665687739.2022
-  eks-distro-minimal-base-nonroot: 2022-10-13-1665687739.2022
-  eks-distro-minimal-base-glibc: 2022-10-13-1665687739.2022
-  eks-distro-minimal-base-iptables: 2022-10-13-1665687739.2022
-  eks-distro-minimal-base-docker-client: 2022-10-13-1665687739.2022
-  eks-distro-minimal-base-csi: 2022-10-13-1665687739.2022
-  eks-distro-minimal-base-csi-ebs: 2022-10-13-1665687739.2022
-  eks-distro-minimal-base-haproxy: 2022-10-13-1665687739.2022
-  eks-distro-minimal-base-kind: 2022-10-13-1665687739.2022
-  eks-distro-minimal-base-nginx: 2022-10-13-1665687739.2022
-  eks-distro-minimal-base-git: 2022-10-13-1665687739.2022
-  eks-distro-minimal-base-nsenter: 2022-10-13-1665687739.2022
-  eks-distro-minimal-base-python3.9: 3.9-2022-10-13-1665687739.2022
+  eks-distro-base: null
+  eks-distro-minimal-base: null
+  eks-distro-minimal-base-nonroot: null
+  eks-distro-minimal-base-glibc: null
+  eks-distro-minimal-base-iptables: null
+  eks-distro-minimal-base-docker-client: null
+  eks-distro-minimal-base-csi: null
+  eks-distro-minimal-base-csi-ebs: null
+  eks-distro-minimal-base-haproxy: null
+  eks-distro-minimal-base-kind: null
+  eks-distro-minimal-base-nginx: null
+  eks-distro-minimal-base-git: null
+  eks-distro-minimal-base-nsenter: null
+  eks-distro-minimal-base-python3.9: null

--- a/eks-distro-base/Dockerfile.minimal-base
+++ b/eks-distro-base/Dockerfile.minimal-base
@@ -71,6 +71,7 @@ RUN set -x && \
         basesystem \
         tzdata \
         ca-certificates && \
+    if_al2022 install_rpm amazon-linux-repo-cdn && \
     cleanup "base"
 
 COPY files/ $NEWROOT


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

In the latest release of al22, from yesterday, they changed where the yum.repos config comes from. This adds the install for the new package.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
