### PR TITLE
decouple golang RPM download from `builder-base` Dockerfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ index.yaml
 eks-distro-base/check-update/
 eks-distro-base/*-pushed
 eks-distro-base/make-tests/actual/
+builder-base/tmp/

--- a/builder-base/Dockerfile
+++ b/builder-base/Dockerfile
@@ -211,11 +211,13 @@ RUN --mount=type=cache,target=/var/cache/yum,sharing=locked \
 FROM ${BUILDER_IMAGE} as golang-1.15
 ARG TARGETARCH
 ARG GOLANG_VERSION_115
+ARG GOLANG_RPM_SOURCE_DIR
 WORKDIR /workdir
 ENV GOPATH /go
 ENV PATH="/go/bin/:$PATH"
 COPY ./scripts/install_base_yum_packages.sh ./scripts/remove_yum_packages.sh ./scripts/common_vars.sh \
     ./scripts/install_golang.sh /
+ADD $GOLANG_RPM_SOURCE_DIR/golang*1.15*.rpm /tmp/
 RUN --mount=type=cache,target=/var/cache/yum,sharing=locked \
     /install_base_yum_packages.sh && \
     /install_golang.sh $GOLANG_VERSION_115 && \
@@ -224,11 +226,13 @@ RUN --mount=type=cache,target=/var/cache/yum,sharing=locked \
 FROM ${BUILDER_IMAGE} as golang-1.16
 ARG TARGETARCH
 ARG GOLANG_VERSION_116
+ARG GOLANG_RPM_SOURCE_DIR
 WORKDIR /workdir
 ENV GOPATH /go
 ENV PATH="/go/bin/:$PATH"
 COPY ./scripts/install_base_yum_packages.sh ./scripts/remove_yum_packages.sh ./scripts/common_vars.sh \
     ./scripts/install_golang.sh /
+ADD $GOLANG_RPM_SOURCE_DIR/golang*1.16*.rpm /tmp/
 RUN --mount=type=cache,target=/var/cache/yum,sharing=locked \
     /install_base_yum_packages.sh && \
     /install_golang.sh $GOLANG_VERSION_116 && \
@@ -237,11 +241,13 @@ RUN --mount=type=cache,target=/var/cache/yum,sharing=locked \
 FROM ${BUILDER_IMAGE} as golang-1.17
 ARG TARGETARCH
 ARG GOLANG_VERSION_117
+ARG GOLANG_RPM_SOURCE_DIR
 WORKDIR /workdir
 ENV GOPATH /go
 ENV PATH="/go/bin/:$PATH"
 COPY ./scripts/install_base_yum_packages.sh ./scripts/remove_yum_packages.sh ./scripts/common_vars.sh \
     ./scripts/install_golang.sh /
+ADD $GOLANG_RPM_SOURCE_DIR/golang*1.17*.rpm /tmp/
 RUN --mount=type=cache,target=/var/cache/yum,sharing=locked \
     /install_base_yum_packages.sh && \
     /install_golang.sh $GOLANG_VERSION_117 && \
@@ -250,11 +256,13 @@ RUN --mount=type=cache,target=/var/cache/yum,sharing=locked \
 FROM ${BUILDER_IMAGE} as golang-1.18
 ARG TARGETARCH
 ARG GOLANG_VERSION_118
+ARG GOLANG_RPM_SOURCE_DIR
 WORKDIR /workdir
 ENV GOPATH /go
 ENV PATH="/go/bin/:$PATH"
 COPY ./scripts/install_base_yum_packages.sh ./scripts/remove_yum_packages.sh ./scripts/common_vars.sh \
     ./scripts/install_golang.sh /
+ADD $GOLANG_RPM_SOURCE_DIR/golang*1.18*.rpm /tmp/
 RUN --mount=type=cache,target=/var/cache/yum,sharing=locked \
     /install_base_yum_packages.sh && \
     /install_golang.sh $GOLANG_VERSION_118 && \
@@ -263,11 +271,13 @@ RUN --mount=type=cache,target=/var/cache/yum,sharing=locked \
 FROM ${BUILDER_IMAGE} as golang-1.19
 ARG TARGETARCH
 ARG GOLANG_VERSION_119
+ARG GOLANG_RPM_SOURCE_DIR
 WORKDIR /workdir
 ENV GOPATH /go
 ENV PATH="/go/bin/:$PATH"
 COPY ./scripts/install_base_yum_packages.sh ./scripts/remove_yum_packages.sh ./scripts/common_vars.sh \
     ./scripts/install_golang.sh /
+ADD $GOLANG_RPM_SOURCE_DIR/golang*1.19*.rpm /tmp/
 RUN --mount=type=cache,target=/var/cache/yum,sharing=locked \
     /install_base_yum_packages.sh && \
     /install_golang.sh $GOLANG_VERSION_119 && \

--- a/builder-base/Makefile
+++ b/builder-base/Makefile
@@ -52,6 +52,9 @@ define NEWLINE
 endef
 
 GOLANG_RPM_OUTPUT_DIR?=$(MAKE_ROOT)/tmp/golang-downloads
+# Resolves to the download-golang-% targets for each golang version present in ./versions.yaml
+# For example, the `GOLANG_VERSION_116: 1.16.15-3` entry in versions.yaml resolves to `download-golang-1.16.15-3`, and so on
+GOLANG_RPM_DOWNLOAD_TARGETS?=$(shell yq  e 'to_entries | .[] | select(.key == "*GOLANG_VERSION*") | .value |= "download-golang-" + . | .value' ${MAKE_ROOT}/versions.yaml)
 
 .PHONY: buildkit-check
 buildkit-check:
@@ -131,7 +134,7 @@ validate-shasums: update-shasums
 	git diff --exit-code ./checksums
 
 .PHONY: download-golang
-download-golang: clean-golang-download $(shell yq  e 'to_entries | .[] | select(.key == "*GOLANG_VERSION*") | .value |= "download-golang-" + . | .value' ${MAKE_ROOT}/versions.yaml)
+download-golang: clean-golang-download $(GOLANG_RPM_DOWNLOAD_TARGETS)
 
 .PHONY: clean-golang-download
 clean-golang-download:

--- a/builder-base/Makefile
+++ b/builder-base/Makefile
@@ -51,6 +51,8 @@ define NEWLINE
 
 endef
 
+GOLANG_RPM_OUTPUT_DIR?=$(MAKE_ROOT)/tmp/golang-downloads
+
 .PHONY: buildkit-check
 buildkit-check:
 	$(MAKE_ROOT)/../scripts/buildkit_check.sh
@@ -75,7 +77,7 @@ images-minimal: FINAL_STAGE_BASE=minimal-copy-stage
 images-minimal: VARIANT=minimal
 
 .PHONY: images-%
-images-%: buildkit-check
+images-%: buildkit-check download-golang
 	$(eval $(subst #,$(NEWLINE),$(shell yq  e 'to_entries | .[] | [.key,.value] | join("=") ' versions.yaml | tr '\n' '#')))
 	$(eval IMAGE_BUILD_ARGS=$(shell yq  e 'to_entries | .[] | .key ' versions.yaml))
 	$(MAKE_ROOT)/../scripts/buildkit.sh \
@@ -86,12 +88,13 @@ images-%: buildkit-check
 		--opt build-arg:BUILDER_IMAGE=$(BUILDER_IMAGE) \
 		--opt build-arg:GOPROXY=$(GOPROXY) \
 		--opt build-arg:FINAL_STAGE_BASE=$(FINAL_STAGE_BASE) \
+		--opt build-arg:GOLANG_RPM_SOURCE_DIR=$(shell realpath --relative-to $(MAKE_ROOT) $(GOLANG_RPM_OUTPUT_DIR)) \
 		$(foreach BUILD_ARG,$(IMAGE_BUILD_ARGS),--opt build-arg:$(BUILD_ARG)=$($(BUILD_ARG))) \
 		--export-cache type=inline \
 		$(foreach repo,$(IMPORT_CACHE_REPOS),--import-cache type=registry,ref=$(repo)/builder-base:$(word 1,$(LATEST))) \
 		--opt no-cache=final \
 		--local dockerfile=./ \
-		--local context=. \
+		--local context=$(MAKE_ROOT) \
 		$(if $(wildcard $(HOME)/.netrc),$(NETRC),) \
 		--progress plain \
 		--output $(BUILDKIT_OUTPUT)
@@ -126,3 +129,15 @@ update-shasums:
 .PHONY: validate-shasums
 validate-shasums: update-shasums
 	git diff --exit-code ./checksums
+
+.PHONY: download-golang
+download-golang: clean-golang-download $(shell yq  e 'to_entries | .[] | select(.key == "*GOLANG_VERSION*") | .value |= "download-golang-" + . | .value' ${MAKE_ROOT}/versions.yaml)
+
+.PHONY: clean-golang-download
+clean-golang-download:
+	rm -f ${GOLANG_RPM_OUTPUT_DIR}/golang-*.rpm
+	mkdir -p ${GOLANG_RPM_OUTPUT_DIR}
+
+.PHONY: download-golang-%
+download-golang-%:
+	${MAKE_ROOT}/scripts/download_golang.sh ${*} ${GOLANG_RPM_OUTPUT_DIR}

--- a/builder-base/scripts/download_golang.sh
+++ b/builder-base/scripts/download_golang.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -x
+set -e
+set -o pipefail
+
+SCRIPT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+
+VERSION="$1"
+OUTPUT_DIR="$2"
+
+RELEASE_NUMBER="$(echo $VERSION | cut -d'-' -f 2)"
+
+source $SCRIPT_ROOT/common_vars.sh
+
+function build::go::download(){
+      # Set up specific go version by using go get, additional versions apart from default can be installed by calling
+    # the function again with the specific parameter.
+    local version=${1%-*}
+    local outputDir=${2}
+
+    if [ $TARGETARCH == 'amd64' ]; then
+        local arch='x86_64'
+    else
+        local arch='aarch64'
+    fi
+
+    for artifact in golang golang-bin; do
+        curl -sSL --retry 5 https://distro.eks.amazonaws.com/golang-go$version/releases/$RELEASE_NUMBER/RPMS/$arch/$artifact-$version-$RELEASE_NUMBER.amzn2.eks.$arch.rpm -o $outputDir/$artifact-$version-$RELEASE_NUMBER.amzn2.eks.$arch.rpm
+    done
+
+    if [ $TARGETARCH == 'amd64' ]; then
+        curl -sSL --retry 5 https://distro.eks.amazonaws.com/golang-go$version/releases/$RELEASE_NUMBER/RPMS/$arch/golang-race-$version-$RELEASE_NUMBER.amzn2.eks.$arch.rpm -o $outputDir/golang-race-$version-$RELEASE_NUMBER.amzn2.eks.$arch.rpm
+    fi
+
+    for artifact in golang-docs golang-misc golang-tests golang-src; do
+        curl -sSL --retry 5 https://distro.eks.amazonaws.com/golang-go$version/releases/$RELEASE_NUMBER/RPMS/noarch/$artifact-$version-$RELEASE_NUMBER.amzn2.eks.noarch.rpm -o $outputDir/$artifact-$version-$RELEASE_NUMBER.amzn2.eks.noarch.rpm
+    done
+}
+
+build::go::download "${VERSION}" "$OUTPUT_DIR"
+

--- a/builder-base/scripts/install_golang.sh
+++ b/builder-base/scripts/install_golang.sh
@@ -21,8 +21,6 @@ SCRIPT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 
 VERSION="$1"
 
-RELEASE_NUMBER="$(echo $VERSION | cut -d'-' -f 2)"
-
 GOLANG_MAJOR_VERSION=${VERSION%.*}
 
 NEWROOT=/golang-${GOLANG_MAJOR_VERSION}
@@ -47,25 +45,6 @@ function build::go::install(){
     # Set up specific go version by using go get, additional versions apart from default can be installed by calling
     # the function again with the specific parameter.
     local version=${1%-*}
-
-    if [ $TARGETARCH == 'amd64' ]; then 
-        local arch='x86_64'
-    else 
-        local arch='aarch64'
-    fi
-
-    for artifact in golang golang-bin; do
-        curl -sSL --retry 5 https://distro.eks.amazonaws.com/golang-go$version/releases/$RELEASE_NUMBER/RPMS/$arch/$artifact-$version-$RELEASE_NUMBER.amzn2.eks.$arch.rpm -o /tmp/$artifact-$version-$RELEASE_NUMBER.amzn2.eks.$arch.rpm
-    done
-
-    if [ $TARGETARCH == 'amd64' ]; then 
-        curl -sSL --retry 5 https://distro.eks.amazonaws.com/golang-go$version/releases/$RELEASE_NUMBER/RPMS/$arch/golang-race-$version-$RELEASE_NUMBER.amzn2.eks.$arch.rpm -o /tmp/golang-race-$version-$RELEASE_NUMBER.amzn2.eks.$arch.rpm
-    fi
-
-    for artifact in golang-docs golang-misc golang-tests golang-src; do
-        curl -sSL --retry 5 https://distro.eks.amazonaws.com/golang-go$version/releases/$RELEASE_NUMBER/RPMS/noarch/$artifact-$version-$RELEASE_NUMBER.amzn2.eks.noarch.rpm -o /tmp/$artifact-$version-$RELEASE_NUMBER.amzn2.eks.noarch.rpm
-    done
-
     build::go::extract $version
     build::go::symlink $version
 }


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/eks-distro-internal/issues/308

*Description of changes:*
We want to have fine-grained control over which Golang RPMs are installed on the `builder-base` at build time. Such controll will allow us to build and test a `builder-base` containing development Golang RPMs more easily.

This PR updates the `builder-base` Dockerfile Go install routine to simply `ADD` the Golang RPMs from the local context, rather than downloading them from the EKS-D CDN directly. The sourcing of the Golang RPMs is left to the Makefile. This will allow us to source the RPMs differently -- such as from the build artifacts of a pipeline, or another local build process, rather than locking us in to using the prod artifacts every time (as is the case with the `install_golang.sh` script, which has the EKS D CDN hard-coded).

So, this PR changes it so we do the following:
- in the `Makefile`
    - download the EKS Go RPMs from the EKS D CDN (by invoking the new `download_golang.sh`)
    - pass the relative location of those fresh RPMs to the `builder-base` as a build argument
- in the `Dockerfile`
   - `ADD` the RPMs from the path given to `/tmp` in the build image
   - invoke the `install_golang.sh` script to unpack the RPMs and link up the binaries as needed inside the image

This will allow us to over-ride the location of the Golang RPMs on the local machine, so that we can then easily build a `builder-base` image with those custom/dev/experimental RPMs. The over-riding of the RPMs ins't in this PR; I'll add that a bit later in a follow-on PR. A further enhancement will be to allow for even more granular control, such as downloading only certain RPMs and sourcing others from the local environment. This can be achieved with target make calls as-is (e.g. only invoking the `download-golang-%` target for the specific golang versions you wish to download) but may need some tweaks for usability. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
