### PR TITLE
Fixes al2022 distro base periodic build

### DIFF
--- a/eks-distro-base/Dockerfile.base
+++ b/eks-distro-base/Dockerfile.base
@@ -17,9 +17,7 @@ FROM ${BASE_IMAGE} as builder
 
 RUN set -x && \
     if grep -q "2022" "/etc/os-release"; then \
-        yum install -y dnf-plugin-release-notification && \
-        NEW_RELEASE="$(yum check-release-update 2>&1 | grep 'dnf update --releasever' | tail -n 1)" && \
-        if [ -n "${NEW_RELEASE}" ]; then ${NEW_RELEASE} -y; fi \
+        dnf upgrade --releasever=latest -y; fi \
     fi && \
     yum upgrade -y && \
     yum update -y && \

--- a/eks-distro-base/Dockerfile.base
+++ b/eks-distro-base/Dockerfile.base
@@ -17,7 +17,7 @@ FROM ${BASE_IMAGE} as builder
 
 RUN set -x && \
     if grep -q "2022" "/etc/os-release"; then \
-        dnf upgrade --releasever=latest -y; fi \
+        dnf upgrade --releasever=latest -y; \
     fi && \
     yum upgrade -y && \
     yum update -y && \


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

The daily image build has been building the 2022 images for a few days now when it shouldnt have, [example](https://github.com/aws/eks-distro-build-tooling/pull/688).

The check update code was properly detecting that there were new updates available, but the newly built image wasnt actually getting the latest packages. The reason for this was the way it checked for new `releasever`, which is new in al22 vs al2, they changed the output from `dnf update ...` to `dnf upgrade ...` so our grep was no longer matching.

They now provide a `latest` releasever so we can remove most of the existing logic and just always set to latest during the build.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
