### PR TITLE
Patch EKS Go 1.17 for CVE-2022-27664

### DIFF
--- a/projects/golang/go/1.17/patches/0006-go-1.17.13-eks-net-http-update-bundled-golang.patch
+++ b/projects/golang/go/1.17/patches/0006-go-1.17.13-eks-net-http-update-bundled-golang.patch
@@ -11,6 +11,7 @@ Backported By: rcrozean@amazon.com
 Backported From: release-branch.go1.18
 Source Commit: https://github.com/golang/go/commit/76cad4edc29d28432a7a0aa27e87385d3d7db7a1
 
+# Original Information
 Disable cmd/internal/moddeps test, since this update includes PRIVATE
 track fixes.
 

--- a/projects/golang/go/1.17/patches/0007-go-1.17.13-eks-replace-all-usages-of-BytesOrPanic.patch
+++ b/projects/golang/go/1.17/patches/0007-go-1.17.13-eks-replace-all-usages-of-BytesOrPanic.patch
@@ -1,3 +1,8 @@
+From 6420add8bb33df4ad09ae46c7601f0c5ebd8fc2f Mon Sep 17 00:00:00 2001
+From: Roland Shoemaker <roland@golang.org>
+Date: Wed, 14 Dec 2022 09:43:16 -0800
+Subject: [PATCH] [go-1.17.13-eks]
+
 # AWS EKS
 Backported To: go-1.17.13-eks
 Backported On: Fri, 17 Feb 2023
@@ -5,16 +10,8 @@ Backported By: szafreen@amazon.com
 Backported From: release-branch.go1.19
 Source Commit: https://github.com/golang/go/commit/00b256e9e3c0fa02a278ec9dfc3e191e02ceaf80
 
-
-From 6420add8bb33df4ad09ae46c7601f0c5ebd8fc2f Mon Sep 17 00:00:00 2001
-From: Roland Shoemaker <roland@golang.org>
-Date: Wed, 14 Dec 2022 09:43:16 -0800
-Subject: [PATCH] go1.17-cherry-pick-from-00b256e
-
-
-During merge conflict in src/crypto/tls/conn.go line 1025 function readHandshake was set to return an `interface{}`, not accepting `any`
+During conflict resolution in src/crypto/tls/conn.go line 1025 function readHandshake was set to return an `interface{}`, not accepting `any`
 to be consistent with the rest of the file.
-
 
 # Original Information
 

--- a/projects/golang/go/1.17/patches/0008-go-1.17.13-eks-multipart-limit-memory-inode-consumption.patch
+++ b/projects/golang/go/1.17/patches/0008-go-1.17.13-eks-multipart-limit-memory-inode-consumption.patch
@@ -1,3 +1,8 @@
+From f7ec47273cb633c955e83443ca557a07dec6ff7d Mon Sep 17 00:00:00 2001
+From: Damien Neil <dneil@google.com>
+Date: Wed, 25 Jan 2023 09:27:01 -0800
+Subject: [PATCH] [go-1.17.13-eks]
+
 # AWS EKS
 Backported To: go-1.17.13-eks
 Backported On: Fri, 17 Feb 2023
@@ -5,19 +10,12 @@ Backported By: szafreen@amazon.com
 Backported From: release-branch.go1.19
 Source Commit: https://github.com/golang/go/commit/5c55ac9bf1e5f779220294c843526536605f42ab
 
-From f7ec47273cb633c955e83443ca557a07dec6ff7d Mon Sep 17 00:00:00 2001
-From: Damien Neil <dneil@google.com>
-Date: Wed, 25 Jan 2023 09:27:01 -0800
-Subject: [PATCH] cherry-pick-5c55ac9
-
 In this patch, go1.19.6 introduces GODEBUG=multipartfiles=distinct option for users, but in this patch we put multipartfiles=distinct as default option. 
 For this reason, the test for `multipartfiles!=distinct` has commented out.
 Also, during the `src/mime/multipart/multipart.go` line 152 function populateHeaders(), all instances has changed to `bp` to be compatible with other functions of the file.
 In `src/net/textproto/reader.go` the merge conflict was resolved by not accepting the new changes for skipping initial spaces in value. 
 
-
 # Original Information
