### PR TITLE
update build badges to relfect arch on readmes

### DIFF
--- a/projects/golang/go/1.15/README.md
+++ b/projects/golang/go/1.15/README.md
@@ -1,5 +1,9 @@
 ## Golang 1.15.15 Build for EKS
-[![Build status](https://prow.eks.amazonaws.com/badge.svg?jobs=*golang-1.15*-tooling-postsubmit)](https://prow.eks.amazonaws.com/?repo=aws%2Feks-distro-build-tooling&type=postsubmit)
+### ARM64 Builds 
+[![Build status](https://prow.eks.amazonaws.com/badge.svg?jobs=golang-1.15-ARM64-PROD-tooling-postsubmit)](https://prow.eks.amazonaws.com/?repo=aws%2Feks-distro-build-tooling&type=postsubmit)
+
+### AMD64 Builds 
+[![Build status](https://prow.eks.amazonaws.com/badge.svg?jobs=golang-1.15-tooling-postsubmit)](https://prow.eks.amazonaws.com/?repo=aws%2Feks-distro-build-tooling&type=postsubmit)
 
 ### Patches
 The patches in `./patches` include relevant security fixes for go `v1.15.15` which have been released since `v1.15.15` left support. 

--- a/projects/golang/go/1.16/README.md
+++ b/projects/golang/go/1.16/README.md
@@ -1,5 +1,10 @@
 # EKS Golang 1.16
-[![Build status](https://prow.eks.amazonaws.com/badge.svg?jobs=*golang-1.16*-tooling-postsubmit)](https://prow.eks.amazonaws.com/?repo=aws%2Feks-distro-build-tooling&type=postsubmit)
+
+### ARM64 Builds
+[![Build status](https://prow.eks.amazonaws.com/badge.svg?jobs=golang-1.16-ARM64-PROD-tooling-postsubmit)](https://prow.eks.amazonaws.com/?repo=aws%2Feks-distro-build-tooling&type=postsubmit)
+
+### AMD64 Builds
+[![Build status](https://prow.eks.amazonaws.com/badge.svg?jobs=golang-1.16-tooling-postsubmit)](https://prow.eks.amazonaws.com/?repo=aws%2Feks-distro-build-tooling&type=postsubmit)
 
 ### Patches
 The patches in `./patches` include relevant security fixes for go `v1.16.15` which have been released since `v1.16.15` left support.

--- a/projects/golang/go/1.17/README.md
+++ b/projects/golang/go/1.17/README.md
@@ -1,6 +1,10 @@
 # EKS Golang 1.17
-[![Build status](https://prow.eks.amazonaws.com/badge.svg?jobs=*golang-1.17*-tooling-postsubmit)](https://prow.eks.amazonaws.com/?repo=aws%2Feks-distro-build-tooling&type=postsubmit)
 
+### ARM64 Builds
+[![Build status](https://prow.eks.amazonaws.com/badge.svg?jobs=golang-1.17-ARM64-PROD-tooling-postsubmit)](https://prow.eks.amazonaws.com/?repo=aws%2Feks-distro-build-tooling&type=postsubmit)
+
+### AMD64 Builds
+[![Build status](https://prow.eks.amazonaws.com/badge.svg?jobs=golang-1.17-tooling-postsubmit)](https://prow.eks.amazonaws.com/?repo=aws%2Feks-distro-build-tooling&type=postsubmit)
 
 ### Patches
 The patches in `./patches` include relevant security fixes for go `v1.17.13` which have been released since `1.17.13` left support.

--- a/projects/golang/go/1.18/README.md
+++ b/projects/golang/go/1.18/README.md
@@ -1,5 +1,10 @@
 # EKS Golang 1.18
-[![Build status](https://prow.eks.amazonaws.com/badge.svg?jobs=*golang-1.18*-tooling-postsubmit)](https://prow.eks.amazonaws.com/?repo=aws%2Feks-distro-build-tooling&type=postsubmit)
+
+### ARM64 Builds
+[![Build status](https://prow.eks.amazonaws.com/badge.svg?jobs=golang-1.18-ARM64-PROD-tooling-postsubmit)](https://prow.eks.amazonaws.com/?repo=aws%2Feks-distro-build-tooling&type=postsubmit)
+
+### AMD64 Builds
+[![Build status](https://prow.eks.amazonaws.com/badge.svg?jobs=golang-1.18-tooling-postsubmit)](https://prow.eks.amazonaws.com/?repo=aws%2Feks-distro-build-tooling&type=postsubmit)
 
 ### Patches
 The patches in `./patches` include relevant security fixes for go `v1.18.7`.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
update build badges on go version readmes to relfect arch builds

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
