### PR TITLE
Backport Go 1.19.8 CVE fixes to 1.18

### DIFF
--- a/projects/golang/go/1.18/patches/0005-go-1.18.10-eks-go-scanner-reject-large-line-a.patch
+++ b/projects/golang/go/1.18/patches/0005-go-1.18.10-eks-go-scanner-reject-large-line-a.patch
@@ -1,0 +1,99 @@
+From c712eabd0d441634460284154016d1f90d2b9c63 Mon Sep 17 00:00:00 2001
+From: Damien Neil <dneil@google.com>
+Date: Wed, 22 Mar 2023 09:33:22 -0700
+Subject: [PATCH] [release-branch.go1.19] go/scanner: reject large line and
+ column numbers in //line directives
+
+# AWS EKS
+Backported To: go-1.18.10-eks
+Backported On: Wed, 5 Apr 2023
+Backported By: kodurub@amazon.com
+Backported From: release-branch.go1.19
+Source Commit: https://github.com/golang/go/commit/126a1d02da82f93ede7ce0bd8d3c51ef627f2104
+
+# Original Information
+Setting a large line or column number using a //line directive can cause
+integer overflow even in small source files.
+
+Limit line and column numbers in //line directives to 2^30-1, which
+is small enough to avoid int32 overflow on all reasonbly-sized files.
+
+Fixes CVE-2023-24537
+Fixes #59273
+For #59180
+
+Reviewed-on: https://team-review.git.corp.google.com/c/golang/go-private/+/1802456
+Reviewed-by: Julie Qiu <julieqiu@google.com>
+Reviewed-by: Roland Shoemaker <bracewell@google.com>
+Run-TryBot: Damien Neil <dneil@google.com>
+Reviewed-on: https://team-review.git.corp.google.com/c/golang/go-private/+/1802611
+Reviewed-by: Damien Neil <dneil@google.com>
+Change-Id: Ifdfa192d54f722d781a4d8c5f35b5fb72d122168
+Reviewed-on: https://go-review.googlesource.com/c/go/+/481986
+Reviewed-by: Matthew Dempsky <mdempsky@google.com>
+TryBot-Result: Gopher Robot <gobot@golang.org>
+Run-TryBot: Michael Knyszek <mknyszek@google.com>
+Auto-Submit: Michael Knyszek <mknyszek@google.com>
+---
+ src/go/parser/parser_test.go | 16 ++++++++++++++++
+ src/go/scanner/scanner.go    |  7 +++++--
+ 2 files changed, 21 insertions(+), 2 deletions(-)
+
+diff --git a/src/go/parser/parser_test.go b/src/go/parser/parser_test.go
+index 1a46c87866..993df6315f 100644
+--- a/src/go/parser/parser_test.go
++++ b/src/go/parser/parser_test.go
+@@ -746,3 +746,19 @@ func TestScopeDepthLimit(t *testing.T) {
+ 		}
+ 	}
+ }
++
++// TestIssue59180 tests that line number overflow doesn't cause an infinite loop.
++func TestIssue59180(t *testing.T) {
++	testcases := []string{
++		"package p\n//line :9223372036854775806\n\n//",
++		"package p\n//line :1:9223372036854775806\n\n//",
++		"package p\n//line file:9223372036854775806\n\n//",
++	}
++
++	for _, src := range testcases {
++		_, err := ParseFile(token.NewFileSet(), "", src, ParseComments)
++		if err == nil {
++			t.Errorf("ParseFile(%s) succeeded unexpectedly", src)
++		}
++	}
++}
+diff --git a/src/go/scanner/scanner.go b/src/go/scanner/scanner.go
+index 23d8db9d1c..02bd3240bb 100644
+--- a/src/go/scanner/scanner.go
++++ b/src/go/scanner/scanner.go
+@@ -251,13 +251,16 @@ func (s *Scanner) updateLineInfo(next, offs int, text []byte) {
+ 		return
+ 	}
+ 
++	// Put a cap on the maximum size of line and column numbers.
++	// 30 bits allows for some additional space before wrapping an int32.
++	const maxLineCol = 1<<30 - 1
+ 	var line, col int
+ 	i2, n2, ok2 := trailingDigits(text[:i-1])
+ 	if ok2 {
+ 		//line filename:line:col
+ 		i, i2 = i2, i
+ 		line, col = n2, n
+-		if col == 0 {
++		if col == 0 || col > maxLineCol {
+ 			s.error(offs+i2, "invalid column number: "+string(text[i2:]))
+ 			return
+ 		}
+@@ -267,7 +270,7 @@ func (s *Scanner) updateLineInfo(next, offs int, text []byte) {
+ 		line = n
+ 	}
+ 
+-	if line == 0 {
++	if line == 0 || line > maxLineCol {
+ 		s.error(offs+i, "invalid line number: "+string(text[i:]))
+ 		return
+ 	}
+-- 
+2.39.1
+

--- a/projects/golang/go/1.18/patches/0006-go-1.18.10-eks-go-net-textproto-avoid-overpredic.patch
+++ b/projects/golang/go/1.18/patches/0006-go-1.18.10-eks-go-net-textproto-avoid-overpredic.patch
@@ -1,0 +1,195 @@
+From 3bab58728be435a9285c6247151a66088c293f26 Mon Sep 17 00:00:00 2001
+From: Damien Neil <dneil@google.com>
+Date: Fri, 10 Mar 2023 14:21:05 -0800
+Subject: [PATCH] [release-branch.go1.19] net/textproto: avoid overpredicting
+ the number of MIME header keys
+
+# AWS EKS
+Backported To: go-1.18.10-eks
+Backported On: Wed, 5 Apr 2023
+Backported By: kodurub@amazon.com
+Backported From: release-branch.go1.19
+Source Commit: https://github.com/golang/go/commit/d6759e7a059f4208f07aa781402841d7ddaaef96
+
+A parsed MIME header is a map[string][]string. In the common case,
+a header contains many one-element []string slices. To avoid
+allocating a separate slice for each key, ReadMIMEHeader looks
+ahead in the input to predict the number of keys that will be
+parsed, and allocates a single []string of that length.
+The individual slices are then allocated out of the larger one.
+
+The prediction of the number of header keys was done by counting
+newlines in the input buffer, which does not take into account
+header continuation lines (where a header key/value spans multiple
+lines) or the end of the header block and the start of the body.
+This could lead to a substantial amount of overallocation, for
+example when the body consists of nothing but a large block of
+newlines.
+
+Fix header key count prediction to take into account the end of
+the headers (indicated by a blank line) and continuation lines
+(starting with whitespace).
+
+Thanks to Jakob Ackermann (@das7pad) for reporting this issue.
+
+Fixes CVE-2023-24534
+For #58975
+Fixes #59267
+
+Reviewed-on: https://team-review.git.corp.google.com/c/golang/go-private/+/1802452
+Run-TryBot: Damien Neil <dneil@google.com>
+Reviewed-by: Roland Shoemaker <bracewell@google.com>
+Reviewed-by: Julie Qiu <julieqiu@google.com>
+(cherry picked from commit f739f080a72fd5b06d35c8e244165159645e2ed6)
+Reviewed-on: https://team-review.git.corp.google.com/c/golang/go-private/+/1802393
+Reviewed-by: Damien Neil <dneil@google.com>
+Run-TryBot: Roland Shoemaker <bracewell@google.com>
+Change-Id: I675451438d619a9130360c56daf529559004903f
+Reviewed-on: https://go-review.googlesource.com/c/go/+/481982
+Run-TryBot: Michael Knyszek <mknyszek@google.com>
+TryBot-Result: Gopher Robot <gobot@golang.org>
+Reviewed-by: Matthew Dempsky <mdempsky@google.com>
+Auto-Submit: Michael Knyszek <mknyszek@google.com>
+---
+ src/net/textproto/reader.go      | 24 ++++++++++---
+ src/net/textproto/reader_test.go | 59 ++++++++++++++++++++++++++++++++
+ 2 files changed, 79 insertions(+), 4 deletions(-)
+
+diff --git a/src/net/textproto/reader.go b/src/net/textproto/reader.go
+index 497c0c5d83..8956dc4ac9 100644
+--- a/src/net/textproto/reader.go
++++ b/src/net/textproto/reader.go
+@@ -495,8 +495,11 @@ func readMIMEHeader(r *Reader, lim int64) (MIMEHeader, error) {
+ 	// large one ahead of time which we'll cut up into smaller
+ 	// slices. If this isn't big enough later, we allocate small ones.
+ 	var strs []string
+-	hint := r.upcomingHeaderNewlines()
++	hint := r.upcomingHeaderKeys()
+ 	if hint > 0 {
++		if hint > 1000 {
++			hint = 1000 // set a cap to avoid overallocation
++		}
+ 		strs = make([]string, hint)
+ 	}
+ 
+@@ -579,9 +582,9 @@ func mustHaveFieldNameColon(line []byte) error {
+ 
+ var nl = []byte("\n")
+ 
+-// upcomingHeaderNewlines returns an approximation of the number of newlines
++// upcomingHeaderKeys returns an approximation of the number of keys
+ // that will be in this header. If it gets confused, it returns 0.
+-func (r *Reader) upcomingHeaderNewlines() (n int) {
++func (r *Reader) upcomingHeaderKeys() (n int) {
+ 	// Try to determine the 'hint' size.
+ 	r.R.Peek(1) // force a buffer load if empty
+ 	s := r.R.Buffered()
+@@ -589,7 +592,20 @@ func (r *Reader) upcomingHeaderNewlines() (n int) {
+ 		return
+ 	}
+ 	peek, _ := r.R.Peek(s)
+-	return bytes.Count(peek, nl)
++	for len(peek) > 0 && n < 1000 {
++		var line []byte
++		line, peek, _ = bytes.Cut(peek, nl)
++		if len(line) == 0 || (len(line) == 1 && line[0] == '\r') {
++			// Blank line separating headers from the body.
++			break
++		}
++		if line[0] == ' ' || line[0] == '\t' {
++			// Folded continuation of the previous line.
++			continue
++		}
++		n++
++	}
++	return n
+ }
+ 
+ // CanonicalMIMEHeaderKey returns the canonical format of the
+diff --git a/src/net/textproto/reader_test.go b/src/net/textproto/reader_test.go
+index 3124d438fa..3ae0de1353 100644
+--- a/src/net/textproto/reader_test.go
++++ b/src/net/textproto/reader_test.go
+@@ -9,6 +9,7 @@ import (
+ 	"bytes"
+ 	"io"
+ 	"reflect"
++	"runtime"
+ 	"strings"
+ 	"testing"
+ )
+@@ -127,6 +128,42 @@ func TestReadMIMEHeaderSingle(t *testing.T) {
+ 	}
+ }
+ 
++// TestReaderUpcomingHeaderKeys is testing an internal function, but it's very
++// difficult to test well via the external API.
++func TestReaderUpcomingHeaderKeys(t *testing.T) {
++	for _, test := range []struct {
++		input string
++		want  int
++	}{{
++		input: "",
++		want:  0,
++	}, {
++		input: "A: v",
++		want:  1,
++	}, {
++		input: "A: v\r\nB: v\r\n",
++		want:  2,
++	}, {
++		input: "A: v\nB: v\n",
++		want:  2,
++	}, {
++		input: "A: v\r\n  continued\r\n  still continued\r\nB: v\r\n\r\n",
++		want:  2,
++	}, {
++		input: "A: v\r\n\r\nB: v\r\nC: v\r\n",
++		want:  1,
++	}, {
++		input: "A: v" + strings.Repeat("\n", 1000),
++		want:  1,
++	}} {
++		r := reader(test.input)
++		got := r.upcomingHeaderKeys()
++		if test.want != got {
++			t.Fatalf("upcomingHeaderKeys(%q): %v; want %v", test.input, got, test.want)
++		}
++	}
++}
++
+ func TestReadMIMEHeaderNoKey(t *testing.T) {
+ 	r := reader(": bar\ntest-1: 1\n\n")
+ 	m, err := r.ReadMIMEHeader()
+@@ -223,6 +260,28 @@ func TestReadMIMEHeaderTrimContinued(t *testing.T) {
+ 	}
+ }
+ 
++// Test that reading a header doesn't overallocate. Issue 58975.
++func TestReadMIMEHeaderAllocations(t *testing.T) {
++	var totalAlloc uint64
++	const count = 200
++	for i := 0; i < count; i++ {
++		r := reader("A: b\r\n\r\n" + strings.Repeat("\n", 4096))
++		var m1, m2 runtime.MemStats
++		runtime.ReadMemStats(&m1)
++		_, err := r.ReadMIMEHeader()
++		if err != nil {
++			t.Fatalf("ReadMIMEHeader: %v", err)
++		}
++		runtime.ReadMemStats(&m2)
++		totalAlloc += m2.TotalAlloc - m1.TotalAlloc
++	}
++	// 32k is large and we actually allocate substantially less,
++	// but prior to the fix for #58975 we allocated ~400k in this case.
++	if got, want := totalAlloc/count, uint64(32768); got > want {
++		t.Fatalf("ReadMIMEHeader allocated %v bytes, want < %v", got, want)
++	}
++}
++
+ type readResponseTest struct {
+ 	in       string
+ 	inCode   int
+-- 
+2.39.1
+

--- a/projects/golang/go/1.18/patches/0007-go-1.18.10-eks-mime-multipart-avoid-excessive.patch
+++ b/projects/golang/go/1.18/patches/0007-go-1.18.10-eks-mime-multipart-avoid-excessive.patch
@@ -1,0 +1,140 @@
+From edb04ddd2332b55a76b78cd1c0f723863000d805 Mon Sep 17 00:00:00 2001
+From: Damien Neil <dneil@google.com>
+Date: Thu, 16 Mar 2023 14:18:04 -0700
+Subject: [PATCH] [release-branch.go1.19] mime/multipart: avoid excessive copy
+ buffer allocations in ReadForm
+
+# AWS EKS
+Backported To: go-1.18.10-eks
+Backported On: Wed, 5 Apr 2023
+Backported By: kodurub@amazon.com
+Backported From: release-branch.go1.19
+Source Commit: https://github.com/golang/go/commit/ef41a4e2face45e580c5836eaebd51629fc23f15
+
+When copying form data to disk with io.Copy,
+allocate only one copy buffer and reuse it rather than
+creating two buffers per file (one from io.multiReader.WriteTo,
+and a second one from os.File.ReadFrom).
+
+Thanks to Jakob Ackermann (@das7pad) for reporting this issue.
+
+For CVE-2023-24536
+For #59153
+For #59269
+
+Reviewed-on: https://team-review.git.corp.google.com/c/golang/go-private/+/1802453
+Run-TryBot: Damien Neil <dneil@google.com>
+Reviewed-by: Julie Qiu <julieqiu@google.com>
+Reviewed-by: Roland Shoemaker <bracewell@google.com>
+Reviewed-on: https://team-review.git.corp.google.com/c/golang/go-private/+/1802395
+Run-TryBot: Roland Shoemaker <bracewell@google.com>
+Reviewed-by: Damien Neil <dneil@google.com>
+Change-Id: Ie405470c92abffed3356913b37d813e982c96c8b
+Reviewed-on: https://go-review.googlesource.com/c/go/+/481983
+Run-TryBot: Michael Knyszek <mknyszek@google.com>
+TryBot-Result: Gopher Robot <gobot@golang.org>
+Auto-Submit: Michael Knyszek <mknyszek@google.com>
+Reviewed-by: Matthew Dempsky <mdempsky@google.com>
+---
+ src/mime/multipart/formdata.go      | 15 +++++++--
+ src/mime/multipart/formdata_test.go | 49 +++++++++++++++++++++++++++++
+ 2 files changed, 61 insertions(+), 3 deletions(-)
+
+diff --git a/src/mime/multipart/formdata.go b/src/mime/multipart/formdata.go
+index a7d4ca97f0..975dcb6b26 100644
+--- a/src/mime/multipart/formdata.go
++++ b/src/mime/multipart/formdata.go
+@@ -84,6 +84,7 @@ func (r *Reader) readForm(maxMemory int64) (_ *Form, err error) {
+ 			maxMemoryBytes = math.MaxInt64
+ 		}
+ 	}
++	var copyBuf []byte
+ 	for {
+ 		p, err := r.nextPart(false, maxMemoryBytes)
+ 		if err == io.EOF {
+@@ -147,14 +148,22 @@ func (r *Reader) readForm(maxMemory int64) (_ *Form, err error) {
+ 				}
+ 			}
+ 			numDiskFiles++
+-			size, err := io.Copy(file, io.MultiReader(&b, p))
++			if _, err := file.Write(b.Bytes()); err != nil {
++				return nil, err
++			}
++			if copyBuf == nil {
++				copyBuf = make([]byte, 32*1024) // same buffer size as io.Copy uses
++			}
++			// os.File.ReadFrom will allocate its own copy buffer if we let io.Copy use it.
++			type writerOnly struct{ io.Writer }
++			remainingSize, err := io.CopyBuffer(writerOnly{file}, p, copyBuf)
+ 			if err != nil {
+ 				return nil, err
+ 			}
+ 			fh.tmpfile = file.Name()
+-			fh.Size = size
++			fh.Size = int64(b.Len()) + remainingSize
+ 			fh.tmpoff = fileOff
+-			fileOff += size
++			fileOff += fh.Size
+ 			if !combineFiles {
+ 				if err := file.Close(); err != nil {
+ 					return nil, err
+diff --git a/src/mime/multipart/formdata_test.go b/src/mime/multipart/formdata_test.go
+index 5cded7170c..f5b56083b2 100644
+--- a/src/mime/multipart/formdata_test.go
++++ b/src/mime/multipart/formdata_test.go
+@@ -368,3 +368,52 @@ func testReadFormManyFiles(t *testing.T, distinct bool) {
+ 		t.Fatalf("temp dir contains %v files; want 0", len(names))
+ 	}
+ }
++
++func BenchmarkReadForm(b *testing.B) {
++	for _, test := range []struct {
++		name string
++		form func(fw *Writer, count int)
++	}{{
++		name: "fields",
++		form: func(fw *Writer, count int) {
++			for i := 0; i < count; i++ {
++				w, _ := fw.CreateFormField(fmt.Sprintf("field%v", i))
++				fmt.Fprintf(w, "value %v", i)
++			}
++		},
++	}, {
++		name: "files",
++		form: func(fw *Writer, count int) {
++			for i := 0; i < count; i++ {
++				w, _ := fw.CreateFormFile(fmt.Sprintf("field%v", i), fmt.Sprintf("file%v", i))
++				fmt.Fprintf(w, "value %v", i)
++			}
++		},
++	}} {
++		b.Run(test.name, func(b *testing.B) {
++			for _, maxMemory := range []int64{
++				0,
++				1 << 20,
++			} {
++				var buf bytes.Buffer
++				fw := NewWriter(&buf)
++				test.form(fw, 10)
++				if err := fw.Close(); err != nil {
++					b.Fatal(err)
++				}
++				b.Run(fmt.Sprintf("maxMemory=%v", maxMemory), func(b *testing.B) {
++					b.ReportAllocs()
++					for i := 0; i < b.N; i++ {
++						fr := NewReader(bytes.NewReader(buf.Bytes()), fw.Boundary())
++						form, err := fr.ReadForm(maxMemory)
++						if err != nil {
++							b.Fatal(err)
++						}
++						form.RemoveAll()
++					}
++
++				})
++			}
++		})
++	}
++}
+-- 
+2.39.1
+

--- a/projects/golang/go/1.18/patches/0008-go-1.18.10-eks-net-textproto-mime-multipart-i.patch
+++ b/projects/golang/go/1.18/patches/0008-go-1.18.10-eks-net-textproto-mime-multipart-i.patch
@@ -1,0 +1,190 @@
+From 03723d66e753c89c132e6a1dc87e45f7d6525a41 Mon Sep 17 00:00:00 2001
+From: Damien Neil <dneil@google.com>
+Date: Thu, 16 Mar 2023 16:56:12 -0700
+Subject: [PATCH] [release-branch.go1.19] net/textproto, mime/multipart:
+ improve accounting of non-file data
+
+# AWS EKS
+Backported To: go-1.18.10-eks
+Backported On: Wed, 5 Apr 2023
+Backported By: kodurub@amazon.com
+Backported From: release-branch.go1.19
+Source Commit: https://github.com/golang/go/commit/7a359a651c7ebdb29e0a1c03102fce793e9f58f0
+
+For requests containing large numbers of small parts,
+memory consumption of a parsed form could be about 250%
+over the estimated size.
+
+When considering the size of parsed forms, account for the size of
+FileHeader structs and increase the estimate of memory consumed by
+map entries.
+
+Thanks to Jakob Ackermann (@das7pad) for reporting this issue.
+
+For CVE-2023-24536
+For #59153
+For #59269
+
+Reviewed-on: https://team-review.git.corp.google.com/c/golang/go-private/+/1802454
+Run-TryBot: Damien Neil <dneil@google.com>
+Reviewed-by: Roland Shoemaker <bracewell@google.com>
+Reviewed-by: Julie Qiu <julieqiu@google.com>
+Reviewed-on: https://team-review.git.corp.google.com/c/golang/go-private/+/1802396
+Run-TryBot: Roland Shoemaker <bracewell@google.com>
+Reviewed-by: Damien Neil <dneil@google.com>
+Change-Id: I31bc50e9346b4eee6fbe51a18c3c57230cc066db
+Reviewed-on: https://go-review.googlesource.com/c/go/+/481984
+Reviewed-by: Matthew Dempsky <mdempsky@google.com>
+Auto-Submit: Michael Knyszek <mknyszek@google.com>
+TryBot-Result: Gopher Robot <gobot@golang.org>
+Run-TryBot: Michael Knyszek <mknyszek@google.com>
+---
+ src/mime/multipart/formdata.go      |  9 +++--
+ src/mime/multipart/formdata_test.go | 55 ++++++++++++-----------------
+ src/net/textproto/reader.go         |  8 ++++-
+ 3 files changed, 37 insertions(+), 35 deletions(-)
+
+diff --git a/src/mime/multipart/formdata.go b/src/mime/multipart/formdata.go
+index 975dcb6b26..3f6ff697ca 100644
+--- a/src/mime/multipart/formdata.go
++++ b/src/mime/multipart/formdata.go
+@@ -103,8 +103,9 @@ func (r *Reader) readForm(maxMemory int64) (_ *Form, err error) {
+ 		// Multiple values for the same key (one map entry, longer slice) are cheaper
+ 		// than the same number of values for different keys (many map entries), but
+ 		// using a consistent per-value cost for overhead is simpler.
++		const mapEntryOverhead = 200
+ 		maxMemoryBytes -= int64(len(name))
+-		maxMemoryBytes -= 100 // map overhead
++		maxMemoryBytes -= mapEntryOverhead
+ 		if maxMemoryBytes < 0 {
+ 			// We can't actually take this path, since nextPart would already have
+ 			// rejected the MIME headers for being too large. Check anyway.
+@@ -128,7 +129,10 @@ func (r *Reader) readForm(maxMemory int64) (_ *Form, err error) {
+ 		}
+ 
+ 		// file, store in memory or on disk
++		const fileHeaderSize = 100
+ 		maxMemoryBytes -= mimeHeaderSize(p.Header)
++		maxMemoryBytes -= mapEntryOverhead
++		maxMemoryBytes -= fileHeaderSize
+ 		if maxMemoryBytes < 0 {
+ 			return nil, ErrMessageTooLarge
+ 		}
+@@ -183,9 +187,10 @@ func (r *Reader) readForm(maxMemory int64) (_ *Form, err error) {
+ }
+ 
+ func mimeHeaderSize(h textproto.MIMEHeader) (size int64) {
++	size = 400
+ 	for k, vs := range h {
+ 		size += int64(len(k))
+-		size += 100 // map entry overhead
++		size += 200 // map entry overhead
+ 		for _, v := range vs {
+ 			size += int64(len(v))
+ 		}
+diff --git a/src/mime/multipart/formdata_test.go b/src/mime/multipart/formdata_test.go
+index f5b56083b2..8ed26e0c34 100644
+--- a/src/mime/multipart/formdata_test.go
++++ b/src/mime/multipart/formdata_test.go
+@@ -192,10 +192,10 @@ func (r *failOnReadAfterErrorReader) Read(p []byte) (n int, err error) {
+ // TestReadForm_NonFileMaxMemory asserts that the ReadForm maxMemory limit is applied
+ // while processing non-file form data as well as file form data.
+ func TestReadForm_NonFileMaxMemory(t *testing.T) {
+-	n := 10<<20 + 25
+ 	if testing.Short() {
+-		n = 10<<10 + 25
++		t.Skip("skipping in -short mode")
+ 	}
++	n := 10 << 20
+ 	largeTextValue := strings.Repeat("1", n)
+ 	message := `--MyBoundary
+ Content-Disposition: form-data; name="largetext"
+@@ -203,38 +203,29 @@ Content-Disposition: form-data; name="largetext"
+ ` + largeTextValue + `
+ --MyBoundary--
+ `
+-
+ 	testBody := strings.ReplaceAll(message, "\n", "\r\n")
+-	testCases := []struct {
+-		name      string
+-		maxMemory int64
+-		err       error
+-	}{
+-		{"smaller", 50 + int64(len("largetext")) + 100, nil},
+-		{"exact-fit", 25 + int64(len("largetext")) + 100, nil},
+-		{"too-large", 0, ErrMessageTooLarge},
+-	}
+-	for _, tc := range testCases {
+-		t.Run(tc.name, func(t *testing.T) {
+-			if tc.maxMemory == 0 && testing.Short() {
+-				t.Skip("skipping in -short mode")
+-			}
+-			b := strings.NewReader(testBody)
+-			r := NewReader(b, boundary)
+-			f, err := r.ReadForm(tc.maxMemory)
+-			if err == nil {
+-				defer f.RemoveAll()
+-			}
+-			if tc.err != err {
+-				t.Fatalf("ReadForm error - got: %v; expected: %v", err, tc.err)
+-			}
+-			if err == nil {
+-				if g := f.Value["largetext"][0]; g != largeTextValue {
+-					t.Errorf("largetext mismatch: got size: %v, expected size: %v", len(g), len(largeTextValue))
+-				}
+-			}
+-		})
++	// Try parsing the form with increasing maxMemory values.
++	// Changes in how we account for non-file form data may cause the exact point
++	// where we change from rejecting the form as too large to accepting it to vary,
++	// but we should see both successes and failures.
++	const failWhenMaxMemoryLessThan = 128
++	for maxMemory := int64(0); maxMemory < failWhenMaxMemoryLessThan*2; maxMemory += 16 {
++		b := strings.NewReader(testBody)
++		r := NewReader(b, boundary)
++		f, err := r.ReadForm(maxMemory)
++		if err != nil {
++			continue
++		}
++		if g := f.Value["largetext"][0]; g != largeTextValue {
++			t.Errorf("largetext mismatch: got size: %v, expected size: %v", len(g), len(largeTextValue))
++		}
++		f.RemoveAll()
++		if maxMemory < failWhenMaxMemoryLessThan {
++			t.Errorf("ReadForm(%v): no error, expect to hit memory limit when maxMemory < %v", maxMemory, failWhenMaxMemoryLessThan)
++		}
++		return
+ 	}
++	t.Errorf("ReadForm(x) failed for x < 1024, expect success")
+ }
+ 
+ // TestReadForm_MetadataTooLarge verifies that we account for the size of field names,
+diff --git a/src/net/textproto/reader.go b/src/net/textproto/reader.go
+index 8956dc4ac9..5c25aad092 100644
+--- a/src/net/textproto/reader.go
++++ b/src/net/textproto/reader.go
+@@ -505,6 +505,12 @@ func readMIMEHeader(r *Reader, lim int64) (MIMEHeader, error) {
+ 
+ 	m := make(MIMEHeader, hint)
+ 
++	// Account for 400 bytes of overhead for the MIMEHeader, plus 200 bytes per entry.
++	// Benchmarking map creation as of go1.20, a one-entry MIMEHeader is 416 bytes and large
++	// MIMEHeaders average about 200 bytes per entry.
++	lim -= 400
++	const mapEntryOverhead = 200
++
+ 	// The first line cannot start with a leading space.
+ 	if buf, err := r.R.Peek(1); err == nil && (buf[0] == ' ' || buf[0] == '\t') {
+ 		line, err := r.readLineSlice()
+@@ -540,7 +546,7 @@ func readMIMEHeader(r *Reader, lim int64) (MIMEHeader, error) {
+ 		vv := m[key]
+ 		if vv == nil {
+ 			lim -= int64(len(key))
+-			lim -= 100 // map entry overhead
++			lim -= mapEntryOverhead
+ 		}
+ 		lim -= int64(len(value))
+ 		if lim < 0 {
+-- 
+2.39.1
+

--- a/projects/golang/go/1.18/patches/0009-go-1.18.10-eks-mime-multipart-limit-parsed-mi.patch
+++ b/projects/golang/go/1.18/patches/0009-go-1.18.10-eks-mime-multipart-limit-parsed-mi.patch
@@ -1,0 +1,355 @@
+From e5c94b4041e93461b3ca2976c4dadf105e6b469d Mon Sep 17 00:00:00 2001
+From: Damien Neil <dneil@google.com>
+Date: Mon, 20 Mar 2023 10:43:19 -0700
+Subject: [PATCH] [release-branch.go1.19] mime/multipart: limit parsed mime
+ message sizes
+
+# AWS EKS
+Backported To: go-1.18.10-eks
+Backported On: Wed, 5 Apr 2023
+Backported By: kodurub@amazon.com
+Backported From: release-branch.go1.19
+Source Commit: https://github.com/golang/go/commit/7917b5f31204528ea72e0629f0b7d52b35b27538
+
+The parsed forms of MIME headers and multipart forms can consume
+substantially more memory than the size of the input data.
+A malicious input containing a very large number of headers or
+form parts can cause excessively large memory allocations.
+
+Set limits on the size of MIME data:
+
+Reader.NextPart and Reader.NextRawPart limit the the number
+of headers in a part to 10000.
+
+Reader.ReadForm limits the total number of headers in all
+FileHeaders to 10000.
+
+Both of these limits may be set with with
+GODEBUG=multipartmaxheaders=<values>.
+
+Reader.ReadForm limits the number of parts in a form to 1000.
+This limit may be set with GODEBUG=multipartmaxparts=<value>.
+
+Thanks for Jakob Ackermann (@das7pad) for reporting this issue.
+
+For CVE-2023-24536
+For #59153
+For #59269
+
+Reviewed-on: https://team-review.git.corp.google.com/c/golang/go-private/+/1802455
+Run-TryBot: Damien Neil <dneil@google.com>
+Reviewed-by: Roland Shoemaker <bracewell@google.com>
+Reviewed-by: Julie Qiu <julieqiu@google.com>
+Reviewed-on: https://team-review.git.corp.google.com/c/golang/go-private/+/1801087
+Reviewed-by: Damien Neil <dneil@google.com>
+Run-TryBot: Roland Shoemaker <bracewell@google.com>
+Change-Id: If134890d75f0d95c681d67234daf191ba08e6424
+Reviewed-on: https://go-review.googlesource.com/c/go/+/481985
+Run-TryBot: Michael Knyszek <mknyszek@google.com>
+Auto-Submit: Michael Knyszek <mknyszek@google.com>
+TryBot-Result: Gopher Robot <gobot@golang.org>
+Reviewed-by: Matthew Dempsky <mdempsky@google.com>
+---
+ src/mime/multipart/formdata.go       | 19 ++++++++-
+ src/mime/multipart/formdata_test.go  | 61 ++++++++++++++++++++++++++++
+ src/mime/multipart/multipart.go      | 35 +++++++++++-----
+ src/mime/multipart/readmimeheader.go |  2 +-
+ src/net/textproto/reader.go          | 19 +++++----
+ 5 files changed, 117 insertions(+), 19 deletions(-)
+
+diff --git a/src/mime/multipart/formdata.go b/src/mime/multipart/formdata.go
+index 3f6ff697ca..4f26aab2cf 100644
+--- a/src/mime/multipart/formdata.go
++++ b/src/mime/multipart/formdata.go
+@@ -12,6 +12,7 @@ import (
+ 	"math"
+ 	"net/textproto"
+ 	"os"
++	"strconv"
+ )
+ 
+ // ErrMessageTooLarge is returned by ReadForm if the message form
+@@ -41,6 +42,15 @@ func (r *Reader) readForm(maxMemory int64) (_ *Form, err error) {
+ 	numDiskFiles := 0
+ 	multipartFiles := godebug.Get("multipartfiles")
+ 	combineFiles := multipartFiles != "distinct"
++	maxParts := 1000
++	multipartMaxParts := godebug.Get("multipartmaxparts")
++	if multipartMaxParts != "" {
++		if v, err := strconv.Atoi(multipartMaxParts); err == nil && v >= 0 {
++			maxParts = v
++		}
++	}
++	maxHeaders := maxMIMEHeaders()
++
+ 	defer func() {
+ 		if file != nil {
+ 			if cerr := file.Close(); err == nil {
+@@ -86,13 +96,17 @@ func (r *Reader) readForm(maxMemory int64) (_ *Form, err error) {
+ 	}
+ 	var copyBuf []byte
+ 	for {
+-		p, err := r.nextPart(false, maxMemoryBytes)
++		p, err := r.nextPart(false, maxMemoryBytes, maxHeaders)
+ 		if err == io.EOF {
+ 			break
+ 		}
+ 		if err != nil {
+ 			return nil, err
+ 		}
++		if maxParts <= 0 {
++			return nil, ErrMessageTooLarge
++		}
++		maxParts--
+ 
+ 		name := p.FormName()
+ 		if name == "" {
+@@ -136,6 +150,9 @@ func (r *Reader) readForm(maxMemory int64) (_ *Form, err error) {
+ 		if maxMemoryBytes < 0 {
+ 			return nil, ErrMessageTooLarge
+ 		}
++		for _, v := range p.Header {
++			maxHeaders -= int64(len(v))
++		}
+ 		fh := &FileHeader{
+ 			Filename: filename,
+ 			Header:   p.Header,
+diff --git a/src/mime/multipart/formdata_test.go b/src/mime/multipart/formdata_test.go
+index 8ed26e0c34..c78eeb7a12 100644
+--- a/src/mime/multipart/formdata_test.go
++++ b/src/mime/multipart/formdata_test.go
+@@ -360,6 +360,67 @@ func testReadFormManyFiles(t *testing.T, distinct bool) {
+ 	}
+ }
+ 
++func TestReadFormLimits(t *testing.T) {
++	for _, test := range []struct {
++		values           int
++		files            int
++		extraKeysPerFile int
++		wantErr          error
++		godebug          string
++	}{
++		{values: 1000},
++		{values: 1001, wantErr: ErrMessageTooLarge},
++		{values: 500, files: 500},
++		{values: 501, files: 500, wantErr: ErrMessageTooLarge},
++		{files: 1000},
++		{files: 1001, wantErr: ErrMessageTooLarge},
++		{files: 1, extraKeysPerFile: 9998}, // plus Content-Disposition and Content-Type
++		{files: 1, extraKeysPerFile: 10000, wantErr: ErrMessageTooLarge},
++		{godebug: "multipartmaxparts=100", values: 100},
++		{godebug: "multipartmaxparts=100", values: 101, wantErr: ErrMessageTooLarge},
++		{godebug: "multipartmaxheaders=100", files: 2, extraKeysPerFile: 48},
++		{godebug: "multipartmaxheaders=100", files: 2, extraKeysPerFile: 50, wantErr: ErrMessageTooLarge},
++	} {
++		name := fmt.Sprintf("values=%v/files=%v/extraKeysPerFile=%v", test.values, test.files, test.extraKeysPerFile)
++		if test.godebug != "" {
++			name += fmt.Sprintf("/godebug=%v", test.godebug)
++		}
++		t.Run(name, func(t *testing.T) {
++			if test.godebug != "" {
++				t.Setenv("GODEBUG", test.godebug)
++			}
++			var buf bytes.Buffer
++			fw := NewWriter(&buf)
++			for i := 0; i < test.values; i++ {
++				w, _ := fw.CreateFormField(fmt.Sprintf("field%v", i))
++				fmt.Fprintf(w, "value %v", i)
++			}
++			for i := 0; i < test.files; i++ {
++				h := make(textproto.MIMEHeader)
++				h.Set("Content-Disposition",
++					fmt.Sprintf(`form-data; name="file%v"; filename="file%v"`, i, i))
++				h.Set("Content-Type", "application/octet-stream")
++				for j := 0; j < test.extraKeysPerFile; j++ {
++					h.Set(fmt.Sprintf("k%v", j), "v")
++				}
++				w, _ := fw.CreatePart(h)
++				fmt.Fprintf(w, "value %v", i)
++			}
++			if err := fw.Close(); err != nil {
++				t.Fatal(err)
++			}
++			fr := NewReader(bytes.NewReader(buf.Bytes()), fw.Boundary())
++			form, err := fr.ReadForm(1 << 10)
++			if err == nil {
++				defer form.RemoveAll()
++			}
++			if err != test.wantErr {
++				t.Errorf("ReadForm = %v, want %v", err, test.wantErr)
++			}
++		})
++	}
++}
++
+ func BenchmarkReadForm(b *testing.B) {
+ 	for _, test := range []struct {
+ 		name string
+diff --git a/src/mime/multipart/multipart.go b/src/mime/multipart/multipart.go
+index 19fe0ea019..bc5096f018 100644
+--- a/src/mime/multipart/multipart.go
++++ b/src/mime/multipart/multipart.go
+@@ -16,11 +16,13 @@ import (
+ 	"bufio"
+ 	"bytes"
+ 	"fmt"
++	"internal/godebug"
+ 	"io"
+ 	"mime"
+ 	"mime/quotedprintable"
+ 	"net/textproto"
+ 	"path/filepath"
++	"strconv"
+ 	"strings"
+ )
+ 
+@@ -128,12 +130,12 @@ func (r *stickyErrorReader) Read(p []byte) (n int, _ error) {
+ 	return n, r.err
+ }
+ 
+-func newPart(mr *Reader, rawPart bool, maxMIMEHeaderSize int64) (*Part, error) {
++func newPart(mr *Reader, rawPart bool, maxMIMEHeaderSize, maxMIMEHeaders int64) (*Part, error) {
+ 	bp := &Part{
+ 		Header: make(map[string][]string),
+ 		mr:     mr,
+ 	}
+-	if err := bp.populateHeaders(maxMIMEHeaderSize); err != nil {
++	if err := bp.populateHeaders(maxMIMEHeaderSize, maxMIMEHeaders); err != nil {
+ 		return nil, err
+ 	}
+ 	bp.r = partReader{bp}
+@@ -149,11 +151,11 @@ func newPart(mr *Reader, rawPart bool, maxMIMEHeaderSize int64) (*Part, error) {
+ 	return bp, nil
+ }
+ 
+-func (bp *Part) populateHeaders(maxMIMEHeaderSize int64) error {
+-	r := textproto.NewReader(bp.mr.bufReader)
+-	header, err := readMIMEHeader(r, maxMIMEHeaderSize)
++func (p *Part) populateHeaders(maxMIMEHeaderSize, maxMIMEHeaders int64) error {
++	r := textproto.NewReader(p.mr.bufReader)
++	header, err := readMIMEHeader(r, maxMIMEHeaderSize, maxMIMEHeaders)
+ 	if err == nil {
+-		bp.Header = header
++		p.Header = header
+ 	}
+ 	// TODO: Add a distinguishable error to net/textproto.
+ 	if err != nil && err.Error() == "message too large" {
+@@ -313,6 +315,19 @@ type Reader struct {
+ // including header keys, values, and map overhead.
+ const maxMIMEHeaderSize = 10 << 20
+ 
++func maxMIMEHeaders() int64 {
++	// multipartMaxHeaders is the maximum number of header entries NextPart will return,
++	// as well as the maximum combined total of header entries Reader.ReadForm will return
++	// in FileHeaders.
++	multipartMaxHeaders := godebug.Get("multipartmaxheaders")
++	if multipartMaxHeaders != "" {
++		if v, err := strconv.ParseInt(multipartMaxHeaders, 10, 64); err == nil && v >= 0 {
++			return v
++		}
++	}
++	return 10000
++}
++
+ // NextPart returns the next part in the multipart or an error.
+ // When there are no more parts, the error io.EOF is returned.
+ //
+@@ -320,7 +335,7 @@ const maxMIMEHeaderSize = 10 << 20
+ // has a value of "quoted-printable", that header is instead
+ // hidden and the body is transparently decoded during Read calls.
+ func (r *Reader) NextPart() (*Part, error) {
+-	return r.nextPart(false, maxMIMEHeaderSize)
++	return r.nextPart(false, maxMIMEHeaderSize, maxMIMEHeaders())
+ }
+ 
+ // NextRawPart returns the next part in the multipart or an error.
+@@ -329,10 +344,10 @@ func (r *Reader) NextPart() (*Part, error) {
+ // Unlike NextPart, it does not have special handling for
+ // "Content-Transfer-Encoding: quoted-printable".
+ func (r *Reader) NextRawPart() (*Part, error) {
+-	return r.nextPart(true, maxMIMEHeaderSize)
++	return r.nextPart(true, maxMIMEHeaderSize, maxMIMEHeaders())
+ }
+ 
+-func (r *Reader) nextPart(rawPart bool, maxMIMEHeaderSize int64) (*Part, error) {
++func (r *Reader) nextPart(rawPart bool, maxMIMEHeaderSize, maxMIMEHeaders int64) (*Part, error) {
+ 	if r.currentPart != nil {
+ 		r.currentPart.Close()
+ 	}
+@@ -357,7 +372,7 @@ func (r *Reader) nextPart(rawPart bool, maxMIMEHeaderSize int64) (*Part, error)
+ 
+ 		if r.isBoundaryDelimiterLine(line) {
+ 			r.partsRead++
+-			bp, err := newPart(r, rawPart, maxMIMEHeaderSize)
++			bp, err := newPart(r, rawPart, maxMIMEHeaderSize, maxMIMEHeaders)
+ 			if err != nil {
+ 				return nil, err
+ 			}
+diff --git a/src/mime/multipart/readmimeheader.go b/src/mime/multipart/readmimeheader.go
+index 6836928c9e..25aa6e2092 100644
+--- a/src/mime/multipart/readmimeheader.go
++++ b/src/mime/multipart/readmimeheader.go
+@@ -11,4 +11,4 @@ import (
+ // readMIMEHeader is defined in package net/textproto.
+ //
+ //go:linkname readMIMEHeader net/textproto.readMIMEHeader
+-func readMIMEHeader(r *textproto.Reader, lim int64) (textproto.MIMEHeader, error)
++func readMIMEHeader(r *textproto.Reader, maxMemory, maxHeaders int64) (textproto.MIMEHeader, error)
+diff --git a/src/net/textproto/reader.go b/src/net/textproto/reader.go
+index 5c25aad092..265de35a92 100644
+--- a/src/net/textproto/reader.go
++++ b/src/net/textproto/reader.go
+@@ -485,12 +485,12 @@ var colon = []byte(":")
+ //	}
+ //
+ func (r *Reader) ReadMIMEHeader() (MIMEHeader, error) {
+-	return readMIMEHeader(r, math.MaxInt64)
++	return readMIMEHeader(r, math.MaxInt64, math.MaxInt64)
+ }
+ 
+ // readMIMEHeader is a version of ReadMIMEHeader which takes a limit on the header size.
+ // It is called by the mime/multipart package.
+-func readMIMEHeader(r *Reader, lim int64) (MIMEHeader, error) {
++func readMIMEHeader(r *Reader, maxMemory, maxHeaders int64) (MIMEHeader, error) {
+ 	// Avoid lots of small slice allocations later by allocating one
+ 	// large one ahead of time which we'll cut up into smaller
+ 	// slices. If this isn't big enough later, we allocate small ones.
+@@ -508,7 +508,7 @@ func readMIMEHeader(r *Reader, lim int64) (MIMEHeader, error) {
+ 	// Account for 400 bytes of overhead for the MIMEHeader, plus 200 bytes per entry.
+ 	// Benchmarking map creation as of go1.20, a one-entry MIMEHeader is 416 bytes and large
+ 	// MIMEHeaders average about 200 bytes per entry.
+-	lim -= 400
++	maxMemory -= 400
+ 	const mapEntryOverhead = 200
+ 
+ 	// The first line cannot start with a leading space.
+@@ -540,16 +540,21 @@ func readMIMEHeader(r *Reader, lim int64) (MIMEHeader, error) {
+ 			continue
+ 		}
+ 
++		maxHeaders--
++		if maxHeaders < 0 {
++			return nil, errors.New("message too large")
++		}
++
+ 		// Skip initial spaces in value.
+ 		value := string(bytes.TrimLeft(v, " \t"))
+ 
+ 		vv := m[key]
+ 		if vv == nil {
+-			lim -= int64(len(key))
+-			lim -= mapEntryOverhead
++			maxMemory -= int64(len(key))
++			maxMemory -= mapEntryOverhead
+ 		}
+-		lim -= int64(len(value))
+-		if lim < 0 {
++		maxMemory -= int64(len(value))
++		if maxMemory < 0 {
+ 			// TODO: This should be a distinguishable error (ErrMessageTooLarge)
+ 			// to allow mime/multipart to detect it.
+ 			return m, errors.New("message too large")
+-- 
+2.39.1
+

--- a/projects/golang/go/1.18/rpmbuild/SPECS/golang.spec
+++ b/projects/golang/go/1.18/rpmbuild/SPECS/golang.spec
@@ -166,6 +166,7 @@ Patch3:       0003-go-1.18.10-eks-multipart-limit-memory-inode-consumption.patch
 Patch4:       0004-go-1.18.10-eks-path-filepath-do-not-Clean-relative-path..patch
 Patch5:       0005-go-1.18.10-eks-go-scanner-reject-large-line-a.patch
 Patch6:       0006-go-1.18.10-eks-go-net-textproto-avoid-overpredic.patch
+Patch7:       0007-go-1.18.10-eks-mime-multipart-avoid-excessive.patch
 
 Patch101:       0101-syscall-expose-IfInfomsg.X__ifi_pad-on-s390x.patch
 Patch102:       0102-cmd-go-disable-Google-s-proxy-and-sumdb.patch
@@ -557,6 +558,7 @@ fi
 - Includes security fix for CVE-2022-41723
 - Includes security fix for CVE-2022-41724 
 - Includes security fix for CVE-2022-41725
+- Includes security fix for CVE-2023-24536
 
 * Wed Jan 11 2023 Daniel Budris <budris@amazon.com> - 1.18.10-1
 - Bump tracking patch version to 1.18.10 from 1.18.9

--- a/projects/golang/go/1.18/rpmbuild/SPECS/golang.spec
+++ b/projects/golang/go/1.18/rpmbuild/SPECS/golang.spec
@@ -167,6 +167,7 @@ Patch4:       0004-go-1.18.10-eks-path-filepath-do-not-Clean-relative-path..patc
 Patch5:       0005-go-1.18.10-eks-go-scanner-reject-large-line-a.patch
 Patch6:       0006-go-1.18.10-eks-go-net-textproto-avoid-overpredic.patch
 Patch7:       0007-go-1.18.10-eks-mime-multipart-avoid-excessive.patch
+Patch8:       0008-go-1.18.10-eks-net-textproto-mime-multipart-i.patch
 
 Patch101:       0101-syscall-expose-IfInfomsg.X__ifi_pad-on-s390x.patch
 Patch102:       0102-cmd-go-disable-Google-s-proxy-and-sumdb.patch

--- a/projects/golang/go/1.18/rpmbuild/SPECS/golang.spec
+++ b/projects/golang/go/1.18/rpmbuild/SPECS/golang.spec
@@ -168,6 +168,7 @@ Patch5:       0005-go-1.18.10-eks-go-scanner-reject-large-line-a.patch
 Patch6:       0006-go-1.18.10-eks-go-net-textproto-avoid-overpredic.patch
 Patch7:       0007-go-1.18.10-eks-mime-multipart-avoid-excessive.patch
 Patch8:       0008-go-1.18.10-eks-net-textproto-mime-multipart-i.patch
+Patch9:       0009-go-1.18.10-eks-mime-multipart-limit-parsed-mi.patch
 
 Patch101:       0101-syscall-expose-IfInfomsg.X__ifi_pad-on-s390x.patch
 Patch102:       0102-cmd-go-disable-Google-s-proxy-and-sumdb.patch

--- a/projects/golang/go/1.18/rpmbuild/SPECS/golang.spec
+++ b/projects/golang/go/1.18/rpmbuild/SPECS/golang.spec
@@ -165,6 +165,7 @@ Patch2:       0002-go-1.18.10-eks-replace-all-usages-of-BytesOrPanic.patch
 Patch3:       0003-go-1.18.10-eks-multipart-limit-memory-inode-consumption.patch
 Patch4:       0004-go-1.18.10-eks-path-filepath-do-not-Clean-relative-path..patch
 Patch5:       0005-go-1.18.10-eks-go-scanner-reject-large-line-a.patch
+Patch6:       0006-go-1.18.10-eks-go-net-textproto-avoid-overpredic.patch
 
 Patch101:       0101-syscall-expose-IfInfomsg.X__ifi_pad-on-s390x.patch
 Patch102:       0102-cmd-go-disable-Google-s-proxy-and-sumdb.patch
@@ -547,6 +548,10 @@ fi
 %endif
 
 %changelog
+* Wed Apr 5 2023 Bhavitha Koduru <kodurub@amazon.com> - 1.18.10-3
+- Includes security fix for CVE-2023-24537
+- Includes security fix for CVE-2023-24534
+
 * Wed Feb 15 2023 Sajia Zafreen <szafreen@amazon.com> - 1.18.10-2
 - Includes security fix for CVE-2022-41722
 - Includes security fix for CVE-2022-41723

--- a/projects/golang/go/1.18/rpmbuild/SPECS/golang.spec
+++ b/projects/golang/go/1.18/rpmbuild/SPECS/golang.spec
@@ -164,6 +164,7 @@ Patch1:       0001-go-1.18.10-eks-update-bundled-golang.org.patch
 Patch2:       0002-go-1.18.10-eks-replace-all-usages-of-BytesOrPanic.patch
 Patch3:       0003-go-1.18.10-eks-multipart-limit-memory-inode-consumption.patch
 Patch4:       0004-go-1.18.10-eks-path-filepath-do-not-Clean-relative-path..patch
+Patch5:       0005-go-1.18.10-eks-go-scanner-reject-large-line-a.patch
 
 Patch101:       0101-syscall-expose-IfInfomsg.X__ifi_pad-on-s390x.patch
 Patch102:       0102-cmd-go-disable-Google-s-proxy-and-sumdb.patch


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