-
 Reader.ReadForm is documented as storing "up to maxMemory bytes + 10MB"
 in memory. Parsed forms can consume substantially more memory than
 this limit, since ReadForm does not account for map entry overhead

--- a/projects/golang/go/1.17/patches/0009-go-1.17.13-eks-path-filepath-do-not-clean-relative-path.patch
+++ b/projects/golang/go/1.17/patches/0009-go-1.17.13-eks-path-filepath-do-not-clean-relative-path.patch
@@ -1,3 +1,9 @@
+From d066343b27e05f91adfbc394fa3b5de2a00e21cf Mon Sep 17 00:00:00 2001
+From: Damien Neil <dneil@google.com>
+Date: Mon, 12 Dec 2022 16:43:37 -0800
+Subject: [PATCH] [go-1.17.13-eks] path/filepath: do not
+ Clean("a/../c:/b") into c:\b on Windows
+
 # AWS EKS
 Backported To: go-1.17.13-eks
 Backported On: Fri, 17 Feb 2023
@@ -5,12 +11,7 @@ Backported By: szafreen@amazon.com
 Backported From: release-branch.go1.19
 Source Commit: https://github.com/golang/go/commit/3345ddca41f00f9ed6fc3c1a36f6e2bede02d7ff
 
-From d066343b27e05f91adfbc394fa3b5de2a00e21cf Mon Sep 17 00:00:00 2001
-From: Damien Neil <dneil@google.com>
-Date: Mon, 12 Dec 2022 16:43:37 -0800
-Subject: [PATCH] [release-branch.go1.19] path/filepath: do not
- Clean("a/../c:/b") into c:\b on Windows
-
+# Original Information
 Do not permit Clean to convert a relative path into one starting
 with a drive reference. This change causes Clean to insert a .
 path element at the start of a path when the original path does not

--- a/projects/golang/go/1.17/patches/0010-go-1.17.13-eks-update-bundled-golang-org.patch
+++ b/projects/golang/go/1.17/patches/0010-go-1.17.13-eks-update-bundled-golang-org.patch
@@ -1,3 +1,8 @@
+From 0e8915b65039ce42d672ad74f790c322e8671b5f Mon Sep 17 00:00:00 2001
+From: Roland Shoemaker <bracewell@google.com>
+Date: Mon, 6 Feb 2023 10:03:44 -0800
+Subject: [PATCH] [go-1.17.13-eks]
+
 # AWS EKS
 Backported To: go-1.17.13-eks
 Backported On: Fri, 17 Feb 2023
@@ -5,13 +10,7 @@ Backported By: szafreen@amazon.com
 Backported From: release-branch.go1.19
 Source Commit: https://github.com/golang/go/commit/5c3e11bd0b5c0a86e5beffcd4339b86a902b21c3
 
-From 0e8915b65039ce42d672ad74f790c322e8671b5f Mon Sep 17 00:00:00 2001
-From: Roland Shoemaker <bracewell@google.com>
-Date: Mon, 6 Feb 2023 10:03:44 -0800
-Subject: [PATCH] cherry-pick-from-5c3e11b
-
 # Original Information
-
 Disable cmd/internal/moddeps test, since this update includes PRIVATE
 track fixes.
 

