### PR TITLE
Fix yaml parsing issue in pod-identity-webhook

### DIFF
--- a/helm-charts/stable/amazon-eks-pod-identity-webhook/Chart.yaml
+++ b/helm-charts/stable/amazon-eks-pod-identity-webhook/Chart.yaml
@@ -29,7 +29,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.16
+version: 1.0.17
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm-charts/stable/amazon-eks-pod-identity-webhook/templates/Deployment.yaml
+++ b/helm-charts/stable/amazon-eks-pod-identity-webhook/templates/Deployment.yaml
@@ -17,16 +17,16 @@ kind: Deployment
 metadata:
   name: {{ include "amazon-eks-pod-identity-webhook.fullname" . }}
   labels:
-{{- include "amazon-eks-pod-identity-webhook.labels" . | nindent 8 }}
+    {{- include "amazon-eks-pod-identity-webhook.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:
-{{- include "amazon-eks-pod-identity-webhook.selectorLabels" . | nindent 12 }}
+      {{- include "amazon-eks-pod-identity-webhook.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       labels:
-{{- include "amazon-eks-pod-identity-webhook.selectorLabels" . | nindent 16 }}
+        {{- include "amazon-eks-pod-identity-webhook.selectorLabels" . | nindent 8 }}
     spec:
       serviceAccountName: {{ include "amazon-eks-pod-identity-webhook.fullname" . }}
       {{- if .Values.fargate }}
@@ -85,10 +85,10 @@ spec:
   secretName: {{ include "amazon-eks-pod-identity-webhook.secretName" . }} 
   commonName: "pod-identity-webhook.default.svc"
   dnsNames:
-  {{- include "amazon-eks-pod-identity-webhook.fullname" . }} 
-  {{- include "amazon-eks-pod-identity-webhook.fullname" . }}".default" 
-  {{- include "amazon-eks-pod-identity-webhook.fullname" . }}".default.svc"
-  {{- include "amazon-eks-pod-identity-webhook.fullname" . }}".default.svc.local"
+    {{- include "amazon-eks-pod-identity-webhook.fullname" . | nindent 4 }}
+    {{- include "amazon-eks-pod-identity-webhook.fullname" . | nindent 4 }}.default
+    {{- include "amazon-eks-pod-identity-webhook.fullname" . | nindent 4 }}.default.svc
+    {{- include "amazon-eks-pod-identity-webhook.fullname" . | nindent 4 }}.default.svc.local
   isCA: true
   duration: 2160h # 90d
   renewBefore: 360h # 15d


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
These changes were tested with `helm template`
Previously attempting to create the lines at dnsNames resulted in:
```
  dnsNames:eks-distro-pod-identity-webhookeks-distro-pod-identity-webhook".default"eks-distro-pod-identity-webhook".default.svc"eks-distro-pod-identity-webhook".default.svc.local"
```
After these changes:
```
  dnsNames:
    eks-distro-pod-identity-webhook
    eks-distro-pod-identity-webhook.default
    eks-distro-pod-identity-webhook.default.svc
    eks-distro-pod-identity-webhook.default.svc.local
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
