### PR TITLE
add darwin/arm64 platform to std lib install of eks go make

### DIFF
--- a/projects/golang/go/Makefile
+++ b/projects/golang/go/Makefile
@@ -155,7 +155,7 @@ test: test-windows test-darwin test-linux
 test-windows: test-platform-windows-amd64 test-platform-windows-386
 
 .PHONY: test-darwin
-test-darwin: test-platform-darwin-amd64
+test-darwin: test-platform-darwin-amd64 test-platform-darwin-arm64
 
 .PHONY: test-linux
 test-linux: test-platform-linux-s390x test-platform-linux-ppc64le test-platform-linux-arm test-platform-linux-arm64 test-platform-linux-386


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
adding `darwin/arm64` std lib install smoketest to EKS Go makefile

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
