### PR TITLE
Falls back to find for looking for libs

### DIFF
--- a/eks-distro-base/scripts/eks-d-common
+++ b/eks-distro-base/scripts/eks-d-common
@@ -236,9 +236,13 @@ function build::common::dep_exists() {
         return 0
     fi
 
-    # if does not start with /, it does not exist
     if [[ ! $dep = /* ]]; then
-        return 1
+        # try using find in case it in fact does exist but in a uncommon folder
+        if find $NEWROOT -type f -name $dep -exec false {} +; then
+            # not found
+            return 1
+        fi
+        return 0
     fi
 
     # ldd return the dep that exists in the newroot folder, nothing to do


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

In yesterdays periodic, the iptables arm image could not be built. From the logs it appears that the ldd was working fine for ebtables until all of a sudden it started segfaulting. Once it segfaulted, the code properly fell back to obdump, however objdump does not return full paths.  The libs for the binary in question, ebtables, are under /lib64/ebtables/* which the current code does not search for. 

This PR adds a fallback to find to search across the newroot folder for cases like this.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
