### PR TITLE
Update golang spec to include go env

### DIFF
--- a/projects/golang/go/1.21/rpmbuild/SPECS/golang.spec
+++ b/projects/golang/go/1.21/rpmbuild/SPECS/golang.spec
@@ -342,7 +342,7 @@ mkdir -p $RPM_BUILD_ROOT%{goroot}
 
 # install everything into libdir (until symlink problems are fixed)
 # https://code.google.com/p/go/issues/detail?id=5830
-cp -apv api bin doc lib pkg src misc test VERSION \
+cp -apv api bin doc lib pkg src misc test go.env VERSION \
    $RPM_BUILD_ROOT%{goroot}
 echo "== 2 =="
 # bz1099206
@@ -516,6 +516,7 @@ fi
 %{_bindir}/gofmt
 %{goroot}/bin/linux_%{gohostarch}/go
 %{goroot}/bin/linux_%{gohostarch}/gofmt
+%{goroot}/go.env
 
 %if %{shared}
 %files shared -f go-shared.list


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
update Go 1.21 spec to include the go.env in the go root during the build. Thx @jaxesn 

https://src.fedoraproject.org/rpms/golang/c/e1a400ab5f64e0883f3516f49f8d7e25dcdd9449?branch=rawhide

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
