### PR TITLE
Add profile flag for Golang sns script

### DIFF
--- a/projects/golang/go/scripts/eks_golang_release_notification.sh
+++ b/projects/golang/go/scripts/eks_golang_release_notification.sh
@@ -60,6 +60,7 @@ golang_tracking_version: ${GOLANG_TRACKING_TAG:2}" # removes "go" at front
 
 SNS_MESSAGE_ID=$(
   aws sns publish \
+    --profile "artifacts-push"
     --topic-arn "$SNS_TOPIC_ARN" \
     --subject "New Release of EKS Golang v$GO_SOURCE_VERSION" \
     --message "$SNS_MESSAGE"\

--- a/projects/golang/go/scripts/eks_golang_release_notification.sh
+++ b/projects/golang/go/scripts/eks_golang_release_notification.sh
@@ -60,7 +60,7 @@ golang_tracking_version: ${GOLANG_TRACKING_TAG:2}" # removes "go" at front
 
 SNS_MESSAGE_ID=$(
   aws sns publish \
-    --profile "artifacts-push"
+    --profile "artifacts-push" \
     --topic-arn "$SNS_TOPIC_ARN" \
     --subject "New Release of EKS Golang v$GO_SOURCE_VERSION" \
     --message "$SNS_MESSAGE"\


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Adding the `--profile` flag to use the profile when calling `aws sns` for golang release.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
