### PR TITLE
initial commit for EKS Go vulnerability management tracking

### DIFF
--- a/projects/golang/go/VulnerabilityManagement/eks-distro-golang-vex.json
+++ b/projects/golang/go/VulnerabilityManagement/eks-distro-golang-vex.json
@@ -67,7 +67,7 @@
             "name": "v1.21.0-eks-0",
             "product": {
               "product_id": "eks-distro-golang:v1-21-0",
-              "name": "Amazon EKS Distribution Golang version v1.21.0 release 0"
+              "name": "Amazon EKS Distribution Golang version v1.21.0 EKS release 0"
             }
           }
         ]

--- a/projects/golang/go/VulnerabilityManagement/eks-distro-golang-vex.json
+++ b/projects/golang/go/VulnerabilityManagement/eks-distro-golang-vex.json
@@ -56,7 +56,7 @@
                     "filename": ""
                   }
                 }
-          },
+          }
           {
             "category": "product_version",
             "name": "v1.19.12-eks-9",

--- a/projects/golang/go/VulnerabilityManagement/eks-distro-golang-vex.json
+++ b/projects/golang/go/VulnerabilityManagement/eks-distro-golang-vex.json
@@ -26,7 +26,7 @@
           "summary": "Initial version."
         }
       ],
-      "status": "final",
+      "status": "draft",
       "version": "1"
     }
   },

--- a/projects/golang/go/VulnerabilityManagement/eks-distro-golang-vex.json
+++ b/projects/golang/go/VulnerabilityManagement/eks-distro-golang-vex.json
@@ -1,0 +1,101 @@
+{
+  "document": {
+    "category": "csaf_vex",
+    "csaf_version": "2.0",
+    "notes": [
+      {
+        "category": "summary",
+        "text": "VEX Document for AWS EKS Distribution Golang.",
+        "title": "EKS Golnag VEX"
+      }
+    ],
+    "publisher": {
+      "category": "vendor",
+      "name": "Amazon Web Services Inc",
+      "namespace": "https://aws.amazon.com/"
+    },
+    "title": "Vulnerability Tracking Document for AWS EKS Distro Golang",
+    "tracking": {
+      "current_release_date": "2023-08-28T11:00:00Z",
+      "id": "2023-08-EKS-D-GO",
+      "initial_release_date": "2023-08-28T11:00:00Z",
+      "revision_history": [
+        {
+          "date": "2023-08-28T11:00:00Z",
+          "number": "1",
+          "summary": "Initial version."
+        }
+      ],
+      "status": "final",
+      "version": "1"
+    }
+  },
+  "product_tree": {
+    "category": "vendor",
+    "name": "Amazon Web Services Inc",
+    "branches": [
+      {
+        "category": "product_name",
+        "name": "eks-distro-golang",
+        "branches": [
+          {
+            "category": "product_version",
+            "name": "v1.18.10-eks-8",
+            "product": {
+              "product_id": "eks-distro-golang:v1-18-10-eks-8",
+              "name": "Amazon EKS Distribution Golang version v1.18.10 EKS Release 8"
+            }
+          },
+          {
+            "category": "product_version",
+            "name": "v1.19.12-eks-9",
+            "product": {
+              "product_id": "eks-distro-golang:v1-19-12-eks-9",
+              "name": "Amazon EKS Distribution Golang version v1.19.12 EKS Release 9"
+            }
+          },
+          {
+            "category": "product_version",
+            "name": "v1.20.7-eks-8",
+            "product": {
+              "product_id": "eks-distro-golang:v1-20-7-eks-8",
+              "name": "Amazon EKS Distribution Golang version v1.20.7 release 8"
+            }
+          },
+          {
+            "category": "product_version",
+            "name": "v1.21.0-eks-0",
+            "product": {
+              "product_id": "eks-distro-golang:v1-21-0",
+              "name": "Amazon EKS Distribution Golang version v1.21.0 release 0"
+            }
+          }
+        ]
+      }
+    ]
+  },
+  "vulnerabilities": [
+    {
+      "cve": "CVE-2022-41723",
+      "notes": [
+        {
+          "category": "description",
+          "text": "A maliciously crafted HTTP/2 stream could cause excessive CPU consumption in the HPACK decoder, sufficient to cause a denial of service from a small number of small requests.",
+          "title": "CVE description"
+        }
+      ],
+      "product_status": {
+        "fixed": [
+          "eks-distro-golang:v1-18-10-eks-8"
+        ]
+      },
+      "references": [
+        {
+          "category": "external",
+          "summary": "NVD - CVE-2022-41723",
+          "url": "https://nvd.nist.gov/vuln/detail/cve-2022-41723"
+        }
+      ]
+    }
+  ]
+}

