### PR TITLE
move buildspecs to main

### DIFF
--- a/projects/golang/go/build/conformanceTests/builderBaseRebuildBuildspec.yaml
+++ b/projects/golang/go/build/conformanceTests/builderBaseRebuildBuildspec.yaml
@@ -22,7 +22,7 @@ env:
     BUILDKIT_PLATFORMS: "linux/amd64"
     EKS_D_BUILD_TOOLING_REMOTE_URL: "https://github.com/aws/eks-distro-build-tooling.git"
     IMAGE_NAME: "builder-base-development"
-    TARGET_BRANCH: "codebuildTest"
+    TARGET_BRANCH: "main"
     UPDATE_BASE_IMAGE: "false"
 
 phases:

--- a/projects/golang/go/build/conformanceTests/eksDistroRebuildBuildspec.yaml
+++ b/projects/golang/go/build/conformanceTests/eksDistroRebuildBuildspec.yaml
@@ -50,7 +50,7 @@ env:
     NODE_INSTANCE_PROFILE: "arn:aws:iam::125833916567:instance-profile/KopsNodesBuildRole"
     REBUILD_ALL: "true"
     SKIP_CHECKSUM_VALIDATION: "true"
-    TARGET_BRANCH: "codebuildTest"
+    TARGET_BRANCH: "main"
     TEST_ROLE_ARN: "arn:aws:iam::125833916567:role/TestBuildRole"
 
 phases:

--- a/projects/golang/go/build/conformanceTests/golangBuildspec.yaml
+++ b/projects/golang/go/build/conformanceTests/golangBuildspec.yaml
@@ -48,7 +48,7 @@ env:
     ARTIFACTS_BUCKET: "eks-d-postsubmit-artifacts"
     BUILD_PREPROD_IMAGES: "false"
     EKS_D_BUILD_TOOLING_REMOTE_URL: "https://github.com/aws/eks-distro-build-tooling.git"
-    TARGET_BRANCH: "codebuildTest"
+    TARGET_BRANCH: "main"
 
 phases:
   pre_build:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
final step in our conformance-test-in-codebuild switchover -- move the target branch in the codebuild to `main`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
