### PR TITLE
Add env of the ARG binary name

### DIFF
--- a/tools/eksDistroBuildToolingOpsTools/docker/Dockerfile
+++ b/tools/eksDistroBuildToolingOpsTools/docker/Dockerfile
@@ -3,9 +3,10 @@ FROM public.ecr.aws/eks-distro-build-tooling/eks-distro-base:latest
 ARG BINARY_OUTPUT_PATH
 
 ARG BINARY_NAME
+ENV OPS_TOOL_BINARY=$BINARY_NAME
 
 ADD $BINARY_OUTPUT_PATH /usr/bin
 
 RUN chmod +x /usr/bin/$BINARY_NAME
 
-ENTRYPOINT $BINARY_NAME
+ENTRYPOINT echo $OPS_TOOL_BINARY


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Apparently ARG isn't available at the time ENTRYPOINT is run, which is why it was taking the literal $BINARY_NAME , but ENV is. If we want to leave it generic (just something discussed when writing the file originally) this was an option I found that is supposed to work.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
