### PR TITLE
Revert "add some printlns and a hack to get around errors in 1.28 rel…

### DIFF
--- a/release/pkg/kube_reader.go
+++ b/release/pkg/kube_reader.go
@@ -16,7 +16,6 @@ package pkg
 
 import (
 	"bufio"
-	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -56,16 +55,13 @@ func newKubeGitVersionFile(buildSource, releaseBranch string) (*kubeGitVersionFi
 func parseKubeGitVersionContent(input io.Reader) (*kubeGitVersionFile, error) {
 	resp := &kubeGitVersionFile{}
 	scanner := bufio.NewScanner(input)
-	fmt.Println("Scanning kubeGitVersionFile")
 	for scanner.Scan() {
 		line := scanner.Text()
-		fmt.Printf("%s\n", line)
 		parts := strings.SplitN(line, "=", 2)
 		if len(parts) != 2 {
 			return nil, errors.Errorf("no equal sign in line: %s", line)
 		}
 		value := strings.Trim(parts[1], `'`)
-		fmt.Printf("value: %s\n", value)
 		switch parts[0] {
 		case "KUBE_GIT_COMMIT":
 			resp.KubeGitCommit = value
@@ -78,7 +74,6 @@ func parseKubeGitVersionContent(input io.Reader) (*kubeGitVersionFile, error) {
 			}
 			resp.KubeGitMajor = val
 		case "KUBE_GIT_MINOR":
-			value = strings.ReplaceAll(value, "+", "")
 			val, err := strconv.Atoi(value)
 			if err != nil {
 				return nil, errors.Wrapf(err, "Could not parse '%s'", value)


### PR DESCRIPTION
…ease (#1094)"

This reverts commit 8af0d701a8c92a68b4ec5f39cea2bb6bd239806a.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
