### PR TITLE
Add Ops Tool to PROD for Distro-build-tooling

### DIFF
--- a/helm-charts/stable/prow-control-plane/templates/eksdistroopstool-Deployment.yaml
+++ b/helm-charts/stable/prow-control-plane/templates/eksdistroopstool-Deployment.yaml
@@ -1,0 +1,67 @@
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: default
+  name: eksdistroopstool
+  labels:
+    app: eksdistroopstool
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: eksdistroopstool
+  template:
+    metadata:
+      labels:
+        app: eksdistroopstool
+    spec:
+      terminationGracePeriodSeconds: 180
+      containers:
+      - name: eksdistroopstool
+        image: {{ .Values.eksdistroopstool.image }}
+        imagePullPolicy: Always
+        args:
+        - --github-token-path=/etc/github/token
+        - --github-endpoint=http://ghproxy
+        - --github-endpoint=https://api.github.com
+        - --dry-run=false
+        ports:
+          - name: http
+            containerPort: 8888
+        volumeMounts:
+        - name: hmac
+          mountPath: /etc/webhook
+          readOnly: true
+        - name: github-token
+          mountPath: /etc/github
+          readOnly: true
+        - name: tmp
+          mountPath: /tmp
+      volumes:
+      - name: tmp
+        emptyDir: {}
+      - name: hmac
+        secret:
+          secretName: hmac-token
+      - name: github-token
+        secret:
+          secretName: pr-bot-github-token

--- a/helm-charts/stable/prow-control-plane/templates/eksdistroopstool-Service.yaml
+++ b/helm-charts/stable/prow-control-plane/templates/eksdistroopstool-Service.yaml
@@ -1,0 +1,26 @@
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.eksdistroopstool.serviceName }}
+  namespace: default
+spec:
+  selector:
+    app: eksdistroopstool
+  ports:
+  - port: 80
+    targetPort: 8888
+  type: ClusterIP

--- a/helm-charts/stable/prow-control-plane/values.yaml
+++ b/helm-charts/stable/prow-control-plane/values.yaml
@@ -24,7 +24,13 @@ repositories:
 - org: "aws"
   name: "eks-distro-prow-jobs"
   extraPlugins: ["config-updater"]
-  extraExternalPlugins: []
+  extraExternalPlugins: 
+  - name: eksdistroopstool
+    events:
+    - issue_comment
+    - pull_request
+    - issues
+    endpoint: http://eksdistroopstool
 - org: "aws"
   name: "eks-anywhere"
   extraPlugins: []
@@ -192,3 +198,7 @@ plugins:
 cherrypicker:
   serviceName: cherrypicker
   image:  gcr.io/k8s-prow/cherrypicker:v20200924-369a496323 
+
+eksdistroopstool:
+  serviceName: eksdistroopstool
+  image:  public.ecr.aws/eks-distro-build-tooling/eks-distro-ops-tool:0


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Added the Deployment and Service values that are pulled when adding the tool to prod. Added the image information for the tool in the public ecr.

Tested the tool against personal repo and got expected responses to opened issues.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
