### PR TITLE
EKS Go: condition image build + push on AMD64 arch

### DIFF
--- a/projects/golang/go/Makefile
+++ b/projects/golang/go/Makefile
@@ -42,6 +42,11 @@ TO_LOWER=$(subst A,a,$(subst B,b,$(subst C,c,$(subst D,d,$(subst E,e,$(subst \
 	M,m,$(subst N,n,$(subst O,o,$(subst P,p,$(subst Q,q,$(subst R,r,$(subst S,s,$(subst \
 	T,t,$(subst U,u,$(subst V,v,$(subst W,w,$(subst X,x,$(subst Y,y,$(subst Z,z,$(subst _,-,$(1))))))))))))))))))))))))))))
 
+RELEASE_TARGETS = golang-build sync-artifacts-to-s3
+ifeq ($(ARCHITECTURE),AMD64)
+    BUILD_TARGETS += images
+endif
+
 .PHONY: golang-build
 golang-build: check-env setup-rpm-tree fetch-golang-source-archive copy-sources-to-rpmbuild-tree copy-patches-to-rpmbuild-tree build-golang-rpm generate-golang-archive
 
@@ -49,10 +54,10 @@ golang-build: check-env setup-rpm-tree fetch-golang-source-archive copy-sources-
 build: golang-build sync-artifacts-to-s3-dry-run local-images
 
 .PHONY: release
-release: golang-build sync-artifacts-to-s3 images
+release: $(RELEASE_TARGETS)
 
 .PHONY: prod-release
-prod-release: golang-build sync-artifacts-to-s3 images
+prod-release: $(RELEASE_TARGETS)
 
 .PHONY: fetch-golang-source-archive
 fetch-golang-source-archive:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Condition the image-build on AMD64 architecture. We don't want/need to be building + pushing an ARM64 image at this time; if we need to in the future, we can figure out the approach --either coordinating the builds so the manifest points to the right arch, or else pushing 2 tags.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
