### PR TITLE
Remove IS_AL22 in install_bash

### DIFF
--- a/builder-base/scripts/install_bash.sh
+++ b/builder-base/scripts/install_bash.sh
@@ -34,7 +34,7 @@ source $SCRIPT_ROOT/common_vars.sh
 BASH_DOWNLOAD_URL="http://ftp.gnu.org/gnu/bash/bash-$OVERRIDE_BASH_VERSION.tar.gz"
 
 function install_bash() {
-    # al22 already ships with 5.1
+    # al23 already ships with 5.1
     if [ "$IS_AL23" != "false" ]; then
         return
     fi

--- a/builder-base/scripts/install_bash.sh
+++ b/builder-base/scripts/install_bash.sh
@@ -35,7 +35,7 @@ BASH_DOWNLOAD_URL="http://ftp.gnu.org/gnu/bash/bash-$OVERRIDE_BASH_VERSION.tar.g
 
 function install_bash() {
     # al22 already ships with 5.1
-    if [ "$IS_AL22" != "false" ]; then
+    if [ "$IS_AL23" != "false" ]; then
         return
     fi
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Remnant of the AL22 change to AL23 that needed to be updated. Following https://github.com/aws/eks-distro-build-tooling/pull/913 changes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
