### PR TITLE
Add backport request handler

### DIFF
--- a/tools/eksDistroBuildToolingOpsTools/pkg/server/backportRequest.go
+++ b/tools/eksDistroBuildToolingOpsTools/pkg/server/backportRequest.go
@@ -1,0 +1,70 @@
+package server
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+	"sync"
+
+	"github.com/sirupsen/logrus"
+	"k8s.io/test-infra/prow/github"
+)
+
+type backportRequest struct {
+	org    string
+	repo   string
+	issNum int
+}
+
+// Currently handling Golang Patch Releases and Golang Minor Releases
+var backportRe = regexp.MustCompile(`(?m)^(?:/backport)\s+(.+)$`)
+
+func (s *Server) handleBackportRequest(l *logrus.Entry, requestor string, issue *github.Issue, backportMatches []string, org, repo string, num int) error {
+	var lock *sync.Mutex
+	func() {
+		s.mapLock.Lock()
+		defer s.mapLock.Unlock()
+		if _, ok := s.lockBackportMap[backportRequest{org, repo, num}]; !ok {
+			if s.lockBackportMap == nil {
+				s.lockBackportMap = map[backportRequest]*sync.Mutex{}
+			}
+			s.lockBackportMap[backportRequest{org, repo, num}] = &sync.Mutex{}
+		}
+		lock = s.lockBackportMap[backportRequest{org, repo, num}]
+	}()
+	lock.Lock()
+	defer lock.Unlock()
+
+	//Only a org member should be able to request a issue backport
+	if !s.AllowAll {
+		ok, err := s.Ghc.IsMember(org, requestor)
+		if err != nil {
+			return err
+		}
+		if !ok {
+			resp := fmt.Sprintf("only [%s](https://github.com/orgs/%s/people) org members may request may trigger automated issues. You can still create the issue manually.", org, org)
+			l.Info(resp)
+			return s.Ghc.CreateComment(org, repo, num, resp)
+		}
+	}
+
+	// Handle "/backport all"
+
+	// Handle "/backport v1.15.15 ...
+	for _, version := range backportMatches {
+		_, err := s.Ghc.CreateIssue(org, repo, fmt.Sprintf("[%s]%s", version, issue.Title), s.generateBackportIssueBody(issue, requestor), 0, nil, []string{requestor})
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *Server) generateBackportIssueBody(issue *github.Issue, requestor string) string {
+	b := strings.Builder{}
+
+	b.WriteString(fmt.Sprintf("A backport of issue %v was requested by @%v\n", issue.HTMLURL, requestor))
+	b.WriteString(fmt.Sprintf("%v", issue.Body))
+	bs := b.String()
+	return bs
+}

--- a/tools/eksDistroBuildToolingOpsTools/pkg/server/server.go
+++ b/tools/eksDistroBuildToolingOpsTools/pkg/server/server.go
@@ -69,6 +69,7 @@ type Server struct {
 	Repos              []github.Repo
 	mapLock            sync.Mutex
 	lockGolangPatchMap map[golangPatchReleaseRequest]*sync.Mutex
+	lockBackportMap    map[backportRequest]*sync.Mutex
 }
 
 // ServeHTTP validates an incoming webhook and puts it into the event channel.
@@ -98,6 +99,16 @@ func (s *Server) handleEvent(eventType, eventGUID string, payload []byte) error 
 		go func() {
 			if err := s.handleIssue(l, ie); err != nil {
 				s.Log.WithError(err).WithFields(l.Data).Info("Handle Issue Failed.")
+			}
+		}()
+	case "issue_comment":
+		var ic github.IssueCommentEvent
+		if err := json.Unmarshal(payload, &ic); err != nil {
+			return err
+		}
+		go func() {
+			if err := s.handleIssueComment(l, ic); err != nil {
+				s.Log.WithError(err).WithFields(l.Data).Info("Handle Issue Comment Failed.")
 			}
 		}()
 	default:
@@ -135,6 +146,34 @@ func (s *Server) handleIssue(l *logrus.Entry, ie github.IssueEvent) error {
 	//TODO: add golangMinorMatches := golangMinorReleaseRe.FindAllStringSubmatch(ie.Issue.Title, -1)
 	//Regex for thisi is below.
 	//var golangMinorReleaseRe = regexp.MustCompile(`(?m)^(?:Golang Minor Release:)\s+(.+)$`)
+
+	return nil
+}
+
+func (s *Server) handleIssueComment(l *logrus.Entry, ic github.IssueCommentEvent) error {
+	// Only consider newly opened issues.
+	if ic.Action != github.IssueCommentActionCreated {
+		return nil
+	}
+
+	org := ic.Repo.Owner.Login
+	repo := ic.Repo.Name
+	num := ic.Issue.Number
+	commentAuthor := ic.Comment.User.Login
+
+	// Do not create a new logger, its fields are re-used by the caller in case of errors
+	*l = *l.WithFields(logrus.Fields{
+		github.OrgLogField:  org,
+		github.RepoLogField: repo,
+		github.PrLogField:   num,
+	})
+
+	backportMatches := backportRe.FindAllString(ic.Comment.Body, -1)
+	if len(backportMatches) != 0 {
+		if err := s.handleBackportRequest(l, commentAuthor, &ic.Issue, backportMatches, org, repo, num); err != nil {
+			return fmt.Errorf("Handle backport request failure: %w", err)
+		}
+	}
 
 	return nil
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Add a /backport handler to the prow plugin, currently for go, but should be able to work for other projects as well.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
