### PR TITLE
remove variable entrypoint

### DIFF
--- a/tools/eksDistroBuildToolingOpsTools/docker/Dockerfile
+++ b/tools/eksDistroBuildToolingOpsTools/docker/Dockerfile
@@ -9,4 +9,4 @@ ADD $BINARY_OUTPUT_PATH /usr/bin
 
 RUN chmod +x /usr/bin/$BINARY_NAME
 
-ENTRYPOINT echo $OPS_TOOL_BINARY
+ENTRYPOINT ["eksDistroOpsProwPlugin"]


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Doing it the previous way invokes `/bin/sh -c echo $variable` which just returns the value at the variable which isn't the intended purpose. To try and test it as is, just going to hardcode for now and see if there is a good way to make generic later.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
