### PR TITLE
Adds yum-plugin-ovl to builder base

### DIFF
--- a/builder-base/scripts/install_final.sh
+++ b/builder-base/scripts/install_final.sh
@@ -67,6 +67,13 @@ yum install -y \
     which \
     yum-utils
 
+# We see issues in fargate when installing on top of these images
+# including this plugin appears to fix it
+# ref: https://unix.stackexchange.com/questions/348941/rpmdb-checksum-is-invalid-trying-to-install-gcc-in-a-centos-7-2-docker-image    
+if [ "$IS_AL22" = "false" ]; then 
+    yum install -y yum-plugin-ovl
+fi
+
 if [ "${FINAL_STAGE_BASE}" = "full-copy-stage" ]; then
     yum install -y \
         gcc \


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This seems to help avoid the checksum issue when running yum in fargate on builder-base

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
