### PR TITLE
Handle variant prefix in builder_base_tag_file

### DIFF
--- a/builder-base/update_base_image.sh
+++ b/builder-base/update_base_image.sh
@@ -24,10 +24,10 @@ SCRIPT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 
 ${SCRIPT_ROOT}/../pr-scripts/update_local_branch.sh eks-distro-prow-jobs
 ${SCRIPT_ROOT}/../pr-scripts/update_image_tag.sh eks-distro-prow-jobs 'builder-base:(.+)-.*' 'builder-base:'"\1-$NEW_TAG" '*.yaml'
-${SCRIPT_ROOT}/../pr-scripts/update_image_tag.sh eks-distro-prow-jobs '.*' $NEW_TAG BUILDER_BASE_TAG_FILE
+${SCRIPT_ROOT}/../pr-scripts/update_image_tag.sh eks-distro-prow-jobs '(.+)-.*' "\1-$NEW_TAG" BUILDER_BASE_TAG_FILE
 ${SCRIPT_ROOT}/../pr-scripts/create_pr.sh eks-distro-prow-jobs '*.yaml'
 
 ${SCRIPT_ROOT}/../pr-scripts/update_local_branch.sh eks-anywhere-prow-jobs
 ${SCRIPT_ROOT}/../pr-scripts/update_image_tag.sh eks-anywhere-prow-jobs 'builder-base:(.+).*' 'builder-base:'"\1-$NEW_TAG" '*.yaml'
-${SCRIPT_ROOT}/../pr-scripts/update_image_tag.sh eks-anywhere-prow-jobs '.*' $NEW_TAG BUILDER_BASE_TAG_FILE
+${SCRIPT_ROOT}/../pr-scripts/update_image_tag.sh eks-anywhere-prow-jobs '(.+)-.*' "\1-$NEW_TAG" BUILDER_BASE_TAG_FILE
 ${SCRIPT_ROOT}/../pr-scripts/create_pr.sh eks-anywhere-prow-jobs '*.yaml'


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
In my last [change](https://github.com/aws/eks-distro-build-tooling/pull/684) I missed that the BUILDER_BASE_TAG_FILE needed the standard/minimal prefix as well. We could harcode standard here, but this feels better just in case we change to minimal in the future, one less spot to change.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
