### PR TITLE
unifiy golang and debian base image prod releases

### DIFF
--- a/projects/golang/go/Makefile
+++ b/projects/golang/go/Makefile
@@ -75,6 +75,7 @@ release: $(RELEASE_TARGETS)
 prod-release: golang-build sync-artifacts-to-s3
 
 .PHONY: prod-release-images
+prod-release-images: export AWS_PROFILE=ecr-public-push
 prod-release-images: fetch-eks-go-archive images
 
 .PHONY: fetch-eks-go-archive

--- a/projects/golang/go/Makefile
+++ b/projects/golang/go/Makefile
@@ -35,8 +35,9 @@ AWS_ACCOUNT_ID?=$(shell aws sts get-caller-identity --query Account --output tex
 # This build is specifically focused on a debian base image for use with EKS build systems
 IMAGE_REPO?=$(AWS_ACCOUNT_ID).dkr.ecr.$(AWS_REGION).amazonaws.com
 IMAGE_NAME?=golang-debian
-IMAGE_TAG?=$(GIT_TAG)-$(IMAGE_BUILD_ID)
-IMAGE?=$(IMAGE_REPO)/$(IMAGE_NAME):$(IMAGE_TAG)
+IMAGE_TAG?=$(GIT_TAG)-$(BUILD_ID)-$(IMAGE_BUILD_ID)
+LATEST_IMAGE=$(IMAGE_REPO)/$(IMAGE_NAME):$(GIT_TAG)
+IMAGE?=$(IMAGE_REPO)/$(IMAGE_NAME):$(IMAGE_TAG),$(LATEST_IMAGE)
 
 PUSH_IMAGES?=true
 BUILDKIT_OUTPUT=type=image,oci-mediatypes=true,\"name=$(IMAGE)\",push=$(PUSH_IMAGES)
@@ -72,7 +73,7 @@ build: $(BUILD_TARGETS)
 release: $(RELEASE_TARGETS)
 
 .PHONY: prod-release
-prod-release: golang-build sync-artifacts-to-s3
+prod-release: golang-build sync-artifacts-to-s3 prod-release-images
 
 .PHONY: prod-release-images
 prod-release-images: export AWS_PROFILE=ecr-public-push

--- a/projects/golang/go/docker/debianBase/README.md
+++ b/projects/golang/go/docker/debianBase/README.md
@@ -1,5 +1,21 @@
 ## EKS Go Debian Base Image
-This Debian base image is inteneded for limited use as a base for upstream Kubernetes toolchain artifacts like `kube-cross`
+This Debian base image is intended for limited use as a base for upstream Kubernetes toolchain artifacts like `kube-cross`
+
+### Public ECR
+EKS Go Debian Base Images are available through the EKS Distribution Public ECR: https://gallery.ecr.aws/eks-distro-build-tooling/golang-debian
+
+### Image Tags
+EKS Go Debian Base Images are tagged with the following format:
+
+`$GOLANG_GIT_TAG-$EKS_GO_RELEASE-$EKS_GO_DEBIAN_DOCKERFILE_RELEASE`
+
+For example, the Golang 1.20 Debian base image would have a tag like the following: `1.20.1-5-6`.
+
+Where 
+- `$GOLANG_GIT_TAG` is the git tag of the tracked Golang version (e.g. [for Go 1.20](../../1.20/GIT_TAG))
+- `$EKS_GO_RELEASE` is the corresponding EKS Go release of the given Go version, as noted in the `RELEASE` file for the given version (e.g. [for Go 1.20](../../1.20/RELEASE)).
+- `$EKS_GO_DEBIAN_DOCKERFILE_RELEASE` is the corresponding version of the dockerfile used to build the image, from the [`RELEASE` file for the Debian base image](./RELEASE)
+
 
 ## Releases
 ### 1

--- a/projects/golang/go/scripts/prow_release.sh
+++ b/projects/golang/go/scripts/prow_release.sh
@@ -37,6 +37,11 @@ web_identity_token_file=/var/run/secrets/eks.amazonaws.com/serviceaccount/token
 role_arn=$ARTIFACT_DEPLOYMENT_ROLE_ARN
 region=${AWS_REGION:-${AWS_DEFAULT_REGION:-us-east-1}}
 source_profile=default
+
+[profile ecr-public-push]
+role_arn=$ECR_PUBLIC_PUSH_ROLE_ARN
+region=us-east-1
+source_profile=default
 EOF
 export AWS_CONFIG_FILE=$(pwd)/awscliconfig
 export AWS_PROFILE=artifacts-push


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/orgs/aws/projects/23/views/26?pane=issue&itemId=18822067

*Description of changes:*
Now, when we release a Golang Debian Base Image, the tags will:
- include one tagged simply with the latest Git tag for the given version, with no other identifiers, to act like a 'latest' image
- include a tag which includes the Git tag, the EKS Go release number, and the Dockerfile release number

The Debian dockerfile release will also take place as a part of the standard EKS Go prod release. This way, we can still update the Dockerfile independently of the EKS Go release process in order to trigger a release and modify the image, but we also get the convenience of automation release when we release a new prod version of EKS Go. See the ticket for the whole picture.

Requires some updates to the prow jobs, [specifically including an image build in each one.](https://github.com/aws/eks-distro-prow-jobs/pull/482)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
