### PR TITLE
Eks go 1.16 CVE 2022 41716

### DIFF
--- a/projects/golang/go/1.16/patches/0020-go-1.16.15-eks-syscall-os-exec-reject-environ.patch
+++ b/projects/golang/go/1.16/patches/0020-go-1.16.15-eks-syscall-os-exec-reject-environ.patch
@@ -1,0 +1,265 @@
+From bdd6e90830216c96364d56e7f0997700bdc2c534 Mon Sep 17 00:00:00 2001
+From: Damien Neil <dneil@google.com>
+Date: Mon, 17 Oct 2022 17:38:29 -0700
+Subject: [PATCH] [go-1.16.15-eks] syscall, os/exec: reject environment
+ variables containing NULs
+
+# AWS EKS
+Backported To: go-1.16.15-eks
+Backported On: Thu, 03 Nov 2022
+Backported By: budris@amazon.com
+Backported From: release-branch.go1.18
+Source Commit: https://github.com/golang/go/commit/aba57b07721cac39b4b7cf70f8dfbf9e2e299187
+
+# Original Information
+
+Check for and reject environment variables containing NULs.
+
+The conventions for passing environment variables to subprocesses
+cause most or all systems to interpret a NUL as a separator. The
+syscall package rejects environment variables containing a NUL
+on most systems, but erroneously did not do so on Windows. This
+causes an environment variable such as "FOO=a\x00BAR=b" to be
+interpreted as "FOO=a", "BAR=b".
+
+Check for and reject NULs in environment variables passed to
+syscall.StartProcess on Windows.
+
+Add a redundant check to os/exec as extra insurance.
+
+Updates #56284
+Fixes #56327
+Fixes CVE-2022-41716
+
+Change-Id: I2950e2b0cb14ebd26e5629be1521858f66a7d4ae
+Reviewed-on: https://team-review.git.corp.google.com/c/golang/go-private/+/1609434
+Run-TryBot: Damien Neil <dneil@google.com>
+Reviewed-by: Tatiana Bradley <tatianabradley@google.com>
+Reviewed-by: Roland Shoemaker <bracewell@google.com>
+TryBot-Result: Security TryBots <security-trybots@go-security-trybots.iam.gserviceaccount.com>
+(cherry picked from commit 845accdebb2772c5344ed0c96df9910f3b02d741)
+Reviewed-on: https://team-review.git.corp.google.com/c/golang/go-private/+/1617552
+Run-TryBot: Tatiana Bradley <tatianabradley@google.com>
+Reviewed-by: Damien Neil <dneil@google.com>
+Reviewed-on: https://go-review.googlesource.com/c/go/+/446915
+Reviewed-by: Heschi Kreinick <heschi@google.com>
+Run-TryBot: Matthew Dempsky <mdempsky@google.com>
+TryBot-Result: Gopher Robot <gobot@golang.org>
+Reviewed-by: Tatiana Bradley <tatiana@golang.org>
+---
+ src/os/exec/env_test.go     | 19 +++++++++-----
+ src/os/exec/exec.go         | 19 +++++++++++---
+ src/os/exec/exec_test.go    |  9 +++++++
+ src/syscall/exec_windows.go | 52 +++++++++++++++++++++++++++++++++----
+ 4 files changed, 84 insertions(+), 15 deletions(-)
+
+diff --git a/src/os/exec/env_test.go b/src/os/exec/env_test.go
+index b5ac398c27..47b7c04705 100644
+--- a/src/os/exec/env_test.go
++++ b/src/os/exec/env_test.go
+@@ -11,9 +11,10 @@ import (
+ 
+ func TestDedupEnv(t *testing.T) {
+ 	tests := []struct {
+-		noCase bool
+-		in     []string
+-		want   []string
++		noCase  bool
++		in      []string
++		want    []string
++		wantErr bool
+ 	}{
+ 		{
+ 			noCase: true,
+@@ -29,11 +30,17 @@ func TestDedupEnv(t *testing.T) {
+ 			in:   []string{"=a", "=b", "foo", "bar"},
+ 			want: []string{"=b", "foo", "bar"},
+ 		},
++		{
++			// Filter out entries containing NULs.
++			in:      []string{"A=a\x00b", "B=b", "C\x00C=c"},
++			want:    []string{"B=b"},
++			wantErr: true,
++		},
+ 	}
+ 	for _, tt := range tests {
+-		got := dedupEnvCase(tt.noCase, tt.in)
+-		if !reflect.DeepEqual(got, tt.want) {
+-			t.Errorf("Dedup(%v, %q) = %q; want %q", tt.noCase, tt.in, got, tt.want)
++		got, err := dedupEnvCase(tt.noCase, tt.in)
++		if !reflect.DeepEqual(got, tt.want) || (err != nil) != tt.wantErr {
++			t.Errorf("Dedup(%v, %q) = %q, %v; want %q, error:%v", tt.noCase, tt.in, got, err, tt.want, tt.wantErr)
+ 		}
+ 	}
+ }
+diff --git a/src/os/exec/exec.go b/src/os/exec/exec.go
+index 0c49575511..00a0a58da4 100644
+--- a/src/os/exec/exec.go
++++ b/src/os/exec/exec.go
+@@ -419,10 +419,14 @@ func (c *Cmd) Start() error {
+ 		return err
+ 	}
+ 
++	env, err := dedupEnv(envv)
++	if err != nil {
++		return err
++	}
+ 	c.Process, err = os.StartProcess(c.Path, c.argv(), &os.ProcAttr{
+ 		Dir:   c.Dir,
+ 		Files: c.childFiles,
+-		Env:   addCriticalEnv(dedupEnv(envv)),
++		Env:   addCriticalEnv(env),
+ 		Sys:   c.SysProcAttr,
+ 	})
+ 	if err != nil {
+@@ -738,16 +742,23 @@ func minInt(a, b int) int {
+ // dedupEnv returns a copy of env with any duplicates removed, in favor of
+ // later values.
+ // Items not of the normal environment "key=value" form are preserved unchanged.
+-func dedupEnv(env []string) []string {
++// Items containing NUL characters are removed, and an error is returned along with
++// the remaining values.
++func dedupEnv(env []string) ([]string, error) {
+ 	return dedupEnvCase(runtime.GOOS == "windows", env)
+ }
+ 
+ // dedupEnvCase is dedupEnv with a case option for testing.
+ // If caseInsensitive is true, the case of keys is ignored.
+-func dedupEnvCase(caseInsensitive bool, env []string) []string {
++func dedupEnvCase(caseInsensitive bool, env []string) ([]string, error) {
++	var err error
+ 	out := make([]string, 0, len(env))
+ 	saw := make(map[string]int, len(env)) // key => index into out
+ 	for _, kv := range env {
++		if strings.IndexByte(kv, 0) != -1 {
++			err = errors.New("exec: environment variable contains NUL")
++			continue
++		}
+ 		eq := strings.Index(kv, "=")
+ 		if eq < 0 {
+ 			out = append(out, kv)
+@@ -764,7 +775,7 @@ func dedupEnvCase(caseInsensitive bool, env []string) []string {
+ 		saw[k] = len(out)
+ 		out = append(out, kv)
+ 	}
+-	return out
++	return out, err
+ }
+ 
+ // addCriticalEnv adds any critical environment variables that are required
+diff --git a/src/os/exec/exec_test.go b/src/os/exec/exec_test.go
+index 8b0c93f382..0dfbdbd621 100644
+--- a/src/os/exec/exec_test.go
++++ b/src/os/exec/exec_test.go
+@@ -1122,6 +1122,15 @@ func TestDedupEnvEcho(t *testing.T) {
+ 	}
+ }
+ 
++func TestEnvNULCharacter(t *testing.T) {
++	cmd := helperCommand(t, "echoenv", "FOO", "BAR")
++	cmd.Env = append(cmd.Env, "FOO=foo\x00BAR=bar")
++	out, err := cmd.CombinedOutput()
++	if err == nil {
++		t.Errorf("output = %q; want error", string(out))
++	}
++}
++
+ func TestString(t *testing.T) {
+ 	echoPath, err := exec.LookPath("echo")
+ 	if err != nil {
+diff --git a/src/syscall/exec_windows.go b/src/syscall/exec_windows.go
+index 46cbd7567d..56d187cc18 100644
+--- a/src/syscall/exec_windows.go
++++ b/src/syscall/exec_windows.go
+@@ -7,6 +7,8 @@
+ package syscall
+ 
+ import (
++	"internal/bytealg"
++	"runtime"
+ 	"sync"
+ 	"unicode/utf16"
+ 	"unsafe"
+@@ -114,12 +116,16 @@ func makeCmdLine(args []string) string {
+ // the representation required by CreateProcess: a sequence of NUL
+ // terminated strings followed by a nil.
+ // Last bytes are two UCS-2 NULs, or four NUL bytes.
+-func createEnvBlock(envv []string) *uint16 {
++// If any string contains a NUL, it returns (nil, EINVAL).
++func createEnvBlock(envv []string) (*uint16, error) {
+ 	if len(envv) == 0 {
+-		return &utf16.Encode([]rune("\x00\x00"))[0]
++		return &utf16.Encode([]rune("\x00\x00"))[0], nil
+ 	}
+ 	length := 0
+ 	for _, s := range envv {
++		if bytealg.IndexByteString(s, 0) != -1 {
++			return nil, EINVAL
++		}
+ 		length += len(s) + 1
+ 	}
+ 	length += 1
+@@ -134,7 +140,7 @@ func createEnvBlock(envv []string) *uint16 {
+ 	}
+ 	copy(b[i:i+1], []byte{0})
+ 
+-	return &utf16.Encode([]rune(string(b)))[0]
++	return &utf16.Encode([]rune(string(b)))[0], nil
+ }
+ 
+ func CloseOnExec(fd Handle) {
+@@ -338,13 +344,49 @@ func StartProcess(argv0 string, argv []string, attr *ProcAttr) (pid int, handle
+ 	si.StdOutput = fd[1]
+ 	si.StdErr = fd[2]
+ 
++	fd = append(fd, sys.AdditionalInheritedHandles...)
++
++	// On Windows 7, console handles aren't real handles, so don't pass them
++	// through to PROC_THREAD_ATTRIBUTE_HANDLE_LIST.
++	for i := range fd {
++		if isLegacyWin7ConsoleHandle(fd[i]) {
++			fd[i] = 0
++		}
++	}
++
++	// The presence of a NULL handle in the list is enough to cause PROC_THREAD_ATTRIBUTE_HANDLE_LIST
++	// to treat the entire list as empty, so remove NULL handles.
++	j := 0
++	for i := range fd {
++		if fd[i] != 0 {
++			fd[j] = fd[i]
++			j++
++		}
++	}
++	fd = fd[:j]
++
++	willInheritHandles := len(fd) > 0 && !sys.NoInheritHandles
++
++	// Do not accidentally inherit more than these handles.
++	if willInheritHandles {
++		err = updateProcThreadAttribute(si.ProcThreadAttributeList, 0, _PROC_THREAD_ATTRIBUTE_HANDLE_LIST, unsafe.Pointer(&fd[0]), uintptr(len(fd))*unsafe.Sizeof(fd[0]), nil, nil)
++		if err != nil {
++			return 0, 0, err
++		}
++	}
++
++	envBlock, err := createEnvBlock(attr.Env)
++	if err != nil {
++		return 0, 0, err
++	}
++
+ 	pi := new(ProcessInformation)
+ 
+ 	flags := sys.CreationFlags | CREATE_UNICODE_ENVIRONMENT
+ 	if sys.Token != 0 {
+-		err = CreateProcessAsUser(sys.Token, argv0p, argvp, sys.ProcessAttributes, sys.ThreadAttributes, !sys.NoInheritHandles, flags, createEnvBlock(attr.Env), dirp, si, pi)
++		err = CreateProcessAsUser(sys.Token, argv0p, argvp, sys.ProcessAttributes, sys.ThreadAttributes, willInheritHandles, flags, envBlock, dirp, &si.StartupInfo, pi)
+ 	} else {
+-		err = CreateProcess(argv0p, argvp, sys.ProcessAttributes, sys.ThreadAttributes, !sys.NoInheritHandles, flags, createEnvBlock(attr.Env), dirp, si, pi)
++		err = CreateProcess(argv0p, argvp, sys.ProcessAttributes, sys.ThreadAttributes, willInheritHandles, flags, envBlock, dirp, &si.StartupInfo, pi)
+ 	}
+ 	if err != nil {
+ 		return 0, 0, err
+-- 
+2.30.1 (Apple Git-130)
+

--- a/projects/golang/go/1.16/rpmbuild/SPECS/golang.spec
+++ b/projects/golang/go/1.16/rpmbuild/SPECS/golang.spec
@@ -173,6 +173,7 @@ Patch15:       0015-go-1.16.15-eks-archive-tar-limit-size-of-head.patch
 Patch17:       0017-go-1.16.15-eks-regexp-limit-size-of-parsed-regexps.patch
 Patch18:       0018-go-1.16.15-eks-net-url-reject-query-values-with-semicolons.patch
 Patch19:       0019-go-1.16.15-eks-net-http-httputil-avoid-query-.patch
+Patch20:       0020-go-1.16.15-eks-syscall-os-exec-reject-environ.patch
 
 Patch101:       0101-syscall-expose-IfInfomsg.X__ifi_pad-on-s390x.patch
 Patch102:       0102-cmd-go-disable-Google-s-proxy-and-sumdb.patch
@@ -554,11 +555,17 @@ fi
 %endif
 
 %changelog
+* Thu Nov 03 2022 Dan Budris <budris@amazon.com> - 1.16.15.2
+- Include backported patch for CVE-2022-41716
+- Fixes: CVE-2022-41716
+
 * Thu Oct 06 2022 Cameron Rozean <rcrozean@amazon.com> - 1.16.15-2
 - Include backported patch for CVE-2022-41715
+- Fixes: CVE-2022-41715
 
 * Thu Oct 06 2022 Cameron Rozean <rcrozean@amazon.com> - 1.16.15-2
 - Included backported patch for CVE-2022-2879
+- Fixes: CVE-2022-2879
 
 * Thu Mar 10 2022 Alejandro Sáez <asm@redhat.com> - 1.16.15-1
 - Update to go1.16.15


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Backport upstream Golang patch from source https://github.com/golang/go/commit/aba57b07721cac39b4b7cf70f8dfbf9e2e299187 to EKS Go 1.16 to fix CVE-2022-41716.

Update RPM Spec to incorporate patch into EKS Go 1.16

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
