### PR TITLE
Update kubectl version for amazon-eks-pod-identity-webhook

### DIFF
--- a/helm-charts/stable/amazon-eks-pod-identity-webhook/Chart.yaml
+++ b/helm-charts/stable/amazon-eks-pod-identity-webhook/Chart.yaml
@@ -29,7 +29,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.9
+version: 1.0.10
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm-charts/stable/amazon-eks-pod-identity-webhook/config/install.sh
+++ b/helm-charts/stable/amazon-eks-pod-identity-webhook/config/install.sh
@@ -20,9 +20,9 @@ echo "Running install.sh in $(pwd)"
 
 yum install -y jq
 
-KUBECTL_VERSION=v1.22.6
-EKS_D_RELEASE_BRANCH=1-22
-EKS_D_RELEASE_NUMBER=3
+KUBECTL_VERSION=v1.24.16
+EKS_D_RELEASE_BRANCH=1-24
+EKS_D_RELEASE_NUMBER=24
 curl -sSL "https://distro.eks.amazonaws.com/kubernetes-${EKS_D_RELEASE_BRANCH}/releases/${EKS_D_RELEASE_NUMBER}/artifacts/kubernetes/${KUBECTL_VERSION}/bin/linux/amd64/kubectl" -o /bin/kubectl
 chmod +x /bin/kubectl
 

--- a/helm-charts/stable/amazon-eks-pod-identity-webhook/config/uninstall.sh
+++ b/helm-charts/stable/amazon-eks-pod-identity-webhook/config/uninstall.sh
@@ -18,9 +18,9 @@ set -x
 
 echo "Running uninstall.sh in $(pwd)"
 
-KUBECTL_VERSION=v1.20.7
-EKS_D_RELEASE_BRANCH=1-20
-EKS_D_RELEASE_NUMBER=8
+KUBECTL_VERSION=v1.24.16
+EKS_D_RELEASE_BRANCH=1-24
+EKS_D_RELEASE_NUMBER=24
 curl -sSL "https://distro.eks.amazonaws.com/kubernetes-${EKS_D_RELEASE_BRANCH}/releases/${EKS_D_RELEASE_NUMBER}/artifacts/kubernetes/${KUBECTL_VERSION}/bin/linux/amd64/kubectl" -o /bin/kubectl
 chmod +x /bin/kubectl
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Updating the kubelet version for pod-identity-webhook and bumping the chart version

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
