### PR TITLE
Adds local regi check to be used in presubmit

### DIFF
--- a/scripts/local_registry_check.sh
+++ b/scripts/local_registry_check.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+set -o pipefail
+set -x
+
+function registry_ready() {
+  for i in {1..24}
+  do
+    if ! curl http://$IMAGE_REPO/ > /dev/null 2>&1;
+    then
+      echo "Local registry at ${IMAGE_REPO} is not running. Retrying."
+      sleep 5
+    else
+      exit 0
+    fi
+  done
+  echo "Local registry at ${IMAGE_REPO} is not available"
+  exit 1
+}
+
+registry_ready


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

We ran into an issue yesterday where we were getting rate limited by docker hub pulling the registry container. @abhay-krishna fixed this to pull from ecr, but I figured it doesnst hurt to have a check like this which mirrors what we already do for buildkitd.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
