### PR TITLE
Trigger label with slash command

### DIFF
--- a/pr-scripts/create_pr.sh
+++ b/pr-scripts/create_pr.sh
@@ -79,6 +79,10 @@ else
     fi
 fi
 
+# Adding this here to include the "do-not-merge/hold" label. Trying to use the gh client with the --label arg will not succeed
+# as the bot doesn't have permission to add labels. Doing it this way our Prow chatops will pick it up and add it.
+printf "\n/hold\n" >> $PR_BODY_FILE
+
 PROW_BUCKET_NAME=$(echo $JOB_SPEC | jq -r ".decoration_config.gcs_configuration.bucket" | awk -F// '{print $NF}')
 printf "\nClick [here](https://prow.eks.amazonaws.com/view/s3/$PROW_BUCKET_NAME/logs/$JOB_NAME/$BUILD_ID) to view job logs.
 \nBy submitting this pull request,\
@@ -125,5 +129,5 @@ gh auth login --with-token < /secrets/github-secrets/token
 
 PR_EXISTS=$(gh pr list -H "${PR_BRANCH}" || true)
 if [ $PR_EXISTS -eq 0 ]; then
-  gh pr create --title "$PR_TITLE" --body "$PR_BODY" --label "do-not-merge/hold"
+  gh pr create --title "$PR_TITLE" --body "$PR_BODY"
 fi


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
[Adding the 'do-not-merge/hold' label with the gh api ](https://github.com/aws/eks-distro-build-tooling/blob/main/pr-scripts/create_pr.sh#L128)doesn't work as the PR bot is not listed as an outside collaborator to our org (and just treated like an external developer). We could get around adding the bot by using a GH Action Labeler to hold all PRs from the bot, but even simpler is to use our existing Prow chatops feature with the slash hold command. 

Tested manually by adding the slash as the bot and it succceeded in adding hte label.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
