### PR TITLE
Add golang archive to /usr/local/go instead of /usr/local

### DIFF
--- a/projects/golang/go/docker/debianBase/Dockerfile
+++ b/projects/golang/go/docker/debianBase/Dockerfile
@@ -2,7 +2,9 @@ FROM buildpack-deps:bullseye-scm
 
 ARG GOLANG_ARCHIVE_PATH
 
-ADD $GOLANG_ARCHIVE_PATH /usr/local
+RUN mkdir -p /usr/local/go
+
+ADD $GOLANG_ARCHIVE_PATH /usr/local/go
 
 ENV GOPATH /go
 ENV PATH /usr/local/go/bin:$GOPATH/bin:$PATH


### PR DESCRIPTION
*Issue #, if available:*

I expected the go archive to be added to `/usr/local/go` but it's currently not.

```
docker run -it public.ecr.aws/eks-distro-build-tooling/golang-debian:go1.19.4-1 /bin/bash
root@fb2bdc9d204f:/go# ls /usr/local/go
ls: cannot access '/usr/local/go': No such file or directory
```

Instead, it's added to `/usr/local`

```
docker run -it public.ecr.aws/eks-distro-build-tooling/golang-debian:go1.19.4-1 /bin/bash 
root@27bf04ae2de9:/go# ls /usr/local/bin/
go  gofmt  linux_amd64
root@27bf04ae2de9:/go# 
```


*Description of changes:* Go archive should be added to `/usr/local/go` instead of `/usr/local`. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
