### PR TITLE
Bumps go-licenses to fix missing licenses bug

### DIFF
--- a/builder-base/scripts/install_go_licenses.sh
+++ b/builder-base/scripts/install_go_licenses.sh
@@ -32,7 +32,11 @@ function install_go_licenses() {
     # with GOROOT pointed to /root/sdk/go... instead of /usr/local/go so it
     # is able to properly packages from the standard Go library
     # We currently  use 1.19, 1.17 or 1.16, so installing for all
-    GO111MODULE=on GOBIN=${NEWROOT}/${GOPATH}/${GOLANG_MAJOR_VERSION}/bin go install github.com/google/go-licenses@$GO_LICENSES_VERSION
+    if [ "${GOLANG_MAJOR_VERSION}" = "go1.16" ]; then
+        GO111MODULE=on GOBIN=${NEWROOT}/${GOPATH}/${GOLANG_MAJOR_VERSION}/bin go install github.com/jaxesn/go-licenses@4497a2a38565e4e6ad095ea8117c25ecd622d0cc
+    else
+        GO111MODULE=on GOBIN=${NEWROOT}/${GOPATH}/${GOLANG_MAJOR_VERSION}/bin go install github.com/jaxesn/go-licenses@6800d77c11d0ef8628e7eda908b1d1149383ca48
+    fi
 
     # symlink to go/bin and depending on which go-licenses vs is added last to
     # the final image, will take precedent and be the default


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

For background on the issue: https://github.com/google/go-licenses/pull/178

Tested in eks-a, updates made https://github.com/aws/eks-anywhere-build-tooling/pull/1718

I am going to work to get the PR upstream merged after doing verification with our build pipelines, which is mostly already done at this point, this is the last step.  For now, going to install go-liceses via my fork and will update back to the upstream tag when its available.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
