### PR TITLE
Change RPM build sync destination for AMD and ARM architecture

### DIFF
--- a/builder-base/scripts/download_golang.sh
+++ b/builder-base/scripts/download_golang.sh
@@ -36,21 +36,21 @@ function build::go::download(){
     for artifact in golang golang-bin; do
         local filename="$outputDir/$artifact-$version-$RELEASE_NUMBER.amzn2.eks.$arch.rpm"
         if [ ! -f $filename ]; then
-            curl -sSL --retry 5 https://distro.eks.amazonaws.com/golang-go$version/releases/$RELEASE_NUMBER/$arch/RPMS/$arch/$artifact-$version-$RELEASE_NUMBER.amzn2.eks.$arch.rpm -o $filename
+            curl -sSL --retry 5 https://distro.eks.amazonaws.com/golang-go$version/releases/$RELEASE_NUMBER/RPMS/$arch/$artifact-$version-$RELEASE_NUMBER.amzn2.eks.$arch.rpm -o $filename
         fi
     done
 
     if [ $arch == 'x86_64' ]; then
         local filename="$outputDir/golang-race-$version-$RELEASE_NUMBER.amzn2.eks.$arch.rpm"
         if [ ! -f $filename ]; then
-            curl -sSL --retry 5 https://distro.eks.amazonaws.com/golang-go$version/releases/$RELEASE_NUMBER/$arch/RPMS/$arch/golang-race-$version-$RELEASE_NUMBER.amzn2.eks.$arch.rpm -o $filename
+            curl -sSL --retry 5 https://distro.eks.amazonaws.com/golang-go$version/releases/$RELEASE_NUMBER/RPMS/$arch/golang-race-$version-$RELEASE_NUMBER.amzn2.eks.$arch.rpm -o $filename
         fi
     fi
 
     for artifact in golang-docs golang-misc golang-tests golang-src; do
         local filename="$outputDir/$artifact-$version-$RELEASE_NUMBER.amzn2.eks.noarch.rpm"
         if [ ! -f $filename ]; then
-            curl -sSL --retry 5 https://distro.eks.amazonaws.com/golang-go$version/releases/$RELEASE_NUMBER/$arch/RPMS/noarch/$artifact-$version-$RELEASE_NUMBER.amzn2.eks.noarch.rpm -o $filename
+            curl -sSL --retry 5 https://distro.eks.amazonaws.com/golang-go$version/releases/$RELEASE_NUMBER/RPMS/noarch/$artifact-$version-$RELEASE_NUMBER.amzn2.eks.noarch.rpm -o $filename
         fi
     done
 }

--- a/builder-base/scripts/download_golang.sh
+++ b/builder-base/scripts/download_golang.sh
@@ -36,21 +36,21 @@ function build::go::download(){
     for artifact in golang golang-bin; do
         local filename="$outputDir/$artifact-$version-$RELEASE_NUMBER.amzn2.eks.$arch.rpm"
         if [ ! -f $filename ]; then
-            curl -sSL --retry 5 https://distro.eks.amazonaws.com/golang-go$version/releases/$RELEASE_NUMBER/RPMS/$arch/$artifact-$version-$RELEASE_NUMBER.amzn2.eks.$arch.rpm -o $filename
+            curl -sSL --retry 5 https://distro.eks.amazonaws.com/golang-go$version/releases/$RELEASE_NUMBER/$arch/RPMS/$arch/$artifact-$version-$RELEASE_NUMBER.amzn2.eks.$arch.rpm -o $filename
         fi
     done
 
     if [ $arch == 'x86_64' ]; then
         local filename="$outputDir/golang-race-$version-$RELEASE_NUMBER.amzn2.eks.$arch.rpm"
         if [ ! -f $filename ]; then
-            curl -sSL --retry 5 https://distro.eks.amazonaws.com/golang-go$version/releases/$RELEASE_NUMBER/RPMS/$arch/golang-race-$version-$RELEASE_NUMBER.amzn2.eks.$arch.rpm -o $filename
+            curl -sSL --retry 5 https://distro.eks.amazonaws.com/golang-go$version/releases/$RELEASE_NUMBER/$arch/RPMS/$arch/golang-race-$version-$RELEASE_NUMBER.amzn2.eks.$arch.rpm -o $filename
         fi
     fi
 
     for artifact in golang-docs golang-misc golang-tests golang-src; do
         local filename="$outputDir/$artifact-$version-$RELEASE_NUMBER.amzn2.eks.noarch.rpm"
         if [ ! -f $filename ]; then
-            curl -sSL --retry 5 https://distro.eks.amazonaws.com/golang-go$version/releases/$RELEASE_NUMBER/RPMS/noarch/$artifact-$version-$RELEASE_NUMBER.amzn2.eks.noarch.rpm -o $filename
+            curl -sSL --retry 5 https://distro.eks.amazonaws.com/golang-go$version/releases/$RELEASE_NUMBER/$arch/RPMS/noarch/$artifact-$version-$RELEASE_NUMBER.amzn2.eks.noarch.rpm -o $filename
         fi
     done
 }

