### PR TITLE
Adds make to compiler-base

### DIFF
--- a/eks-distro-base/Dockerfile.minimal-base-compiler
+++ b/eks-distro-base/Dockerfile.minimal-base-compiler
@@ -39,6 +39,7 @@ RUN set -x && \
         gawk \
         grep \
         gzip \
+        make \
         tar \
         sed \
         which && \


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Our first golang consumer needed make in the golang compiler image.  We had them use the -gcc variant since it includes make, however, adding make to the compiler-base only adds like 1Mb.  It seems worth it to just move it up to the base so its in all the compiler variants.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
