### PR TITLE
Update cron job api version due to K8s deprecation

### DIFF
--- a/helm-charts/stable/amazon-eks-pod-identity-webhook/Chart.yaml
+++ b/helm-charts/stable/amazon-eks-pod-identity-webhook/Chart.yaml
@@ -29,7 +29,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.8
+version: 1.0.9
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm-charts/stable/amazon-eks-pod-identity-webhook/templates/install-CronJob.yaml
+++ b/helm-charts/stable/amazon-eks-pod-identity-webhook/templates/install-CronJob.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: {{ .Values.installJobName }}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Getting warnings about k8 1.22+ deprecating the cronjob v1beta1 api -> v1. Bumping the helm version to include the change.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
