### PR TITLE
Fix the filepath trim error

### DIFF
--- a/tools/eksDistroBuildToolingOpsTools/cmd/eksGoTool/cmd/root.go
+++ b/tools/eksDistroBuildToolingOpsTools/cmd/eksGoTool/cmd/root.go
@@ -79,7 +79,7 @@ func readConfig() error {
 	// Attempt to parse the config file when flag present
 	if config != "" {
 		filename := filepath.Base(config)
-		viper.SetConfigName(strings.TrimSuffix(filename, filename.Ext(filename)))
+		viper.SetConfigName(strings.TrimSuffix(filename, filepath.Ext(filename)))
 		viper.AddConfigPath(filepath.Dir(config))
 
 		if err := viper.ReadInConfig(); err != nil {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Had an issue with the root command's config file path trimmer.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
