### PR TITLE
fixes PR description to include updated packages in minimal images

### DIFF
--- a/eks-distro-base/update_base_image_other_repos.sh
+++ b/eks-distro-base/update_base_image_other_repos.sh
@@ -18,14 +18,14 @@ set -e
 set -o pipefail
 set -x
 
+SCRIPT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+
 OTHER_CLONE_ROOT=${OTHER_CLONE_ROOT:-${SCRIPT_ROOT}/../../..}
 if [ $REPO_OWNER = "aws" ]; then
     ORIGIN_ORG="eks-distro-pr-bot"
 else
     ORIGIN_ORG=$REPO_OWNER
 fi
-
-SCRIPT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 
 EXTRA_PR_BODY=""
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

I broke this a while ago.  The build was failing to check the other repo because the directory was missing the script_root prefix, since it was being used before it was set. this was the error in prow:

`fatal: cannot change to '/../../../eks-distro-pr-bot/eks-distro': No such file or directory`

I *think* this should bring back the updated packages sections in the PRs we open when bumping new base images.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
