### PR TITLE
Ensure glibc stays in sync between builder and final

### DIFF
--- a/eks-distro-base/Dockerfile.minimal-base-glibc
+++ b/eks-distro-base/Dockerfile.minimal-base-glibc
@@ -35,6 +35,9 @@ ENV CLEANUP_UNNECESSARY_FILES="/etc/nsswitch.conf.rpmnew"
 
 RUN set -x && \
     export OUTPUT_DEBUG_LOG=${OUTPUT_DEBUG_LOG} && \
+    # the version of glibc in the builder image vs the final image
+    # needs to be the same otherwise ldd can start to randomly segfault
+    yum update -y && \
     install_rpm glibc-minimal-langpack \
         glibc \
         glibc-common \


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

I noticed recently that the image builds are segfaulting a lot more than they used to.  This ends up being ok because the code falls back to objdump and ends up producing the same output.  I debugged this and realized that it was due to a mismatch in glibc version between the builder image and final image.  Since the current glibc build does not update the builder image at all, it is going to always have the version of glibc from when the previous minimal-base image was built, which could be months due to the few number of packages in that image.  When the final image is built it is always going to get the latest version of glibc from yum.

Later in the build process when the code uses ldd to find missing required libs, ldd would segfault due to trying to load an newer version of glibc from the /newroot folder.  The alternative could be to try and run ldd chroot'd in cases where glibc exists in newroot, but this adds a bit more complexity.  I believe this PR is the better solve since the version of glibc will always be dedicated by what version was available at the time of the glibc image build.  Thats to say that no other image will update glibc during its respective build.

As a future thought, we may actually want to do this yum update in all the image builds to update their respective builder image, but I am not going to make this change for now until we see a stronger reason to.  

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
