### PR TITLE
Add templates for buildkit-testing role, rolebinding and namespace

### DIFF
--- a/helm-charts/stable/prow-data-plane/Chart.yaml
+++ b/helm-charts/stable/prow-data-plane/Chart.yaml
@@ -29,7 +29,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.0
+version: 1.0.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm-charts/stable/prow-data-plane/templates/buildkit-orchestration-Namespace.yaml
+++ b/helm-charts/stable/prow-data-plane/templates/buildkit-orchestration-Namespace.yaml
@@ -12,10 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-region: 'us-west-2'
-
-s3Credentials:
-  Secret:
-    create: true
-
-serviceAccountName: default
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: buildkit-orchestration

--- a/helm-charts/stable/prow-data-plane/templates/buildkit-orchestration-Role.yaml
+++ b/helm-charts/stable/prow-data-plane/templates/buildkit-orchestration-Role.yaml
@@ -12,10 +12,29 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-region: 'us-west-2'
-
-s3Credentials:
-  Secret:
-    create: true
-
-serviceAccountName: default
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: buildkit-orchestration-role
+  namespace: buildkit-orchestration
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - list
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - get
+  - delete
+  - create
+- apiGroups:
+  - ""
+  resources:
+  - pods/exec
+  verbs:
+  - create

--- a/helm-charts/stable/prow-data-plane/templates/buildkit-orchestration-RoleBinding.yaml
+++ b/helm-charts/stable/prow-data-plane/templates/buildkit-orchestration-RoleBinding.yaml
@@ -12,10 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-region: 'us-west-2'
-
-s3Credentials:
-  Secret:
-    create: true
-
-serviceAccountName: default
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: buildkit-orchestration-rolebinding
+  namespace: buildkit-orchestration
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: buildkit-orchestration-role
+subjects:
+- namespace: default 
+  kind: ServiceAccount
+  name: {{ .Values.serviceAccountName }}


### PR DESCRIPTION
Add new templates for buildkit-testing role, rolebinding and namespace to the dataplane cluster Helm charts.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
