### PR TITLE
Installs nginx-core along with nginx

### DIFF
--- a/EKS_DISTRO_TAG_FILE.yaml
+++ b/EKS_DISTRO_TAG_FILE.yaml
@@ -9,7 +9,7 @@ al2:
   eks-distro-minimal-base-csi-ebs: 2022-10-25-1666703745.2
   eks-distro-minimal-base-haproxy: 2022-10-25-1666703745.2
   eks-distro-minimal-base-kind: 2022-10-25-1666703745.2
-  eks-distro-minimal-base-nginx: 2022-10-25-1666703745.2
+  eks-distro-minimal-base-nginx: null
   eks-distro-minimal-base-git: 2022-10-25-1666703745.2
   eks-distro-minimal-base-nsenter: 2022-10-25-1666703745.2
   eks-distro-minimal-base-python3.9: 3.9-2022-10-25-1666703745.2

--- a/eks-distro-base/Dockerfile.minimal-base-nginx
+++ b/eks-distro-base/Dockerfile.minimal-base-nginx
@@ -37,8 +37,9 @@ RUN set -x && \
     export OUTPUT_DEBUG_LOG=${OUTPUT_DEBUG_LOG} && \
     enable_extra nginx1 && \
     install_rpm nginx-filesystem \         
-        nginx && \
-    if_al2022 install_rpm nginx-core nginx-mimetypes && \
+        nginx \
+        nginx-core && \
+    if_al2022 install_rpm nginx-mimetypes && \
     # TODO: remove these when changes can be coordinated in eks-a-build-tooling
     install_rpm bash \
         coreutils && \


### PR DESCRIPTION
In the newest build of nginx in al2, they introduced the nginx-core package, similar to al22 which includes the mimetypes and other default config files.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
