### PR TITLE
Fix tag update logic for EKS-A Prowjobs

### DIFF
--- a/builder-base/update_base_image.sh
+++ b/builder-base/update_base_image.sh
@@ -28,6 +28,6 @@ ${SCRIPT_ROOT}/../pr-scripts/update_image_tag.sh eks-distro-prow-jobs '(.+)-.*' 
 ${SCRIPT_ROOT}/../pr-scripts/create_pr.sh eks-distro-prow-jobs '*.yaml'
 
 ${SCRIPT_ROOT}/../pr-scripts/update_local_branch.sh eks-anywhere-prow-jobs
-${SCRIPT_ROOT}/../pr-scripts/update_image_tag.sh eks-anywhere-prow-jobs 'builder-base:(.+).*' 'builder-base:'"\1-$NEW_TAG" '*.yaml'
+${SCRIPT_ROOT}/../pr-scripts/update_image_tag.sh eks-anywhere-prow-jobs 'builder-base:(.+)-.*' 'builder-base:'"\1-$NEW_TAG" '*.yaml'
 ${SCRIPT_ROOT}/../pr-scripts/update_image_tag.sh eks-anywhere-prow-jobs '(.+)-.*' "\1-$NEW_TAG" BUILDER_BASE_TAG_FILE
 ${SCRIPT_ROOT}/../pr-scripts/create_pr.sh eks-anywhere-prow-jobs '*.yaml'


### PR DESCRIPTION
Without the dash, the entirety of the tag was being selected for regex grouping, which caused an incorrect substitution.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
