### PR TITLE
Adds disk-usage cm to prow cp

### DIFF
--- a/helm-charts/stable/prow-control-plane/Chart.yaml
+++ b/helm-charts/stable/prow-control-plane/Chart.yaml
@@ -29,7 +29,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.36
+version: 1.0.37
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/helm-charts/stable/prow-control-plane/values.yaml
+++ b/helm-charts/stable/prow-control-plane/values.yaml
@@ -149,6 +149,15 @@ plugins:
     scripts/registry-entrypoint.sh:
       name: registry-entrypoint
       clusters:
+        prow-postsubmits-cluster: # cluster name
+        - default # namespace
+        prow-presubmits-cluster: # cluster name
+        - default # namespace
+    scripts/disk-usage-entrypoint.sh:
+      name: disk-usage-entrypoint
+      clusters:
+        prow-postsubmits-cluster: # cluster name
+        - default # namespace
         prow-presubmits-cluster: # cluster name
         - default # namespace
     jobs/**/*.yaml:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Adding a new entrypoint script for a disk usage monitor sidecar to make it easier to track our usage esp on fargate nodes where it can be so critical.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
