### PR TITLE
Update EKS_DISTRO_TAG_FILE.yaml

### DIFF
--- a/EKS_DISTRO_TAG_FILE.yaml
+++ b/EKS_DISTRO_TAG_FILE.yaml
@@ -3,7 +3,7 @@ al2:
   eks-distro-minimal-base: 2023-06-06-1686078098.2
   eks-distro-minimal-base-nonroot: 2023-06-06-1686078098.2
   eks-distro-minimal-base-glibc: 2023-06-08-1686250870.2
-  eks-distro-minimal-base-iptables: 2023-06-08-1686250870.2
+  eks-distro-minimal-base-iptables: null
   eks-distro-minimal-base-docker-client: 2023-06-08-1686250870.2
   eks-distro-minimal-base-csi: 2023-06-08-1686250870.2
   eks-distro-minimal-base-csi-ebs: 2023-06-08-1686250870.2
@@ -44,7 +44,7 @@ al2023:
   eks-distro-minimal-base: 2023-03-15-1678906918.2023
   eks-distro-minimal-base-nonroot: 2023-03-15-1678906918.2023
   eks-distro-minimal-base-glibc: 2023-03-23-1679598055.2023
-  eks-distro-minimal-base-iptables: 2023-06-07-1686164502.2023
+  eks-distro-minimal-base-iptables: null
   eks-distro-minimal-base-docker-client: 2023-03-23-1679598055.2023
   eks-distro-minimal-base-csi: 2023-06-07-1686164502.2023
   eks-distro-minimal-base-csi-ebs: 2023-03-23-1679598055.2023


### PR DESCRIPTION
trigger a rebuild for the `eks-distro-minimal-base-iptables` to take the latest Golang changes in 1.20.5

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
