### PR TITLE
Fixes open pr check for distro-base

### DIFF
--- a/pr-scripts/create_pr.sh
+++ b/pr-scripts/create_pr.sh
@@ -123,7 +123,7 @@ ssh-agent bash -c 'ssh-add /secrets/ssh-secrets/ssh-key; ssh -o StrictHostKeyChe
 
 gh auth login --with-token < /secrets/github-secrets/token
 
-PR_EXISTS=$(gh pr list | grep -c "${PR_BRANCH}" || true)
+PR_EXISTS=$(gh pr list -H "${PR_BRANCH}" || true)
 if [ $PR_EXISTS -eq 0 ]; then
   gh pr create --title "$PR_TITLE" --body "$PR_BODY" --label "do-not-merge/hold"
 fi

--- a/pr-scripts/open_pr_check.sh
+++ b/pr-scripts/open_pr_check.sh
@@ -37,7 +37,7 @@ cd ${SCRIPT_ROOT}/../../../${ORIGIN_ORG}/${REPO}
 
 gh auth login --with-token < /secrets/github-secrets/token
 
-PR_EXISTS=$(gh pr list | grep -c "${PR_BRANCH}" || true)
+PR_EXISTS=$(gh pr list -H "${PR_BRANCH}" || true)
 if [ $PR_EXISTS -eq 1 ]; then
     echo "There is an existing PR already open, please merge/close before building new images!"
     exit 1


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Follow up to: https://github.com/aws/eks-distro-build-tooling/pull/709

The open-pr check was a bit naive and since the string `al2` is included in the string `al22` the open pr code would bail out if there was a PR open against the al22 branch even tho it was looking for one open against the al2 branch.  This change uses the gh cli to find a PR for the specific branch instead of using grep against all open PRs.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
