### PR TITLE
Copy ARM64 checksum file for Goss

### DIFF
--- a/builder-base/Dockerfile
+++ b/builder-base/Dockerfile
@@ -163,7 +163,7 @@ WORKDIR /workdir
 ARG GOSS_VERSION
 ENV GOSS_VERSION=$GOSS_VERSION
 COPY ./scripts/install_base_yum_packages.sh ./scripts/remove_yum_packages.sh ./scripts/common_vars.sh \
-    ./scripts/install_goss.sh ./checksums/goss-amd64-checksum /
+    ./scripts/install_goss.sh ./checksums/goss-${TARGETARCH}-checksum /
 RUN --mount=type=cache,target=/var/cache/yum,sharing=locked \
     /install_base_yum_packages.sh && \
     /install_goss.sh && \


### PR DESCRIPTION
Copying ARM64 checksum file for Goss into the builder-base container.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
