### PR TITLE
update EKS Go RPM spec to include unified release string format

### DIFF
--- a/projects/golang/go/1.16/rpmbuild/SPECS/golang.spec
+++ b/projects/golang/go/1.16/rpmbuild/SPECS/golang.spec
@@ -113,7 +113,7 @@
 
 Name:           golang
 Version:        %{go_version}
-Release: %{baserelease}%{?dist}.0.1
+Release:        %{?_buildid}%{?dist}.eks
 Summary:        The Go Programming Language
 # source tree includes several copies of Mark.Twain-Tom.Sawyer.txt under Public Domain
 License:        BSD and Public Domain

--- a/projects/golang/go/1.17/rpmbuild/SPECS/golang.spec
+++ b/projects/golang/go/1.17/rpmbuild/SPECS/golang.spec
@@ -113,7 +113,7 @@
 
 Name:           golang
 Version:        %{go_version}
-Release: %{baserelease}%{?dist}.0.1
+Release:        %{?_buildid}%{?dist}.eks
 Summary:        The Go Programming Language
 # source tree includes several copies of Mark.Twain-Tom.Sawyer.txt under Public Domain
 License:        BSD and Public Domain

--- a/projects/golang/go/1.18/rpmbuild/SPECS/golang.spec
+++ b/projects/golang/go/1.18/rpmbuild/SPECS/golang.spec
@@ -118,7 +118,7 @@
  
 Name:           golang
 Version:        %{go_version}
-Release:        %{baserelease}%{?dist}
+Release:        %{?_buildid}%{?dist}.eks
 Summary:        The Go Programming Language
 # source tree includes several copies of Mark.Twain-Tom.Sawyer.txt under Public Domain
 License:        BSD and Public Domain


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/eks-distro-internal/issues/241

*Description of changes:*
Set a uniform RPM release string for all EKS Go versions. In practice, this will look like `1.amzn2.eks`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
