### PR TITLE
Add git image for ops tool

### DIFF
--- a/tools/eksDistroBuildToolingOpsTools/docker/Dockerfile
+++ b/tools/eksDistroBuildToolingOpsTools/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/eks-distro-build-tooling/eks-distro-base:latest
+FROM public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-git:latest-al2
 
 ARG BINARY_OUTPUT_PATH
 

--- a/tools/eksDistroBuildToolingOpsTools/docker/Dockerfile
+++ b/tools/eksDistroBuildToolingOpsTools/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/eks-distro-build-tooling/compiler-base:gcc-latest-al2
+FROM public.ecr.aws/eks-distro-build-tooling/eks-distro-base:latest
 
 ARG BINARY_OUTPUT_PATH
 
@@ -8,5 +8,7 @@ ENV OPS_TOOL_BINARY=$BINARY_NAME
 ADD $BINARY_OUTPUT_PATH /usr/bin
 
 RUN chmod +x /usr/bin/$BINARY_NAME
+
+RUN yum install git
 
 ENTRYPOINT ["eksDistroOpsProwPlugin"]

--- a/tools/eksDistroBuildToolingOpsTools/docker/Dockerfile
+++ b/tools/eksDistroBuildToolingOpsTools/docker/Dockerfile
@@ -1,14 +1,9 @@
-FROM public.ecr.aws/eks-distro-build-tooling/eks-distro-base:latest
+FROM public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-git:latest-al2
 
 ARG BINARY_OUTPUT_PATH
 
 ARG BINARY_NAME
-ENV OPS_TOOL_BINARY=$BINARY_NAME
 
 ADD $BINARY_OUTPUT_PATH /usr/bin
-
-RUN chmod +x /usr/bin/$BINARY_NAME
-
-RUN yum install git
 
 ENTRYPOINT ["eksDistroOpsProwPlugin"]

--- a/tools/eksDistroBuildToolingOpsTools/docker/Dockerfile
+++ b/tools/eksDistroBuildToolingOpsTools/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-git:latest-al2
+FROM public.ecr.aws/eks-distro-build-tooling/compiler-base:gcc-latest-al2
 
 ARG BINARY_OUTPUT_PATH
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Output logs from the ops tool failing from `\"git\": executable file not found in $PATH",`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