--- a/projects/golang/go/VulnerabilityManagement/eks-distro-golang-vex.json
+++ b/projects/golang/go/VulnerabilityManagement/eks-distro-golang-vex.json
@@ -43,15 +43,38 @@
             "name": "v1.18.10-eks-8",
             "product": {
               "product_id": "eks-distro-golang:v1-18-10-eks-8",
-              "name": "Amazon EKS Distribution Golang version v1.18.10 EKS Release 8"
-            }
+              "name": "Amazon EKS Distribution Golang version v1.18.10 EKS Release 8",
+              "product_identification_helper": {
+                "hashes": [
+                  {
+                    "file_hashes": [
+                      {
+                        "algorithm": "",
+                        "value": ""
+                      }
+                    ],
+                    "filename": ""
+                  }
+                }
           },
           {
             "category": "product_version",
             "name": "v1.19.12-eks-9",
             "product": {
               "product_id": "eks-distro-golang:v1-19-12-eks-9",
-              "name": "Amazon EKS Distribution Golang version v1.19.12 EKS Release 9"
+              "name": "Amazon EKS Distribution Golang version v1.19.12 EKS Release 9",
+              "product_identification_helper": {
+                "hashes": [
+                  {
+                    "file_hashes": [
+                      {
+                        "algorithm": "",
+                        "value": ""
+                      }
+                    ],
+                    "filename": ""
+                  }
+                }
             }
           },
           {
@@ -59,7 +82,19 @@
             "name": "v1.20.7-eks-8",
             "product": {
               "product_id": "eks-distro-golang:v1-20-7-eks-8",
-              "name": "Amazon EKS Distribution Golang version v1.20.7 EKS release 8"
+              "name": "Amazon EKS Distribution Golang version v1.20.7 EKS release 8",
+              "product_identification_helper": {
+                "hashes": [
+                  {
+                    "file_hashes": [
+                      {
+                        "algorithm": "",
+                        "value": ""
+                      }
+                    ],
+                    "filename": ""
+                  }
+                }
             }
           },
           {
@@ -67,7 +102,19 @@
             "name": "v1.21.0-eks-0",
             "product": {
               "product_id": "eks-distro-golang:v1-21-0",
-              "name": "Amazon EKS Distribution Golang version v1.21.0 EKS release 0"
+              "name": "Amazon EKS Distribution Golang version v1.21.0 EKS release 0",
+              "product_identification_helper": {
+                "hashes": [
+                  {
+                    "file_hashes": [
+                      {
+                        "algorithm": "",
+                        "value": ""
+                      }
+                    ],
+                    "filename": ""
+                  }
+                }
             }
           }
         ]

--- a/projects/golang/go/VulnerabilityManagement/eks-distro-golang-vex.json
+++ b/projects/golang/go/VulnerabilityManagement/eks-distro-golang-vex.json
@@ -49,14 +49,15 @@
                   {
                     "file_hashes": [
                       {
-                        "algorithm": "",
+                        "algorithm": "sha256",
                         "value": ""
                       }
                     ],
                     "filename": ""
-                  }
+                  }]
                 }
-          }
+              }
+          },
           {
             "category": "product_version",
             "name": "v1.19.12-eks-9",
@@ -68,12 +69,12 @@
                   {
                     "file_hashes": [
                       {
-                        "algorithm": "",
+                        "algorithm": "sha256",
                         "value": ""
                       }
                     ],
                     "filename": ""
-                  }
+                  }]
                 }
             }
           },
