### PR TITLE
add dependnecy updater interfaces and framework

### DIFF
--- a/tools/eksDistroBuildToolingOpsTools/Makefile
+++ b/tools/eksDistroBuildToolingOpsTools/Makefile
@@ -60,6 +60,7 @@ mocks: ## Generate mocks
 	go get github.com/golang/mock/mockgen@v1.6.0
 	${GOPATH}/bin/mockgen -destination=pkg/github/mocks/github.go -package=mocks "github.com/aws/eks-distro-build-tooling/tools/eksDistroBuildToolingOpsTools/pkg/github" GitClient,IssueClient,RepoClient,PullRequestClient
 	${GOPATH}/bin/mockgen -destination=pkg/consumerUpdater/mocks/consumerUpdater.go -package=mocks "github.com/aws/eks-distro-build-tooling/tools/eksDistroBuildToolingOpsTools/pkg/consumerUpdater" Consumer,Updater,Notifier
+	${GOPATH}/bin/mockgen -destination=pkg/consumerUpdater/mocks/dependencyUpdater.go -package=mocks "github.com/aws/eks-distro-build-tooling/tools/eksDistroBuildToolingOpsTools/pkg/dependencyUpdater" Consumer,Updater
 
 .PHONY: local-images-eksDistroOpsProwPlugin
 local-images-eksDistroOpsProwPlugin: PUSH_IMAGES=false

--- a/tools/eksDistroBuildToolingOpsTools/Makefile
+++ b/tools/eksDistroBuildToolingOpsTools/Makefile
@@ -60,7 +60,7 @@ mocks: ## Generate mocks
 	go get github.com/golang/mock/mockgen@v1.6.0
 	${GOPATH}/bin/mockgen -destination=pkg/github/mocks/github.go -package=mocks "github.com/aws/eks-distro-build-tooling/tools/eksDistroBuildToolingOpsTools/pkg/github" GitClient,IssueClient,RepoClient,PullRequestClient
 	${GOPATH}/bin/mockgen -destination=pkg/consumerUpdater/mocks/consumerUpdater.go -package=mocks "github.com/aws/eks-distro-build-tooling/tools/eksDistroBuildToolingOpsTools/pkg/consumerUpdater" Consumer,Updater,Notifier
-	${GOPATH}/bin/mockgen -destination=pkg/consumerUpdater/mocks/dependencyUpdater.go -package=mocks "github.com/aws/eks-distro-build-tooling/tools/eksDistroBuildToolingOpsTools/pkg/dependencyUpdater" Consumer,Updater
+	${GOPATH}/bin/mockgen -destination=pkg/dependencyUpdater/mocks/dependencyUpdater.go -package=mocks "github.com/aws/eks-distro-build-tooling/tools/eksDistroBuildToolingOpsTools/pkg/dependencyUpdater" Consumer,Updater
 
 .PHONY: local-images-eksDistroOpsProwPlugin
 local-images-eksDistroOpsProwPlugin: PUSH_IMAGES=false

--- a/tools/eksDistroBuildToolingOpsTools/pkg/dependencyUpdater/etcd.go
+++ b/tools/eksDistroBuildToolingOpsTools/pkg/dependencyUpdater/etcd.go
@@ -1,0 +1,77 @@
+package dependencyUpdater
+
+import (
+	"fmt"
+
+	"github.com/aws/eks-distro-build-tooling/tools/eksDistroBuildToolingOpsTools/pkg/eksDistroRelease"
+)
+
+const (
+	etcdName = "etcd"
+)
+
+func NewEtcdDependencyUpdater(releases []*eksDistroRelease.Release) Dependency {
+	return &EtcdUpdater{
+		updaters: etcdUpdaters(releases),
+		etcdInfo: etcdConsumerInfo(),
+	}
+}
+
+type EtcdUpdater struct {
+	updaters  []Updater
+	etcdInfo  DependencyInfo
+}
+
+func (b EtcdUpdater) Updaters() []Updater {
+	return b.updaters
+}
+
+func (b EtcdUpdater) UpdateAll() error {
+	for _, u := range b.Updaters() {
+		err := u.Update()
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (b EtcdUpdater) Info() DependencyInfo {
+	return b.etcdInfo
+}
+
+func etcdConsumerInfo() DependencyInfo {
+	return DependencyInfo{
+		Name: etcdName,
+	}
+}
+
+func etcdUpdaters(releases []*eksDistroRelease.Release) []Updater {
+	var updaters []Updater
+	updaters = append(updaters, etcdGithubUpdaters(releases)...)
+	return updaters
+}
+
+func etcdGithubUpdaters(releases []*eksDistroRelease.Release) []Updater {
+	var updaters []Updater
+	for _, r := range releases {
+		updaters = append(updaters, &etcdGithubUpdater {
+			eksDistroRelease: r,
+		})
+	}
+	return updaters
+}
+
+type etcdGithubUpdater struct {
+	eksDistroRelease *eksDistroRelease.Release
+}
+
+func (g *etcdGithubUpdater) Update() error {
+	//implement updater here
+	fmt.Printf("Etcd dependency update stub invoked for EKS D release \n Major: %d\n Minor: %d\n Patch: %d\n Release: %d\n",
+		g.eksDistroRelease.KubernetesMajorVersion(),
+		g.eksDistroRelease.KubernetesMinorVersion(),
+		g.eksDistroRelease.KubernetesPatchVersion(),
+		g.eksDistroRelease.ReleaseNumber())
+	return nil
+}

--- a/tools/eksDistroBuildToolingOpsTools/pkg/dependencyUpdater/factory.go
+++ b/tools/eksDistroBuildToolingOpsTools/pkg/dependencyUpdater/factory.go
@@ -1,0 +1,20 @@
+package dependencyUpdater
+
+import "github.com/aws/eks-distro-build-tooling/tools/eksDistroBuildToolingOpsTools/pkg/eksDistroRelease"
+
+func NewFactory(releases []*eksDistroRelease.Release) *Factory {
+	var dependencies []Dependency
+	dependencies = append(dependencies, NewEtcdDependencyUpdater(releases))
+
+	return &Factory{
+		dependencyUpdaters: dependencies,
+	}
+}
+
+type Factory struct {
+	dependencyUpdaters []Dependency
+}
+
+func (f Factory) DependencyUpdaters() []Dependency {
+	return f.dependencyUpdaters
+}

--- a/tools/eksDistroBuildToolingOpsTools/pkg/dependencyUpdater/types.go
+++ b/tools/eksDistroBuildToolingOpsTools/pkg/dependencyUpdater/types.go
@@ -1,0 +1,15 @@
+package dependencyUpdater
+
+type Dependency interface {
+	Info() DependencyInfo
+	UpdateAll() error
+	Updaters() []Updater
+}
+
+type Updater interface {
+	Update() error
+}
+
+type DependencyInfo struct {
+	Name string
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Adds a `dependencyUpdater` interface and example for implementing 'downstream automation', and providing a potential home for automation around tracking project updates

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
