### PR TITLE
Add go1.18.10 patch 'validate Host header before sending'

### DIFF
--- a/projects/golang/go/1.18/patches/0017-go-1.18.10-eks-net-http-validate-Host-header.patch
+++ b/projects/golang/go/1.18/patches/0017-go-1.18.10-eks-net-http-validate-Host-header.patch
@@ -1,0 +1,216 @@
+From aa1e906b1be11a471b3bfbadfce37acc9d0b3620 Mon Sep 17 00:00:00 2001
+From: Damien Neil <dneil@google.com>
+Date: Wed, 28 Jun 2023 13:20:08 -0700
+Subject: [PATCH] [release-branch.go1.19] net/http: validate Host header before
+ sending
+
+# AWS EKS
+Backported To: go-1.18.10-eks
+Backported On: Tue, 11 Jul 2023
+Backported By: mattwon@amazon.com
+Backported From: release-branch.go1.19
+Source Commit: https://github.com/golang/go/commit/5fa6923b1ea891400153d04ddf1545e23b40041b
+
+# Original Information
+
+Verify that the Host header we send is valid.
+Avoids surprising behavior such as a Host of "go.dev\r\nX-Evil:oops"
+adding an X-Evil header to HTTP/1 requests.
+
+Add a test, skip the test for HTTP/2. HTTP/2 is not vulnerable to
+header injection in the way HTTP/1 is, but x/net/http2 doesn't validate
+the header and will go into a retry loop when the server rejects it.
+CL 506995 adds the necessary validation to x/net/http2.
+
+Updates #60374
+Fixes #61075
+For CVE-2023-29406
+
+Change-Id: I05cb6866a9bead043101954dfded199258c6dd04
+Reviewed-on: https://go-review.googlesource.com/c/go/+/506996
+Reviewed-by: Tatiana Bradley <tatianabradley@google.com>
+TryBot-Result: Gopher Robot <gobot@golang.org>
+Run-TryBot: Damien Neil <dneil@google.com>
+(cherry picked from commit 499458f7ca04087958987a33c2703c3ef03e27e2)
+Reviewed-on: https://go-review.googlesource.com/c/go/+/507358
+Run-TryBot: Tatiana Bradley <tatianabradley@google.com>
+Reviewed-by: Roland Shoemaker <roland@golang.org>
+---
+ src/net/http/http_test.go      | 29 ----------------------
+ src/net/http/request.go        | 45 ++++++++--------------------------
+ src/net/http/request_test.go   | 11 ++-------
+ src/net/http/transport_test.go | 18 ++++++++++++++
+ 4 files changed, 30 insertions(+), 73 deletions(-)
+
+diff --git a/src/net/http/http_test.go b/src/net/http/http_test.go
+index 0d92fe5f96..f03272ab91 100644
+--- a/src/net/http/http_test.go
++++ b/src/net/http/http_test.go
+@@ -48,35 +48,6 @@ func TestForeachHeaderElement(t *testing.T) {
+ 	}
+ }
+ 
+-func TestCleanHost(t *testing.T) {
+-	tests := []struct {
+-		in, want string
+-	}{
+-		{"www.google.com", "www.google.com"},
+-		{"www.google.com foo", "www.google.com"},
+-		{"www.google.com/foo", "www.google.com"},
+-		{" first character is a space", ""},
+-		{"[1::6]:8080", "[1::6]:8080"},
+-
+-		// Punycode:
+-		{"гофер.рф/foo", "xn--c1ae0ajs.xn--p1ai"},
+-		{"bücher.de", "xn--bcher-kva.de"},
+-		{"bücher.de:8080", "xn--bcher-kva.de:8080"},
+-		// Verify we convert to lowercase before punycode:
+-		{"BÜCHER.de", "xn--bcher-kva.de"},
+-		{"BÜCHER.de:8080", "xn--bcher-kva.de:8080"},
+-		// Verify we normalize to NFC before punycode:
+-		{"gophér.nfc", "xn--gophr-esa.nfc"},            // NFC input; no work needed
+-		{"goph\u0065\u0301r.nfd", "xn--gophr-esa.nfd"}, // NFD input
+-	}
+-	for _, tt := range tests {
+-		got := cleanHost(tt.in)
+-		if tt.want != got {
+-			t.Errorf("cleanHost(%q) = %q, want %q", tt.in, got, tt.want)
+-		}
+-	}
+-}
+-
+ // Test that cmd/go doesn't link in the HTTP server.
+ //
+ // This catches accidental dependencies between the HTTP transport and
+diff --git a/src/net/http/request.go b/src/net/http/request.go
+index 76c2317d28..b88a87ddce 100644
+--- a/src/net/http/request.go
++++ b/src/net/http/request.go
+@@ -17,7 +17,6 @@ import (
+ 	"io"
+ 	"mime"
+ 	"mime/multipart"
+-	"net"
+ 	"net/http/httptrace"
+ 	"net/http/internal/ascii"
+ 	"net/textproto"
+@@ -27,6 +26,7 @@ import (
+ 	"strings"
+ 	"sync"
+ 
++	"golang.org/x/net/http/httpguts"
+ 	"golang.org/x/net/idna"
+ )
+ 
+@@ -568,12 +568,19 @@ func (r *Request) write(w io.Writer, usingProxy bool, extraHeaders Header, waitF
+ 	// is not given, use the host from the request URL.
+ 	//
+ 	// Clean the host, in case it arrives with unexpected stuff in it.
+-	host := cleanHost(r.Host)
++	host := r.Host
+ 	if host == "" {
+ 		if r.URL == nil {
+ 			return errMissingHost
+ 		}
+-		host = cleanHost(r.URL.Host)
++		host = r.URL.Host
++	}
++	host, err = httpguts.PunycodeHostPort(host)
++	if err != nil {
++		return err
++	}
++	if !httpguts.ValidHostHeader(host) {
++		return errors.New("http: invalid Host header")
+ 	}
+ 
+ 	// According to RFC 6874, an HTTP client, proxy, or other
+@@ -730,38 +737,6 @@ func idnaASCII(v string) (string, error) {
+ 	return idna.Lookup.ToASCII(v)
+ }
+ 
+-// cleanHost cleans up the host sent in request's Host header.
+-//
+-// It both strips anything after '/' or ' ', and puts the value
+-// into Punycode form, if necessary.
+-//
+-// Ideally we'd clean the Host header according to the spec:
+-//   https://tools.ietf.org/html/rfc7230#section-5.4 (Host = uri-host [ ":" port ]")
+-//   https://tools.ietf.org/html/rfc7230#section-2.7 (uri-host -> rfc3986's host)
+-//   https://tools.ietf.org/html/rfc3986#section-3.2.2 (definition of host)
+-// But practically, what we are trying to avoid is the situation in
+-// issue 11206, where a malformed Host header used in the proxy context
+-// would create a bad request. So it is enough to just truncate at the
+-// first offending character.
+-func cleanHost(in string) string {
+-	if i := strings.IndexAny(in, " /"); i != -1 {
+-		in = in[:i]
+-	}
+-	host, port, err := net.SplitHostPort(in)
+-	if err != nil { // input was just a host
+-		a, err := idnaASCII(in)
+-		if err != nil {
+-			return in // garbage in, garbage out
+-		}
+-		return a
+-	}
+-	a, err := idnaASCII(host)
+-	if err != nil {
+-		return in // garbage in, garbage out
+-	}
+-	return net.JoinHostPort(a, port)
+-}
+-
+ // removeZone removes IPv6 zone identifier from host.
+ // E.g., "[fe80::1%en0]:8080" to "[fe80::1]:8080"
+ func removeZone(host string) string {
+diff --git a/src/net/http/request_test.go b/src/net/http/request_test.go
+index 72647b80d4..2298d35012 100644
+--- a/src/net/http/request_test.go
++++ b/src/net/http/request_test.go
+@@ -782,15 +782,8 @@ func TestRequestBadHost(t *testing.T) {
+ 	}
+ 	req.Host = "foo.com with spaces"
+ 	req.URL.Host = "foo.com with spaces"
+-	req.Write(logWrites{t, &got})
+-	want := []string{
+-		"GET /after HTTP/1.1\r\n",
+-		"Host: foo.com\r\n",
+-		"User-Agent: " + DefaultUserAgent + "\r\n",
+-		"\r\n",
+-	}
+-	if !reflect.DeepEqual(got, want) {
+-		t.Errorf("Writes = %q\n  Want = %q", got, want)
++	if err := req.Write(logWrites{t, &got}); err == nil {
++		t.Errorf("Writing request with invalid Host: succeded, want error")
+ 	}
+ }
+ 
+diff --git a/src/net/http/transport_test.go b/src/net/http/transport_test.go
+index e5d60afb1b..b64dc74a09 100644
+--- a/src/net/http/transport_test.go
++++ b/src/net/http/transport_test.go
+@@ -6541,3 +6541,21 @@ func TestHandlerAbortRacesBodyRead(t *testing.T) {
+ 	}
+ 	wg.Wait()
+ }
++
++func TestRequestSanitization(t *testing.T) {
++	setParallel(t)
++	defer afterTest(t)
++
++	ts := newClientServerTest(t, h1Mode, HandlerFunc(func(rw ResponseWriter, req *Request) {
++		if h, ok := req.Header["X-Evil"]; ok {
++			t.Errorf("request has X-Evil header: %q", h)
++		}
++	})).ts
++	defer ts.Close()
++	req, _ := NewRequest("GET", ts.URL, nil)
++	req.Host = "go.dev\r\nX-Evil:evil"
++	resp, _ := ts.Client().Do(req)
++	if resp != nil {
++		resp.Body.Close()
++	}
++}
+-- 
+2.38.5
+

--- a/projects/golang/go/1.18/rpmbuild/SPECS/golang.spec
+++ b/projects/golang/go/1.18/rpmbuild/SPECS/golang.spec
@@ -176,6 +176,7 @@ Patch13:      0013-go-1.18.10-eks-cmd-go-disallow-package-directories-containing
 Patch14:      0014-go-1.18.10-eks-cmd-go-cgo-in-_cgo_flags-use-one-line-per-flag.patch
 Patch15:      0015-go-1.18.10-eks-cmd-go-enforce-flags-with-non-optional-arguments.patch
 Patch16:      0016-go-1.18.10-eks-runtime-implement-SUID-SGID-protections.patch
+Patch17:      0017-go-1.18.10-eks-net-http-validate-Host-header.patch
 
 Patch101:       0101-syscall-expose-IfInfomsg.X__ifi_pad-on-s390x.patch
 Patch102:       0102-cmd-go-disable-Google-s-proxy-and-sumdb.patch
@@ -558,6 +559,9 @@ fi
 %endif
 
 %changelog
+
+* Tue Jul 11 2023 Matthew Wong <mattwon@amazon.com> - 1.18.10-7
+- Includes security fix for CVE-2023-29406
 
 * Wed Jun 7 2023 Sajia Zafreen <szafreen@amazon.com> - 1.18.10-5
 - Includes security fix for CVE-2023-29402


### PR DESCRIPTION
*Issue #, if available:* backport the fix from 1.19.11 to 1.18.10 https://github.com/aws/eks-distro-build-tooling/issues/1056 

*Description of changes:*

cherry picked https://github.com/golang/go/commit/5fa6923b1ea891400153d04ddf1545e23b40041b from release-branch.go1.19

Technically there was a merge conflict due to gofmt having been applied on go 1.19, see https://github.com/golang/go/blame/3d33532d1cb25955d2bb236394a0afa99899a35c/src/net/http/request.go#L751-L755 vs https://github.com/golang/go/blame/release-branch.go1.18/src/net/http/request.go#L739-L741C55, that's why this patch changes 45 lines whereas the 1.19 changes 47, but I am not sure it was worth mentioning in the commit header.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
