### PR TITLE
Toplevel CVE issue flag fixes

### DIFF
--- a/tools/eksDistroBuildToolingOpsTools/cmd/eksGoTool/cmd/createCveIssue.go
+++ b/tools/eksDistroBuildToolingOpsTools/cmd/eksGoTool/cmd/createCveIssue.go
@@ -37,7 +37,7 @@ func init() {
 	createCveIssue.Flags().StringVarP(&ctiOpts.cveId, cveIdFlag, "c", "", "CVE ID")
 	createCveIssue.Flags().IntVarP(&ctiOpts.upstreamIssueId, upstreamIssueIdFlag, "i", 0, "Upstream Issue ID e.g. ")
 	createCveIssue.Flags().StringVarP(&ctiOpts.upstreamCommitHash, upstreamCommitHashFlag, "u", "", "Upstream Commit ID e.g. ")
-	createCveIssue.Flags().StringVar(&ctiOpts.announcementSourceUrl, "announcemenSourceUrl", "", "Announcement Source URL e.g. https://groups.google.com/g/golang-announce/c/-hjNw559_tE/m/KlGTfid5CAAJ")
+	createCveIssue.Flags().StringVarP(&ctiOpts.announcementSourceUrl, announcementSourceUrlFlag, "a", "", "Announcement Source URL e.g. https://groups.google.com/g/golang-announce/c/-hjNw559_tE/m/KlGTfid5CAAJ")
 
 	requiredFlags := []string{
 		cveIdFlag,
@@ -106,7 +106,7 @@ func GenerateIssueBody(ui *gogithub.Issue) *string {
 	b := strings.Builder{}
 
 	if ctiOpts.announcementSourceUrl != "" {
-		b.WriteString(fmt.Sprintf("From [Goland Security Announcemnt](%s)", ctiOpts.announcementSourceUrl))
+		b.WriteString(fmt.Sprintf("From [Goland Security Announcemnt](%s),\n", ctiOpts.announcementSourceUrl))
 	}
 
 	b.WriteString(fmt.Sprintf("For additional information for %s, go to the upstream issue %s", ctiOpts.cveId, *ui.HTMLURL))

--- a/tools/eksDistroBuildToolingOpsTools/cmd/eksGoTool/cmd/createCveIssue.go
+++ b/tools/eksDistroBuildToolingOpsTools/cmd/eksGoTool/cmd/createCveIssue.go
@@ -35,8 +35,8 @@ var ctiOpts = &createToplevelIssueOptions{}
 func init() {
 	rootCmd.AddCommand(createCveIssue)
 	createCveIssue.Flags().StringVarP(&ctiOpts.cveId, cveIdFlag, "c", "", "CVE ID")
-	createCveIssue.Flags().IntVarP(&ctiOpts.upstreamIssueId, upstreamIssueIdFlag, "i", 0, "Upstream Issue ID e.g. ")
-	createCveIssue.Flags().StringVarP(&ctiOpts.upstreamCommitHash, upstreamCommitHashFlag, "u", "", "Upstream Commit ID e.g. ")
+	createCveIssue.Flags().IntVarP(&ctiOpts.upstreamIssueId, upstreamIssueIdFlag, "i", 0, "Upstream Issue ID e.g. 56350")
+	createCveIssue.Flags().StringVarP(&ctiOpts.upstreamCommitHash, upstreamCommitHashFlag, "u", "", "Upstream Commit Hash e.g. 76cad4edc29d28432a7a0aa27e87385d3d7db7a1")
 	createCveIssue.Flags().StringVarP(&ctiOpts.announcementSourceUrl, announcementSourceUrlFlag, "a", "", "Announcement Source URL e.g. https://groups.google.com/g/golang-announce/c/-hjNw559_tE/m/KlGTfid5CAAJ")
 
 	requiredFlags := []string{


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Small change to add spacing if the announcement url flag is used, and adding "-a" as a flag shortcut for the announcement flag and updated the description for the other flags.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
