### PR TITLE
use EKS Go relese version from the release trigger files if not speci…

### DIFF
--- a/builder-base/install.sh
+++ b/builder-base/install.sh
@@ -92,7 +92,7 @@ function build::go::install() {
     fi
 
     for artifact in golang golang-bin golang-race; do
-      curl $EKS_GO_ARTIFACTS_SOURCE/golang-go$version/releases/$eks_go_release/RPMS/$arch/$artifact-$version-$eks_go_release.amzn2.eks.$arch.rpm -o /tmp/$artifact-$version-$eks_go_release.amzn2ß.eks.$arch.rpm
+      curl $EKS_GO_ARTIFACTS_SOURCE/golang-go$version/releases/$eks_go_release/RPMS/$arch/$artifact-$version-$eks_go_release.amzn2.eks.$arch.rpm -o /tmp/$artifact-$version-$eks_go_release.amzn2.eks.$arch.rpm
     done
 
     for artifact in golang-docs golang-misc golang-tests golang-src; do


### PR DESCRIPTION
…fied

*Issue #, if available:*

*Description of changes:*
Allow us to specify a specific EKS Go release version when installing EKS Go on the builder base.

If no release version is specified via the second argument to `build::go::install`, fetch the release number for the given Go version from the release trigger file in the repository.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
