### PR TITLE
WIP - Add single version file for golang supported versions

### DIFF
--- a/MAINTAINED_GO_VERSIONS.yaml
+++ b/MAINTAINED_GO_VERSIONS.yaml
@@ -7,10 +7,10 @@
   upstream_supported: true
   latest_image_tag: '123'
 '1.17':
-	full_version: 1.17.13
-	upstream_supported: false 
-	latest_image_tag: '123'
+  full_version: 1.17.13
+  upstream_supported: false
+  latest_image_tag: '123'
 '1.16': 
-	full_version: 1.16.15
-	upstream_supported: false 
-	latest_image_tag: '123'
+  full_version: 1.16.15
+  upstream_supported: false 
+  latest_image_tag: '123'

--- a/MAINTAINED_GO_VERSIONS.yaml
+++ b/MAINTAINED_GO_VERSIONS.yaml
@@ -1,0 +1,16 @@
+'1.19':
+  full_version: 1.19.4
+  upstream_supported: true
+  latest_image_tag: '123'
+'1.18':
+  full_version: 1.18.9
+  upstream_supported: true
+  latest_image_tag: '123'
+'1.17':
+	full_version: 1.17.13
+	upstream_supported: false 
+	latest_image_tag: '123'
+'1.16': 
+	full_version: 1.16.15
+	upstream_supported: false 
+	latest_image_tag: '123'


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Example of file we could use as the source of truth on the versions we support. It basically replicates what we have between the version dir and the GIT_TAG file, but what it adds is whether it's an in-support or out of support upstream version, which would be nice to have. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