--- a/projects/golang/go/Makefile
+++ b/projects/golang/go/Makefile
@@ -55,7 +55,7 @@ endif
 golang-build: check-env setup-rpm-tree fetch-golang-source-archive copy-sources-to-rpmbuild-tree copy-patches-to-rpmbuild-tree build-golang-rpm generate-golang-archive test generate-golang-checksum
 
 .PHONY: build
-build: golang-build sync-artifacts-to-s3-dry-run local-images
+build: golang-build sync-artifacts-to-s3-dry-run remove-rpmbuild local-images
 build:
 	echo "test"
 
@@ -100,6 +100,10 @@ ifeq (, $(shell which rpmbuild))
 	$(error "No rpmbuild in $(PATH), try 'yum install rpmbuild'")
 endif
 	rpmbuild -v -ba $(VERSION_DIRECTORY)/rpmbuild/SPECS/golang.spec --define "_rpmdir $(VERSION_DIRECTORY)/rpmbuild" --define "_buildid $(BUILD_ID)"
+
+.PHONY: remove-rpmbuild
+remove-rpmbuild:
+	rm -rf $(VERSION_DIRECTORY)/rpmbuild
 
 .PHONY: local-images
 local-images: PUSH_IMAGES=false

--- a/projects/golang/go/Makefile
+++ b/projects/golang/go/Makefile
@@ -101,10 +101,6 @@ ifeq (, $(shell which rpmbuild))
 endif
 	rpmbuild -v -ba $(VERSION_DIRECTORY)/rpmbuild/SPECS/golang.spec --define "_rpmdir $(VERSION_DIRECTORY)/rpmbuild" --define "_buildid $(BUILD_ID)"
 
-.PHONY: remove-rpmbuild
-remove-rpmbuild:
-	rm -rf $(VERSION_DIRECTORY)/rpmbuild
-
 .PHONY: local-images
 local-images: PUSH_IMAGES=false
 local-images: images

--- a/projects/golang/go/Makefile
+++ b/projects/golang/go/Makefile
@@ -55,7 +55,7 @@ endif
 golang-build: check-env setup-rpm-tree fetch-golang-source-archive copy-sources-to-rpmbuild-tree copy-patches-to-rpmbuild-tree build-golang-rpm generate-golang-archive test generate-golang-checksum
 
 .PHONY: build
-build: golang-build sync-artifacts-to-s3-dry-run remove-rpmbuild local-images
+build: golang-build sync-artifacts-to-s3-dry-run clean local-images
 build:
 	echo "test"
 
@@ -224,6 +224,7 @@ clean:
 	rm -rf $(VERSION_DIRECTORY)/rpmbuild/noarch
 	rm -rf $(VERSION_DIRECTORY)/rpmbuild/x86_64
 	rm -rf $(HOME)/rpmbuild
+	rm -rf /tmp/go-extracted
 
 .PHONY: install-deps
 install-deps:

--- a/projects/golang/go/Makefile
+++ b/projects/golang/go/Makefile
@@ -25,8 +25,8 @@ ifeq ($(ARCHITECTURE), ARM64)
 endif
 ARCH_LOWER=$(call TO_LOWER,$(ARCHITECTURE))
 
-ARCH_RPM_OUT_PATH?=golang-$(GIT_TAG)/releases/$(BUILD_ID)/RPMS/$(RPM_ARCH)
-NOARCH_RPM_OUT_PATH?=golang-$(GIT_TAG)/releases/$(BUILD_ID)/RPMS/noarch
+ARCH_RPM_OUT_PATH?=golang-$(GIT_TAG)/releases/$(BUILD_ID)/$(RPM_ARCH)/RPMS/$(RPM_ARCH)
+NOARCH_RPM_OUT_PATH?=golang-$(GIT_TAG)/releases/$(BUILD_ID)/$(RPM_ARCH)/RPMS/noarch
 ARCHIVES_OUT_PATH?=golang-$(GIT_TAG)/releases/$(BUILD_ID)/archives
 
 AWS_ACCOUNT_ID?=$(shell aws sts get-caller-identity --query Account --output text)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* [Explanation](https://quip-amazon.com/SEFsAzSpzdxB/Resolve-Noarch-RPM-Build-Sync-Path) As the part of the change, in this PR only the Makefile sync path will be changed. The `download_golang.sh` script pulls from the S3 bucket, thus if the Makefile change and the `download_golang.sh` scripts are changed in the same PR, the download_golang.sh script will try to pull from a path which doesn't exist yet. 
Also, in this PR a new target `clean` is introduced to free space before the `local-images` target is run.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
