### PR TITLE
Fixes build setup when deleting old deployments

### DIFF
--- a/scripts/setup_buildx.sh
+++ b/scripts/setup_buildx.sh
@@ -65,7 +65,10 @@ if ! docker buildx ls | grep $BUILDER_NAME > /dev/null 2>&1; then
         # in the case where jobs are evicted or otherwise crash where the trap does
         # not fire, they can be left around. cleanup any instances older than 1 day
         # https://stackoverflow.com/a/53989428 - match the 5 column which is the age against a nuber folloed by "d"
-        kubectl delete deployments -n buildkit-orchestration $(kubectl get deployments -n buildkit-orchestration | awk 'match($5,/[0-9]+d/) {print $1}')
+        DEPLOYMENTS=$(kubectl get deployments -n buildkit-orchestration | awk 'match($5,/[0-9]+d/) {printf $1" "}')
+        if [ -n "$DEPLOYMENTS" ]; then
+            kubectl delete deployments -n buildkit-orchestration $DEPLOYMENTS
+        fi
 
         docker buildx create \
             --bootstrap \


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

The builder-base postsubmit is failing due to trying to delete old buildx deployments, but there are none. This should make the script handle the case where there are none running vs failing out.

https://prow.eks.amazonaws.com/view/s3/prowdataclusterstack-316434458-prowbucket7c73355c-1n9f9v93wpjcm/logs/builder-base-tooling-postsubmit/1611471054729908224

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
