### PR TITLE
changes iptables minimal image default to use iptables-wrapper

### DIFF
--- a/EKS_DISTRO_TAG_FILE.yaml
+++ b/EKS_DISTRO_TAG_FILE.yaml
@@ -3,7 +3,7 @@ al2:
   eks-distro-minimal-base: 2023-06-06-1686078098.2
   eks-distro-minimal-base-nonroot: 2023-06-06-1686078098.2
   eks-distro-minimal-base-glibc: 2023-06-08-1686250870.2
-  eks-distro-minimal-base-iptables: 2023-06-22-1687460500.2
+  eks-distro-minimal-base-iptables: null
   eks-distro-minimal-base-docker-client: 2023-06-08-1686250870.2
   eks-distro-minimal-base-csi: 2023-06-27-1687892493.2
   eks-distro-minimal-base-csi-ebs: 2023-06-27-1687892493.2
@@ -41,7 +41,7 @@ al2023:
   eks-distro-minimal-base: 2023-03-15-1678906918.2023
   eks-distro-minimal-base-nonroot: 2023-03-15-1678906918.2023
   eks-distro-minimal-base-glibc: 2023-03-23-1679598055.2023
-  eks-distro-minimal-base-iptables: 2023-06-27-1687892492.2023
+  eks-distro-minimal-base-iptables: null
   eks-distro-minimal-base-docker-client: 2023-03-23-1679598055.2023
   eks-distro-minimal-base-csi: 2023-06-27-1687892492.2023
   eks-distro-minimal-base-csi-ebs: 2023-06-27-1687892492.2023

--- a/eks-distro-base/Dockerfile.minimal-base-iptables
+++ b/eks-distro-base/Dockerfile.minimal-base-iptables
@@ -74,8 +74,8 @@ RUN set -x && \
         --slave /usr/sbin/ip6tables ip6tables /usr/sbin/iptables-wrapper \
         --slave /usr/sbin/ip6tables-restore ip6tables-restore /usr/sbin/iptables-wrapper \
         --slave /usr/sbin/ip6tables-save ip6tables-save /usr/sbin/iptables-wrapper && \
-    # default to iptables in legacy mode
-    for t in iptables ip6tables; do chroot $NEWROOT update-alternatives --set $t /usr/sbin/$t-legacy; done && \
+    # default to iptables to use golang wrapper
+    chroot $NEWROOT update-alternatives --set iptables /usr/sbin/iptables-wrapper && \
     # Remove bad symlinks due to deleted man files
     find $NEWROOT/etc/alternatives -xtype l -name "*-man" -delete -print && \
     cleanup "iptables"

--- a/eks-distro-base/tests/Dockerfile
+++ b/eks-distro-base/tests/Dockerfile
@@ -28,6 +28,9 @@ CMD ["/bin/check-cgo"]
 
 FROM ${BASE_IMAGE} as check-iptables-legacy
 
+RUN ["update-alternatives", "--set", "iptables", "/usr/sbin/iptables-legacy"]
+RUN ["update-alternatives", "--set", "ip6tables", "/usr/sbin/ip6tables-legacy"]
+
 CMD ["iptables"]
 
 FROM ${BASE_IMAGE} as check-iptables-nft
@@ -46,7 +49,6 @@ RUN cd /iptables-wrappers && \
 FROM ${BASE_IMAGE} as check-iptables-wrapper
 
 COPY --from=iptables-wrapper-tests-builder /iptables-wrappers/bin/tests /
-RUN ["update-alternatives", "--set", "iptables", "/usr/sbin/iptables-wrapper"]
 
 CMD ["iptables"]
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

We added the golang based [iptables-wrapper ](https://github.com/kubernetes-sigs/iptables-wrappers/blob/master/main.go)script to the minimal iptables image a few months ago. At the time we decided to leave the default "alternative" as iptables-legacy to avoid casually breaking downstream consumers of this image.  At the time we updated eks-distro's [kube-proxy](https://github.com/aws/eks-distro/blob/main/projects/kubernetes/release/docker/kube-proxy-base/Dockerfile) to use the new wrapper.

We are now ready to make the wrapper the default alternative to make it easier for downstream consumers to build their images to rely on this wrapper to properly flip between legacy/nft iptables mode based on the host OS.

*Notes*

After this merges and is buiilt, the `latest` tag will point to the new image with the wrapper set as the default alternative. This means the next time any consumers build their images they will get one with this default.  This also means there will be no more cve updates to the iptables image with the previous default.  The eks-distro build could change its dockerfile, but does not have to since its already setting the same alternative.  I have spoken with all the internal consumers I am aware of and made sure they are prepared to take this change.

We also believe this change should not negatively impact anyone using this image, in fact it will probably behave more like they expect, but have not noticed since only recently OS's started shipping with iptables-nft as the default (rhel 8.4+).

ref: https://github.com/aws/eks-distro/issues/2160

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
