### PR TITLE
Add get to allowed actions for prow controller manager

### DIFF
--- a/helm-charts/stable/prow-data-plane/Chart.yaml
+++ b/helm-charts/stable/prow-data-plane/Chart.yaml
@@ -29,7 +29,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.2
+version: 1.0.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm-charts/stable/prow-data-plane/templates/prow-controller-manager-Role.yaml
+++ b/helm-charts/stable/prow-data-plane/templates/prow-controller-manager-Role.yaml
@@ -27,3 +27,4 @@ rules:
       - watch
       - create
       - patch
+      - get


### PR DESCRIPTION
*Issue #, if available:*
Prow control plane failing to update prowjobs in beta

*Description of changes:*
**Fix**
The addition of this [check](https://github.com/kubernetes/test-infra/commit/de4a80675caca4dc9433b21aaadf92e98f29fed1) in the prow image and the requirement to update prow images to for the [Github RSA public key](https://github.com/aws/eks-distro-build-tooling/pull/997). We need to add the `get` action to the prow controller manager, in the data plane clusters. These checks cause the manager to fail on creation
```
	requiredTestPodVerbs := []string{
                "create",
		"delete",
		"list",
		"watch",
		"get",
		"patch",
	}
```
**Testing**
Discovery of this required several steps, when viewing the logs `kubectl logs <prow-controller-manager pod>` there was this entry 
```
{...,"error":"[failed pod resource authorization check: unable to \"create\" pods, failed pod resource authorization check: unable to \"get\" pods]",...}
```
After confirming several other error streams in `crier`, `sinker`, and an event in `ingress/aws-load-balancer`, checking that we could access the build clusters by `exec`ing into the `prow-controller-manager` pod and using the mounted kubeconfig to `kubectl` into the pods. This success led to logging into one of the build clusters that was listed in the `error`. This allowed us to examine the `prow-controller-manager's` definition and adding the `get` verb manually. This restarted the `prow-controller-manager` pod and removed the error for the tested build cluster. These changes will add permanence to the changes.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