@@ -88,12 +89,12 @@
                   {
                     "file_hashes": [
                       {
-                        "algorithm": "",
+                        "algorithm": "sha256",
                         "value": ""
                       }
                     ],
                     "filename": ""
-                  }
+                  }]
                 }
             }
           },
@@ -108,12 +109,12 @@
                   {
                     "file_hashes": [
                       {
-                        "algorithm": "",
+                        "algorithm": "sha256",
                         "value": ""
                       }
                     ],
                     "filename": ""
-                  }
+                  }]
                 }
             }
           }

--- a/projects/golang/go/VulnerabilityManagement/eks-distro-golang-vex.json
+++ b/projects/golang/go/VulnerabilityManagement/eks-distro-golang-vex.json
@@ -59,7 +59,7 @@
             "name": "v1.20.7-eks-8",
             "product": {
               "product_id": "eks-distro-golang:v1-20-7-eks-8",
-              "name": "Amazon EKS Distribution Golang version v1.20.7 release 8"
+              "name": "Amazon EKS Distribution Golang version v1.20.7 EKS release 8"
             }
           },
           {

--- a/projects/golang/go/VulnerabilityManagement/eks-distro-golang-vex.json
+++ b/projects/golang/go/VulnerabilityManagement/eks-distro-golang-vex.json
@@ -43,39 +43,15 @@
             "name": "v1.18.10-eks-8",
             "product": {
               "product_id": "eks-distro-golang:v1-18-10-eks-8",
-              "name": "Amazon EKS Distribution Golang version v1.18.10 EKS Release 8",
-              "product_identification_helper": {
-                "hashes": [
-                  {
-                    "file_hashes": [
-                      {
-                        "algorithm": "sha256",
-                        "value": ""
-                      }
-                    ],
-                    "filename": ""
-                  }]
-                }
-              }
+              "name": "Amazon EKS Distribution Golang version v1.18.10 EKS Release 8"
+            }
           },
           {
             "category": "product_version",
             "name": "v1.19.12-eks-9",
             "product": {
               "product_id": "eks-distro-golang:v1-19-12-eks-9",
-              "name": "Amazon EKS Distribution Golang version v1.19.12 EKS Release 9",
-              "product_identification_helper": {
-                "hashes": [
-                  {
-                    "file_hashes": [
-                      {
-                        "algorithm": "sha256",
-                        "value": ""
-                      }
-                    ],
-                    "filename": ""
-                  }]
-                }
+              "name": "Amazon EKS Distribution Golang version v1.19.12 EKS Release 9"
             }
           },
           {
@@ -83,19 +59,7 @@
             "name": "v1.20.7-eks-8",
             "product": {
               "product_id": "eks-distro-golang:v1-20-7-eks-8",
-              "name": "Amazon EKS Distribution Golang version v1.20.7 EKS release 8",
-              "product_identification_helper": {
-                "hashes": [
-                  {
-                    "file_hashes": [
-                      {
-                        "algorithm": "sha256",
-                        "value": ""
-                      }
-                    ],
-                    "filename": ""
-                  }]
-                }
+              "name": "Amazon EKS Distribution Golang version v1.20.7 EKS release 8"
             }
           },
           {
@@ -103,19 +67,7 @@
             "name": "v1.21.0-eks-0",
             "product": {
               "product_id": "eks-distro-golang:v1-21-0",
-              "name": "Amazon EKS Distribution Golang version v1.21.0 EKS release 0",
-              "product_identification_helper": {
-                "hashes": [
-                  {
-                    "file_hashes": [
-                      {
-                        "algorithm": "sha256",
-                        "value": ""
-                      }
-                    ],
-                    "filename": ""
-                  }]
-                }
+              "name": "Amazon EKS Distribution Golang version v1.21.0 EKS release 0"
             }
           }
         ]


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Initial commit adding a baisc VEX (vulnerability eXchange) document for EKS Go (see https://github.com/oasis-tcs/csaf/blob/master/csaf_2.0/prose/csaf-v2-editor-draft.md). We can use this to track what CVEs are fixed where and then filter them out of GoVulnCheck etc

Only have one CVE in here right now will add more once this is looking good

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
