### PR TITLE
Sets releasever to latest for al22 distro base images

### DIFF
--- a/eks-distro-base/Dockerfile.base
+++ b/eks-distro-base/Dockerfile.base
@@ -17,7 +17,9 @@ FROM ${BASE_IMAGE} as builder
 
 RUN set -x && \
     if grep -q "2022" "/etc/os-release"; then \
-        dnf upgrade --releasever=latest -y; \
+        # to ensure all downstream yum commands always resolve using the latest releasever 
+        # available at that time
+        echo latest > /etc/dnf/vars/releasever; \
     fi && \
     yum upgrade -y && \
     yum update -y && \

--- a/eks-distro-base/Dockerfile.minimal-base
+++ b/eks-distro-base/Dockerfile.minimal-base
@@ -71,7 +71,12 @@ RUN set -x && \
         basesystem \
         tzdata \
         ca-certificates && \
-    if_al2022 install_rpm amazon-linux-repo-cdn && \
+    if grep -q "2022" "/etc/os-release"; then \
+        install_rpm amazon-linux-repo-cdn; \
+        # to ensure all downstream yum commands always resolve using the latest releasever 
+        # available at that time
+        echo latest > /etc/dnf/vars/releasever; \
+    fi && \    
     cleanup "base"
 
 COPY files/ $NEWROOT


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

In the al22 world yum is separated out to releasevers so by default when you run yum it will only pull the latest package for the current releasever. This is different than al2 which always pulls the actually latest when running yum install.  We handle this during the check-update phase, however when the images are actually built its not able to get the latest package since the releasever is never updated.

Setting the releasever file to latest appears to persist it for future runs which would mean that during any build process it will recheck for newer releasevers and use that to determine which yum packages to download/install.  Ill watch this as we get more builds. 

As a side note, we used to always rebuild all al22 images whenever releasever changes, but that is too extreme since in their world every package update results in a new releasever, which would mean we would be cutting new images all the time.  This issue we are seeing described above is new because of that change.

This is a follow up to: #693 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
