### PR TITLE
Ignore golang packages when checking for sec updates

### DIFF
--- a/eks-distro-base/check_update.sh
+++ b/eks-distro-base/check_update.sh
@@ -42,6 +42,9 @@ COPY --from=base_image /var/lib/rpm /var/lib/rpm
 COPY --from=base_image /etc/yum.repos.d /etc/yum.repos.d
 
 RUN set -x && \
+    # yum will think there are updates avail for the golang packages which we are managing
+    # seperately. Remove them to ensure they do not trigger builds
+    rpm -e --justdb --nodeps $(rpm -qav | grep golang) || true && \
     if grep -q "2022" "/etc/os-release"; then \
         yum check-update --security --releasever=latest  > ./check_update_output; echo \$? > ./return_value; \
     else \

--- a/eks-distro-base/check_update.sh
+++ b/eks-distro-base/check_update.sh
@@ -44,7 +44,7 @@ COPY --from=base_image /etc/yum.repos.d /etc/yum.repos.d
 RUN set -x && \
     # yum will think there are updates avail for the golang packages which we are managing
     # seperately. Remove them to ensure they do not trigger builds
-    rpm -e --justdb --nodeps $(rpm -qav | grep golang) || true && \
+    rpm -e --justdb --nodeps \$(rpm -qav | grep golang) || true && \
     if grep -q "2022" "/etc/os-release"; then \
         yum check-update --security --releasever=latest  > ./check_update_output; echo \$? > ./return_value; \
     else \

--- a/eks-distro-base/check_update.sh
+++ b/eks-distro-base/check_update.sh
@@ -44,10 +44,7 @@ COPY --from=base_image /etc/yum.repos.d /etc/yum.repos.d
 RUN set -x && \
     # yum will think there are updates avail for the golang packages which we are managing
     # seperately. Remove them to ensure they do not trigger builds
-    golang_packages=\$(rpm -qav | grep golang) && \
-    if [ -n "\$golang_packages" ]; then \
-        rpm -e --justdb --nodeps \$golang_packages; \
-    fi && \
+    rpm -e --justdb --nodeps golang golang-bin golang-src golang-race golang-docs golang-misc golang-tests golang-src || true && \
     if grep -q "2022" "/etc/os-release"; then \
         yum check-update --security --releasever=latest  > ./check_update_output; echo \$? > ./return_value; \
     else \

--- a/eks-distro-base/check_update.sh
+++ b/eks-distro-base/check_update.sh
@@ -32,6 +32,9 @@ fi
 BASE_IMAGE_TAG="$(yq e ".al$AL_TAG.\"$NAME_FOR_TAG_FILE\"" $SCRIPT_ROOT/../EKS_DISTRO_TAG_FILE.yaml)"
 BASE_IMAGE=public.ecr.aws/eks-distro-build-tooling/$IMAGE_NAME:$BASE_IMAGE_TAG
 mkdir -p check-update
+
+# yum will think there are updates avail for the golang packages which we are managing
+# seperately. Remove them to ensure they do not trigger builds
 cat << EOF > check-update/Dockerfile
 FROM $BASE_IMAGE AS base_image
 
@@ -42,8 +45,6 @@ COPY --from=base_image /var/lib/rpm /var/lib/rpm
 COPY --from=base_image /etc/yum.repos.d /etc/yum.repos.d
 
 RUN set -x && \
-    # yum will think there are updates avail for the golang packages which we are managing
-    # seperately. Remove them to ensure they do not trigger builds
     rpm -e --justdb --nodeps golang golang-bin golang-src golang-race golang-docs golang-misc golang-tests golang-src || true && \
     if grep -q "2022" "/etc/os-release"; then \
         yum check-update --security --releasever=latest  > ./check_update_output; echo \$? > ./return_value; \

--- a/eks-distro-base/check_update.sh
+++ b/eks-distro-base/check_update.sh
@@ -44,7 +44,10 @@ COPY --from=base_image /etc/yum.repos.d /etc/yum.repos.d
 RUN set -x && \
     # yum will think there are updates avail for the golang packages which we are managing
     # seperately. Remove them to ensure they do not trigger builds
-    rpm -e --justdb --nodeps \$(rpm -qav | grep golang) || true && \
+    golang_packages=\$(rpm -qav | grep golang) && \
+    if [ -n "\$golang_packages" ]; then \
+        rpm -e --justdb --nodeps \$golang_packages; \
+    fi && \
     if grep -q "2022" "/etc/os-release"; then \
         yum check-update --security --releasever=latest  > ./check_update_output; echo \$? > ./return_value; \
     else \


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

We added the golang packages to the rpm db for the new golang compiler images. This was mainly to keep our db as accurate as possible and to make it easier to use these images to build future golang rpms.  Because our rpms are named the same as the yum provide golang packages, yum sees them as needing security updates.  We do not want this since we are controlling these packages.

Note: We should look at changing the name of our rpms to avoid this altogether since the al2/yum provided versions are really not upgrades to ours.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
