### PR TITLE
Stops including golang packages in rpm db

### DIFF
--- a/eks-distro-base/Dockerfile.minimal-base-golang
+++ b/eks-distro-base/Dockerfile.minimal-base-golang
@@ -73,13 +73,6 @@ ARG OUTPUT_DEBUG_LOG
 
 RUN set -x && \    
     clean_install git-core && \
-    while read rpm; do \
-        mkdir -p $DOWNLOAD_DIR; \
-        (cd $DOWNLOAD_DIR && curl -O $rpm); \
-        rpm -i --nodeps --justdb --root $NEWROOT $rpm; \
-        rm -f $rpm; \
-    done <$NEWROOT/installed_golang_rpms && \
-    rm $NEWROOT/installed_golang_rpms && \
     cleanup "golang-base"
 
 FROM builder-golang-base as builder

--- a/eks-distro-base/check_update.sh
+++ b/eks-distro-base/check_update.sh
@@ -33,8 +33,6 @@ BASE_IMAGE_TAG="$(yq e ".al$AL_TAG.\"$NAME_FOR_TAG_FILE\"" $SCRIPT_ROOT/../EKS_D
 BASE_IMAGE=public.ecr.aws/eks-distro-build-tooling/$IMAGE_NAME:$BASE_IMAGE_TAG
 mkdir -p check-update
 
-# yum will think there are updates avail for the golang packages which we are managing
-# seperately. Remove them to ensure they do not trigger builds
 cat << EOF > check-update/Dockerfile
 FROM $BASE_IMAGE AS base_image
 
@@ -45,7 +43,6 @@ COPY --from=base_image /var/lib/rpm /var/lib/rpm
 COPY --from=base_image /etc/yum.repos.d /etc/yum.repos.d
 
 RUN set -x && \
-    rpm -e --justdb --nodeps golang golang-bin golang-src golang-race golang-docs golang-misc golang-tests golang-src || true && \
     if grep -q "2022" "/etc/os-release"; then \
         yum check-update --security --releasever=latest  > ./check_update_output; echo \$? > ./return_value; \
     else \

--- a/eks-distro-base/scripts/install_golang
+++ b/eks-distro-base/scripts/install_golang
@@ -60,9 +60,6 @@ function build::go::download_rpm(){
     local filename="$(basename $url)"
 
     curl -sSL --retry 5 $url -o /tmp/$filename
-
-    # track "installed" rpms to install to rpm db in later stage
-    echo $url >> $NEWROOT/installed_golang_rpms
 }
 
 function build::go::install(){


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

We arent uses these images as the build container for golang builds any more and so no longer need these packages in the rpm db.  I think we may want to do this at some point, but as is its kind of confusing because the names are the same as the upstream yum packages.  This means that if you ran yum check-update it would think our packages should be upgraded by the al2 provided package, which is not really our intent.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
