### PR TITLE
add some printlns and a hack to get around errors in 1.28 release

### DIFF
--- a/release/pkg/kube_reader.go
+++ b/release/pkg/kube_reader.go
@@ -16,6 +16,7 @@ package pkg
 
 import (
 	"bufio"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -55,13 +56,16 @@ func newKubeGitVersionFile(buildSource, releaseBranch string) (*kubeGitVersionFi
 func parseKubeGitVersionContent(input io.Reader) (*kubeGitVersionFile, error) {
 	resp := &kubeGitVersionFile{}
 	scanner := bufio.NewScanner(input)
+	fmt.Println("Scanning kubeGitVersionFile")
 	for scanner.Scan() {
 		line := scanner.Text()
+		fmt.Printf("%s\n", line)
 		parts := strings.SplitN(line, "=", 2)
 		if len(parts) != 2 {
 			return nil, errors.Errorf("no equal sign in line: %s", line)
 		}
 		value := strings.Trim(parts[1], `'`)
+		fmt.Printf("value: %s\n", value)
 		switch parts[0] {
 		case "KUBE_GIT_COMMIT":
 			resp.KubeGitCommit = value
@@ -74,6 +78,7 @@ func parseKubeGitVersionContent(input io.Reader) (*kubeGitVersionFile, error) {
 			}
 			resp.KubeGitMajor = val
 		case "KUBE_GIT_MINOR":
+			strings.ReplaceAll(value, "+", "")
 			val, err := strconv.Atoi(value)
 			if err != nil {
 				return nil, errors.Wrapf(err, "Could not parse '%s'", value)

--- a/release/pkg/kube_reader.go
+++ b/release/pkg/kube_reader.go
@@ -78,7 +78,7 @@ func parseKubeGitVersionContent(input io.Reader) (*kubeGitVersionFile, error) {
 			}
 			resp.KubeGitMajor = val
 		case "KUBE_GIT_MINOR":
-			strings.ReplaceAll(value, "+", "")
+			value = strings.ReplaceAll(value, "+", "")
 			val, err := strconv.Atoi(value)
 			if err != nil {
 				return nil, errors.Wrapf(err, "Could not parse '%s'", value)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
our release code is choking on the RC git tag; not exactly sure where the `+` in the string is getting added, as it's part of the generated KUBE_VERSION_FILE that is generated for communication of kube version information among the release code, but added some prints in there to try and get more info and a simple hack to get around it for now.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