--- a/projects/golang/go/1.17/patches/0011-go-1.17.13-eks-net-http-update-bundled-golang.patch
+++ b/projects/golang/go/1.17/patches/0011-go-1.17.13-eks-net-http-update-bundled-golang.patch
@@ -1,0 +1,63 @@
+From 5bc9106458fc07851ac324a4157132a91b1f3479 Mon Sep 17 00:00:00 2001
+From: Damien Neil <dneil@google.com>
+Date: Mon, 22 Aug 2022 16:21:02 -0700
+Subject: [PATCH] [go-1.17.13-eks] net/http: update bundled
+ golang.org/x/net/http2
+
+# AWS EKS
+Backported To: go-1.17.13-eks
+Backported On: Tuesday, 28 Feb 2023
+Backported By: budris@amazon.com
+Backported From: release-branch.go1.18
+Source Commit: https://github.com/golang/go/commit/5bc9106458fc07851ac324a4157132a91b1f3479
+
+# Original Information
+Disable cmd/internal/moddeps test, since this update includes PRIVATE
+track fixes.
+
+Fixes CVE-2022-27664
+Fixes #53977
+For #54658.
+
+Change-Id: I84b0b8f61e49e15ef55ef8d738730107a3cf849b
+Reviewed-on: https://team-review.git.corp.google.com/c/golang/go-private/+/1554415
+Reviewed-by: Roland Shoemaker <bracewell@google.com>
+Reviewed-by: Tatiana Bradley <tatianabradley@google.com>
+Reviewed-on: https://go-review.googlesource.com/c/go/+/428635
+Reviewed-by: Tatiana Bradley <tatiana@golang.org>
+Run-TryBot: Michael Knyszek <mknyszek@google.com>
+TryBot-Result: Gopher Robot <gobot@golang.org>
+Reviewed-by: Carlos Amedee <carlos@golang.org>
+---
+ src/net/http/h2_bundle.go | 8 ++++++--
+ 1 file changed, 6 insertions(+), 2 deletions(-)
+
+diff --git a/src/net/http/h2_bundle.go b/src/net/http/h2_bundle.go
+index c693574492..9d6abd833b 100644
+--- a/src/net/http/h2_bundle.go
++++ b/src/net/http/h2_bundle.go
+@@ -5004,6 +5004,9 @@ func (sc *http2serverConn) startGracefulShutdownInternal() {
+ func (sc *http2serverConn) goAway(code http2ErrCode) {
+ 	sc.serveG.check()
+ 	if sc.inGoAway {
++		if sc.goAwayCode == http2ErrCodeNo {
++			sc.goAwayCode = code
++		}
+ 		return
+ 	}
+ 	sc.inGoAway = true
+@@ -6216,8 +6219,9 @@ func (rws *http2responseWriterState) writeChunk(p []byte) (n int, err error) {
+ // prior to the headers being written. If the set of trailers is fixed
+ // or known before the header is written, the normal Go trailers mechanism
+ // is preferred:
+-//    https://golang.org/pkg/net/http/#ResponseWriter
+-//    https://golang.org/pkg/net/http/#example_ResponseWriter_trailers
++//
++//	https://golang.org/pkg/net/http/#ResponseWriter
++//	https://golang.org/pkg/net/http/#example_ResponseWriter_trailers
+ const http2TrailerPrefix = "Trailer:"
+ 
+ // promoteUndeclaredTrailers permits http.Handlers to set trailers
+-- 
+2.30.1 (Apple Git-130)
+

--- a/projects/golang/go/1.17/rpmbuild/SPECS/golang.spec
+++ b/projects/golang/go/1.17/rpmbuild/SPECS/golang.spec
@@ -543,6 +543,10 @@ fi
 %endif
 
 %changelog
+* Tue Feb 28 2023 Dan Budris <budris@amazon.com> - 1.17.13-3
+- Include backported patch for CVE-2022-27664
+- Fixes: CVE-2022-27664
+
 * Fri Feb 17 2023 Sajia Zafreen <szafreen@amazon.com> - 1.17.13-3
 - Includes security fix for CVE-2022-41722
 - Includes security fix for CVE-2022-41723

--- a/projects/golang/go/1.17/rpmbuild/SPECS/golang.spec
+++ b/projects/golang/go/1.17/rpmbuild/SPECS/golang.spec
@@ -163,6 +163,7 @@ Patch7:   0007-go-1.17.13-eks-replace-all-usages-of-BytesOrPanic.patch
 Patch8:   0008-go-1.17.13-eks-multipart-limit-memory-inode-consumption.patch
 Patch9:   0009-go-1.17.13-eks-path-filepath-do-not-clean-relative-path.patch
 Patch10:  0010-go-1.17.13-eks-update-bundled-golang-org.patch
+Patch11:  0011-go-1.17.13-eks-net-http-update-bundled-golang.patch
 
 Patch101:       0101-syscall-expose-IfInfomsg.X__ifi_pad-on-s390x.patch
 Patch102:       0102-cmd-go-disable-Google-s-proxy-and-sumdb.patch


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/eks-distro-build-tooling/issues/880

*Description of changes:*
Add patch for CVE-2022-27664 to Golang 1.17; clean up other patch formatting

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
