### PR TITLE
Restore eks-distro-minimal-base-iptables value

### DIFF
--- a/EKS_DISTRO_TAG_FILE.yaml
+++ b/EKS_DISTRO_TAG_FILE.yaml
@@ -44,7 +44,7 @@ al2023:
   eks-distro-minimal-base: 2023-08-24-1692903666.2023
   eks-distro-minimal-base-nonroot: 2023-08-24-1692903666.2023
   eks-distro-minimal-base-glibc: 2023-08-24-1692903666.2023
-  eks-distro-minimal-base-iptables: null
+  eks-distro-minimal-base-iptables: 2023-08-24-1692903666.2023
   eks-distro-minimal-base-docker-client: 2023-08-24-1692903666.2023
   eks-distro-minimal-base-csi: 2023-09-08-1694199666.2023
   eks-distro-minimal-base-csi-ebs: 2023-08-24-1692903666.2023


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Revert https://github.com/aws/eks-distro-build-tooling/pull/1165

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
