### PR TITLE
Update mutating webhook due to v1beta1 deprecation

### DIFF
--- a/helm-charts/stable/amazon-eks-pod-identity-webhook/Chart.yaml
+++ b/helm-charts/stable/amazon-eks-pod-identity-webhook/Chart.yaml
@@ -29,7 +29,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.10
+version: 1.0.11
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm-charts/stable/amazon-eks-pod-identity-webhook/config/mutatingwebhook.yaml
+++ b/helm-charts/stable/amazon-eks-pod-identity-webhook/config/mutatingwebhook.yaml
@@ -12,14 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
   name: ${MWC_NAME}
   namespace: ${NAMESPACE}
 webhooks:
 - name: ${WEBHOOK_NAME}.amazonaws.com
-  failurePolicy: Ignore
+  failurePolicy: Fail
   sideEffects: None
   clientConfig:
     service:

--- a/helm-charts/stable/amazon-eks-pod-identity-webhook/config/mutatingwebhook.yaml
+++ b/helm-charts/stable/amazon-eks-pod-identity-webhook/config/mutatingwebhook.yaml
@@ -19,7 +19,7 @@ metadata:
   namespace: ${NAMESPACE}
 webhooks:
 - name: ${WEBHOOK_NAME}.amazonaws.com
-  failurePolicy: Fail
+  failurePolicy: Ignore
   sideEffects: None
   clientConfig:
     service:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Update the values for the mutating webhook following the [deprecation guide](https://kubernetes.io/docs/reference/using-api/deprecation-guide/#webhook-resources-v122)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
