### PR TITLE
update builder base golang version targets during golang test pipelin…

### DIFF
--- a/projects/golang/go/build/conformanceTests/builderBaseRebuildBuildspec.yaml
+++ b/projects/golang/go/build/conformanceTests/builderBaseRebuildBuildspec.yaml
@@ -31,6 +31,7 @@ phases:
       - echo Running pre-build setup and initialization...
       - scripts/sync_uninitialized_git_repository.sh . $EKS_D_BUILD_TOOLING_REMOTE_URL $TARGET_BRANCH
       - scripts/setup_ecr_credential_helper.sh
+      - projects/golang/go/scripts/replace_builder_base_go_versions.sh
   build:
     commands:
       - mkdir -p builder-base/tmp/golang-downloads/x86_64

--- a/projects/golang/go/scripts/replace_builder_base_go_versions.sh
+++ b/projects/golang/go/scripts/replace_builder_base_go_versions.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+set -e
+set -x
+
+BASE_DIRECTORY="$(git rev-parse --show-toplevel)"
+PROJECT_DIRECTORY="$BASE_DIRECTORY/projects/golang/go/"
+BUILDER_BASE_DIRECTORY="$BASE_DIRECTORY/builder-base"
+BUILDER_BASE_VERSIONS_FILE="$BUILDER_BASE_DIRECTORY/versions.yaml"
+
+target_versions=$(yq '.| keys' "$BUILDER_BASE_VERSIONS_FILE" | grep GOLANG | tr -d '-')
+
+for versionstring in $target_versions; do
+  echo "updating versions.yaml golang version $versionstring with new value from current git rev..."
+
+  version=${versionstring: -3}
+  semver="${version:0:1}.${version:1:2}"
+
+  git_tag_file=$(cat "$PROJECT_DIRECTORY""$semver"/GIT_TAG)
+  git_tag="${git_tag_file:2}"
+
+  release=$(cat "$PROJECT_DIRECTORY""$semver"/RELEASE)
+
+  updated_golang_version=$git_tag-$release
+  echo "$updated_golang_version"
+
+  export versionstring=$versionstring
+  export updated_golang_version=$updated_golang_version
+
+  yq e -i '.[env(versionstring)] = env(updated_golang_version)' "$BUILDER_BASE_VERSIONS_FILE"
+done


### PR DESCRIPTION
…e execution, in order to test latest version present in git rev

*Issue #, if available:*

*Description of changes:*
The builder-base-rebuild-with-custom-go-versions was broken, in some cases, by a change to the way we handle golang versions in the builder base. The pipeline would run and execute properly in cases where the builder-base versions had been previously updated and the golang version had been released, but not without one of those factors.

This change will ensure that when the pipeline runs, we update the builder-base golang version to match the version + release present in the current git rev so that we always test the correct golang version

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
