### PR TITLE
Avoid replacing minimal with standard for builder-base tag update

### DIFF
--- a/builder-base/Makefile
+++ b/builder-base/Makefile
@@ -96,7 +96,7 @@ images-%: buildkit-check
 		--progress plain \
 		--output $(BUILDKIT_OUTPUT)
 	if [ "$(AL_TAG)" = "2" ] && [ "$(VARIANT)" = "standard" ]; then \
-		./update_base_image.sh $(VARIANT)-$(IMAGE_TAG); \
+		./update_base_image.sh $(IMAGE_TAG); \
 	fi
 	
 

--- a/builder-base/update_base_image.sh
+++ b/builder-base/update_base_image.sh
@@ -23,11 +23,11 @@ NEW_TAG="$1"
 SCRIPT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 
 ${SCRIPT_ROOT}/../pr-scripts/update_local_branch.sh eks-distro-prow-jobs
-${SCRIPT_ROOT}/../pr-scripts/update_image_tag.sh eks-distro-prow-jobs 'builder-base:.*' 'builder-base:'"$NEW_TAG" '*.yaml'
+${SCRIPT_ROOT}/../pr-scripts/update_image_tag.sh eks-distro-prow-jobs 'builder-base:(.+)-.*' 'builder-base:'"\1-$NEW_TAG" '*.yaml'
 ${SCRIPT_ROOT}/../pr-scripts/update_image_tag.sh eks-distro-prow-jobs '.*' $NEW_TAG BUILDER_BASE_TAG_FILE
 ${SCRIPT_ROOT}/../pr-scripts/create_pr.sh eks-distro-prow-jobs '*.yaml'
 
-${SCRIPT_ROOT}/../pr-scripts/update_local_branch.sh eks-anywhere-prow-jobs
-${SCRIPT_ROOT}/../pr-scripts/update_image_tag.sh eks-anywhere-prow-jobs 'builder-base:.*' 'builder-base:'"$NEW_TAG" '*.yaml'
+${SCRIPT_ROOT}/../pr-scripts/u.sh eks-anywhere-prow-jobs
+${SCRIPT_ROOT}/../pr-scripts/update_image_tag.sh eks-anywhere-prow-jobs 'builder-base:(.+).*' 'builder-base:'"\1-$NEW_TAG" '*.yaml'
 ${SCRIPT_ROOT}/../pr-scripts/update_image_tag.sh eks-anywhere-prow-jobs '.*' $NEW_TAG BUILDER_BASE_TAG_FILE
 ${SCRIPT_ROOT}/../pr-scripts/create_pr.sh eks-anywhere-prow-jobs '*.yaml'

--- a/builder-base/update_base_image.sh
+++ b/builder-base/update_base_image.sh
@@ -27,7 +27,7 @@ ${SCRIPT_ROOT}/../pr-scripts/update_image_tag.sh eks-distro-prow-jobs 'builder-b
 ${SCRIPT_ROOT}/../pr-scripts/update_image_tag.sh eks-distro-prow-jobs '.*' $NEW_TAG BUILDER_BASE_TAG_FILE
 ${SCRIPT_ROOT}/../pr-scripts/create_pr.sh eks-distro-prow-jobs '*.yaml'
 
-${SCRIPT_ROOT}/../pr-scripts/u.sh eks-anywhere-prow-jobs
+${SCRIPT_ROOT}/../pr-scripts/update_local_branch.sh eks-anywhere-prow-jobs
 ${SCRIPT_ROOT}/../pr-scripts/update_image_tag.sh eks-anywhere-prow-jobs 'builder-base:(.+).*' 'builder-base:'"\1-$NEW_TAG" '*.yaml'
 ${SCRIPT_ROOT}/../pr-scripts/update_image_tag.sh eks-anywhere-prow-jobs '.*' $NEW_TAG BUILDER_BASE_TAG_FILE
 ${SCRIPT_ROOT}/../pr-scripts/create_pr.sh eks-anywhere-prow-jobs '*.yaml'

--- a/pr-scripts/update_image_tag.sh
+++ b/pr-scripts/update_image_tag.sh
@@ -49,6 +49,6 @@ if [ "$USE_YQ" = "true" ]; then
     yq -i e "$NEW_TAG" EKS_DISTRO_TAG_FILE.yaml   
 else
     for FILE in $(find ./ -type f -name "$FILEPATH"); do
-        $SED -i "s,${OLD_TAG},${NEW_TAG}," $FILE
+        $SED -i -E "s,${OLD_TAG},${NEW_TAG}," $FILE
     done
 fi


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

There are a few jobs now using the minimal builder base. This changes the sed to only update the tag hash not the prefix of standard/minimal.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
