### PR TITLE
backport patch for CVE-2022-41716 to EKS Go 1.17

### DIFF
--- a/projects/golang/go/1.17/patches/0004-go-1.17.13-eks-syscall-os-exec-reject-environ.patch
+++ b/projects/golang/go/1.17/patches/0004-go-1.17.13-eks-syscall-os-exec-reject-environ.patch
@@ -1,0 +1,233 @@
+From 5210f46055d4f98ecea3297846a2bbac28d62ff4 Mon Sep 17 00:00:00 2001
+From: Damien Neil <dneil@google.com>
+Date: Mon, 17 Oct 2022 17:38:29 -0700
+Subject: [PATCH] [release-branch.go1.18] syscall, os/exec: reject environment
+ variables containing NULs
+
+# AWS EKS
+
+Backported To: go-1.17.13-eks
+Backported On: Thu, 03 Nov 2022
+Backported By: budris@amazon.com
+Backported From: release-branch.go1.18
+Source Commit:  https://github.com/golang/go/commit/aba57b07721cac39b4b7cf70f8dfbf9e2e299187
+
+# Original Information
+
+Check for and reject environment variables containing NULs.
+
+The conventions for passing environment variables to subprocesses
+cause most or all systems to interpret a NUL as a separator. The
+syscall package rejects environment variables containing a NUL
+on most systems, but erroneously did not do so on Windows. This
+causes an environment variable such as "FOO=a\x00BAR=b" to be
+interpreted as "FOO=a", "BAR=b".
+
+Check for and reject NULs in environment variables passed to
+syscall.StartProcess on Windows.
+
+Add a redundant check to os/exec as extra insurance.
+
+Updates #56284
+Fixes #56327
+Fixes CVE-2022-41716
+
+Change-Id: I2950e2b0cb14ebd26e5629be1521858f66a7d4ae
+Reviewed-on: https://team-review.git.corp.google.com/c/golang/go-private/+/1609434
+Run-TryBot: Damien Neil <dneil@google.com>
+Reviewed-by: Tatiana Bradley <tatianabradley@google.com>
+Reviewed-by: Roland Shoemaker <bracewell@google.com>
+TryBot-Result: Security TryBots <security-trybots@go-security-trybots.iam.gserviceaccount.com>
+(cherry picked from commit 845accdebb2772c5344ed0c96df9910f3b02d741)
+Reviewed-on: https://team-review.git.corp.google.com/c/golang/go-private/+/1617552
+Run-TryBot: Tatiana Bradley <tatianabradley@google.com>
+Reviewed-by: Damien Neil <dneil@google.com>
+Reviewed-on: https://go-review.googlesource.com/c/go/+/446915
+Reviewed-by: Heschi Kreinick <heschi@google.com>
+Run-TryBot: Matthew Dempsky <mdempsky@google.com>
+TryBot-Result: Gopher Robot <gobot@golang.org>
+Reviewed-by: Tatiana Bradley <tatiana@golang.org>
+---
+ src/os/exec/env_test.go     | 19 +++++++++++++------
+ src/os/exec/exec.go         | 19 +++++++++++++++----
+ src/os/exec/exec_test.go    |  9 +++++++++
+ src/syscall/exec_windows.go | 20 +++++++++++++++-----
+ 4 files changed, 52 insertions(+), 15 deletions(-)
+
+diff --git a/src/os/exec/env_test.go b/src/os/exec/env_test.go
+index b5ac398c27..47b7c04705 100644
+--- a/src/os/exec/env_test.go
++++ b/src/os/exec/env_test.go
+@@ -11,9 +11,10 @@ import (
+ 
+ func TestDedupEnv(t *testing.T) {
+ 	tests := []struct {
+-		noCase bool
+-		in     []string
+-		want   []string
++		noCase  bool
++		in      []string
++		want    []string
++		wantErr bool
+ 	}{
+ 		{
+ 			noCase: true,
+@@ -29,11 +30,17 @@ func TestDedupEnv(t *testing.T) {
+ 			in:   []string{"=a", "=b", "foo", "bar"},
+ 			want: []string{"=b", "foo", "bar"},
+ 		},
++		{
++			// Filter out entries containing NULs.
++			in:      []string{"A=a\x00b", "B=b", "C\x00C=c"},
++			want:    []string{"B=b"},
++			wantErr: true,
++		},
+ 	}
+ 	for _, tt := range tests {
+-		got := dedupEnvCase(tt.noCase, tt.in)
+-		if !reflect.DeepEqual(got, tt.want) {
+-			t.Errorf("Dedup(%v, %q) = %q; want %q", tt.noCase, tt.in, got, tt.want)
++		got, err := dedupEnvCase(tt.noCase, tt.in)
++		if !reflect.DeepEqual(got, tt.want) || (err != nil) != tt.wantErr {
++			t.Errorf("Dedup(%v, %q) = %q, %v; want %q, error:%v", tt.noCase, tt.in, got, err, tt.want, tt.wantErr)
+ 		}
+ 	}
+ }
+diff --git a/src/os/exec/exec.go b/src/os/exec/exec.go
+index 505de58e84..85fba5b87b 100644
+--- a/src/os/exec/exec.go
++++ b/src/os/exec/exec.go
+@@ -422,10 +422,14 @@ func (c *Cmd) Start() error {
+ 		return err
+ 	}
+ 
++	env, err := dedupEnv(envv)
++	if err != nil {
++		return err
++	}
+ 	c.Process, err = os.StartProcess(c.Path, c.argv(), &os.ProcAttr{
+ 		Dir:   c.Dir,
+ 		Files: c.childFiles,
+-		Env:   addCriticalEnv(dedupEnv(envv)),
++		Env:   addCriticalEnv(env),
+ 		Sys:   c.SysProcAttr,
+ 	})
+ 	if err != nil {
+@@ -741,16 +745,23 @@ func minInt(a, b int) int {
+ // dedupEnv returns a copy of env with any duplicates removed, in favor of
+ // later values.
+ // Items not of the normal environment "key=value" form are preserved unchanged.
+-func dedupEnv(env []string) []string {
++// Items containing NUL characters are removed, and an error is returned along with
++// the remaining values.
++func dedupEnv(env []string) ([]string, error) {
+ 	return dedupEnvCase(runtime.GOOS == "windows", env)
+ }
+ 
+ // dedupEnvCase is dedupEnv with a case option for testing.
+ // If caseInsensitive is true, the case of keys is ignored.
+-func dedupEnvCase(caseInsensitive bool, env []string) []string {
++func dedupEnvCase(caseInsensitive bool, env []string) ([]string, error) {
++	var err error
+ 	out := make([]string, 0, len(env))
+ 	saw := make(map[string]int, len(env)) // key => index into out
+ 	for _, kv := range env {
++		if strings.IndexByte(kv, 0) != -1 {
++			err = errors.New("exec: environment variable contains NUL")
++			continue
++		}
+ 		eq := strings.Index(kv, "=")
+ 		if eq < 0 {
+ 			out = append(out, kv)
+@@ -767,7 +778,7 @@ func dedupEnvCase(caseInsensitive bool, env []string) []string {
+ 		saw[k] = len(out)
+ 		out = append(out, kv)
+ 	}
+-	return out
++	return out, err
+ }
+ 
+ // addCriticalEnv adds any critical environment variables that are required
+diff --git a/src/os/exec/exec_test.go b/src/os/exec/exec_test.go
+index a951be718d..49c2f63ff1 100644
+--- a/src/os/exec/exec_test.go
++++ b/src/os/exec/exec_test.go
+@@ -1104,6 +1104,15 @@ func TestDedupEnvEcho(t *testing.T) {
+ 	}
+ }
+ 
++func TestEnvNULCharacter(t *testing.T) {
++	cmd := helperCommand(t, "echoenv", "FOO", "BAR")
++	cmd.Env = append(cmd.Env, "FOO=foo\x00BAR=bar")
++	out, err := cmd.CombinedOutput()
++	if err == nil {
++		t.Errorf("output = %q; want error", string(out))
++	}
++}
++
+ func TestString(t *testing.T) {
+ 	echoPath, err := exec.LookPath("echo")
+ 	if err != nil {
+diff --git a/src/syscall/exec_windows.go b/src/syscall/exec_windows.go
+index 9d10d6a512..50892bee44 100644
+--- a/src/syscall/exec_windows.go
++++ b/src/syscall/exec_windows.go
+@@ -7,6 +7,7 @@
+ package syscall
+ 
+ import (
++	"internal/bytealg"
+ 	"runtime"
+ 	"sync"
+ 	"unicode/utf16"
+@@ -115,12 +116,16 @@ func makeCmdLine(args []string) string {
+ // the representation required by CreateProcess: a sequence of NUL
+ // terminated strings followed by a nil.
+ // Last bytes are two UCS-2 NULs, or four NUL bytes.
+-func createEnvBlock(envv []string) *uint16 {
++// If any string contains a NUL, it returns (nil, EINVAL).
++func createEnvBlock(envv []string) (*uint16, error) {
+ 	if len(envv) == 0 {
+-		return &utf16.Encode([]rune("\x00\x00"))[0]
++		return &utf16.Encode([]rune("\x00\x00"))[0], nil
+ 	}
+ 	length := 0
+ 	for _, s := range envv {
++		if bytealg.IndexByteString(s, 0) != -1 {
++			return nil, EINVAL
++		}
+ 		length += len(s) + 1
+ 	}
+ 	length += 1
+@@ -135,7 +140,7 @@ func createEnvBlock(envv []string) *uint16 {
+ 	}
+ 	copy(b[i:i+1], []byte{0})
+ 
+-	return &utf16.Encode([]rune(string(b)))[0]
++	return &utf16.Encode([]rune(string(b)))[0], nil
+ }
+ 
+ func CloseOnExec(fd Handle) {
+@@ -400,12 +405,17 @@ func StartProcess(argv0 string, argv []string, attr *ProcAttr) (pid int, handle
+ 		}
+ 	}
+ 
++	envBlock, err := createEnvBlock(attr.Env)
++	if err != nil {
++		return 0, 0, err
++	}
++
+ 	pi := new(ProcessInformation)
+ 	flags := sys.CreationFlags | CREATE_UNICODE_ENVIRONMENT | _EXTENDED_STARTUPINFO_PRESENT
+ 	if sys.Token != 0 {
+-		err = CreateProcessAsUser(sys.Token, argv0p, argvp, sys.ProcessAttributes, sys.ThreadAttributes, willInheritHandles, flags, createEnvBlock(attr.Env), dirp, &si.StartupInfo, pi)
++		err = CreateProcessAsUser(sys.Token, argv0p, argvp, sys.ProcessAttributes, sys.ThreadAttributes, willInheritHandles, flags, envBlock, dirp, &si.StartupInfo, pi)
+ 	} else {
+-		err = CreateProcess(argv0p, argvp, sys.ProcessAttributes, sys.ThreadAttributes, willInheritHandles, flags, createEnvBlock(attr.Env), dirp, &si.StartupInfo, pi)
++		err = CreateProcess(argv0p, argvp, sys.ProcessAttributes, sys.ThreadAttributes, willInheritHandles, flags, envBlock, dirp, &si.StartupInfo, pi)
+ 	}
+ 	if err != nil {
+ 		return 0, 0, err
+-- 
+2.30.1 (Apple Git-130)
+

--- a/projects/golang/go/1.17/patches/0004-go-1.17.13-eks-syscall-os-exec-reject-environ.patch
+++ b/projects/golang/go/1.17/patches/0004-go-1.17.13-eks-syscall-os-exec-reject-environ.patch
@@ -1,7 +1,7 @@
 From 5210f46055d4f98ecea3297846a2bbac28d62ff4 Mon Sep 17 00:00:00 2001
 From: Damien Neil <dneil@google.com>
 Date: Mon, 17 Oct 2022 17:38:29 -0700
-Subject: [PATCH] [release-branch.go1.18] syscall, os/exec: reject environment
+Subject: [PATCH] [go-1.17.13-eks] syscall, os/exec: reject environment
  variables containing NULs
 
 # AWS EKS

--- a/projects/golang/go/1.17/rpmbuild/SPECS/golang.spec
+++ b/projects/golang/go/1.17/rpmbuild/SPECS/golang.spec
@@ -158,6 +158,7 @@ Requires:       go-srpm-macros
 Patch1:		0001-go-1.17.13-eks-archive-tar-limit-size-of-head.patch
 Patch2:		0002-go-1.17.13-eks-net-http-httputil-avoid-query-parameter-smuggling.patch
 Patch3:		0003-go-1.17.13-eks-regexp-limit-size-of-parsed-regexps.patch
+Patch4:     0004-go-1.17.13-eks-syscall-os-exec-reject-environ.patch
 
 Patch101:       0101-syscall-expose-IfInfomsg.X__ifi_pad-on-s390x.patch
 Patch102:       0102-cmd-go-disable-Google-s-proxy-and-sumdb.patch
@@ -537,6 +538,10 @@ fi
 %endif
 
 %changelog
+* Thu Nov 03 2022 Dan Budris <budris@amazon.com> - 1.17.15-1
+- Include backported patch for CVE-2022-41716
+- Fixes: CVE-2022-41716
+
 * Thu Mar 10 2022 Alejandro Sáez <asm@redhat.com> - 1.16.15-1
 - Update to go1.16.15
 

--- a/projects/golang/go/1.17/rpmbuild/SPECS/golang.spec
+++ b/projects/golang/go/1.17/rpmbuild/SPECS/golang.spec
@@ -538,7 +538,7 @@ fi
 %endif
 
 %changelog
-* Thu Nov 03 2022 Dan Budris <budris@amazon.com> - 1.17.15-1
+* Thu Nov 03 2022 Dan Budris <budris@amazon.com> - 1.17.13-1
 - Include backported patch for CVE-2022-41716
 - Fixes: CVE-2022-41716
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Backport a fix from source https://github.com/golang/go/commit/aba57b07721cac39b4b7cf70f8dfbf9e2e299187 to EKS Go 1.17 to patch CVE-2022-41716

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
