### PR TITLE
Scope down rerun auth configs to EKS Distro team

### DIFF
--- a/helm-charts/stable/prow-control-plane/Chart.yaml
+++ b/helm-charts/stable/prow-control-plane/Chart.yaml
@@ -29,7 +29,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.36
+version: 1.0.37
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/helm-charts/stable/prow-control-plane/templates/config-ConfigMap.yaml
+++ b/helm-charts/stable/prow-control-plane/templates/config-ConfigMap.yaml
@@ -104,7 +104,8 @@ data:
           - podinfo.json
       default_rerun_auth_configs:
       - rerun_auth_configs:
-          allow_anyone: true
+          github_team_ids:
+          - 4630040
 
     plank:
       job_url_prefix_config:


### PR DESCRIPTION
The team id for `eks-distro-admins` was obtained using `curl`
```
curl -H "Authorization: token <token> "https://api.github.com/orgs/aws/teams/eks-distro-admins" | jq ".id"`
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
