### PR TITLE
Fixes al22 images with yum wrt releasever latest

### DIFF
--- a/eks-distro-base/scripts/eks-d-common
+++ b/eks-distro-base/scripts/eks-d-common
@@ -392,6 +392,13 @@ function build::common::clean_install() {
     local -r force=${4:-}
     local -r extract_dir="${5:-$NEWROOT}"
     
+    if [ "$NEWROOT" != "/" ] && [ -f /etc/dnf/vars/releasever ] && [ ! -f $NEWROOT/etc/dnf/vars/releasever ]; then
+        # on al22 we set releasever to latest in the base image, but for images that also install
+        # yum, they seem to ignore the releasever file in the /etc dir, copy to newroot as well to fix this
+        mkdir -p $NEWROOT/etc/dnf/vars
+        cp /etc/dnf/vars/releasever $NEWROOT/etc/dnf/vars/
+    fi
+
     if [ $just_db ]; then
         just_db="--justdb"
     else


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

We noticed that images based on AL22 which install yum in the final image (git/kind/compiler) were building over and over. This was due to the releasever not being set to latest so even tho the image was trigger to rebuild each day, it was still downloading the previous version of certain packages because the releasever was old. I tried to fix this in #712 but it appears that once the /newroot folder actually has yum installed, yum ignores the releasever file created in /etc.  

This PR replicates the releasever config file into the newroot folder as well as /etc.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
