### PR TITLE
Add additional CVE entries to VEX document

### DIFF
--- a/projects/golang/go/VulnerabilityManagement/eks-distro-golang-vex.json
+++ b/projects/golang/go/VulnerabilityManagement/eks-distro-golang-vex.json
@@ -56,7 +56,7 @@
                     "filename": ""
                   }
                 }
-          },
+          }
           {
             "category": "product_version",
             "name": "v1.19.12-eks-9",

--- a/projects/golang/go/VulnerabilityManagement/eks-distro-golang-vex.json
+++ b/projects/golang/go/VulnerabilityManagement/eks-distro-golang-vex.json
@@ -43,15 +43,38 @@
             "name": "v1.18.10-eks-8",
             "product": {
               "product_id": "eks-distro-golang:v1-18-10-eks-8",
-              "name": "Amazon EKS Distribution Golang version v1.18.10 EKS Release 8"
-            }
+              "name": "Amazon EKS Distribution Golang version v1.18.10 EKS Release 8",
+              "product_identification_helper": {
+                "hashes": [
+                  {
+                    "file_hashes": [
+                      {
+                        "algorithm": "",
+                        "value": ""
+                      }
+                    ],
+                    "filename": ""
+                  }
+                }
           },
           {
             "category": "product_version",
             "name": "v1.19.12-eks-9",
             "product": {
               "product_id": "eks-distro-golang:v1-19-12-eks-9",
-              "name": "Amazon EKS Distribution Golang version v1.19.12 EKS Release 9"
+              "name": "Amazon EKS Distribution Golang version v1.19.12 EKS Release 9",
+              "product_identification_helper": {
+                "hashes": [
+                  {
+                    "file_hashes": [
+                      {
+                        "algorithm": "",
+                        "value": ""
+                      }
+                    ],
+                    "filename": ""
+                  }
+                }
             }
           },
           {
@@ -59,7 +82,19 @@
             "name": "v1.20.7-eks-8",
             "product": {
               "product_id": "eks-distro-golang:v1-20-7-eks-8",
-              "name": "Amazon EKS Distribution Golang version v1.20.7 EKS release 8"
+              "name": "Amazon EKS Distribution Golang version v1.20.7 EKS release 8",
+              "product_identification_helper": {
+                "hashes": [
+                  {
+                    "file_hashes": [
+                      {
+                        "algorithm": "",
+                        "value": ""
+                      }
+                    ],
+                    "filename": ""
+                  }
+                }
             }
           },
           {
@@ -67,7 +102,19 @@
             "name": "v1.21.0-eks-0",
             "product": {
               "product_id": "eks-distro-golang:v1-21-0",
-              "name": "Amazon EKS Distribution Golang version v1.21.0 EKS release 0"
+              "name": "Amazon EKS Distribution Golang version v1.21.0 EKS release 0",
+              "product_identification_helper": {
+                "hashes": [
+                  {
+                    "file_hashes": [
+                      {
+                        "algorithm": "",
+                        "value": ""
+                      }
+                    ],
+                    "filename": ""
+                  }
+                }
             }
           }
         ]

--- a/projects/golang/go/VulnerabilityManagement/eks-distro-golang-vex.json
+++ b/projects/golang/go/VulnerabilityManagement/eks-distro-golang-vex.json
@@ -49,14 +49,15 @@
                   {
                     "file_hashes": [
                       {
-                        "algorithm": "",
+                        "algorithm": "sha256",
                         "value": ""
                       }
                     ],
                     "filename": ""
-                  }
+                  }]
                 }
-          }
+              }
+          },
           {
             "category": "product_version",
             "name": "v1.19.12-eks-9",
@@ -68,12 +69,12 @@
                   {
                     "file_hashes": [
                       {
-                        "algorithm": "",
+                        "algorithm": "sha256",
                         "value": ""
                       }
                     ],
                     "filename": ""
-                  }
+                  }]
                 }
             }
           },
@@ -88,12 +89,12 @@
                   {
                     "file_hashes": [
                       {
-                        "algorithm": "",
+                        "algorithm": "sha256",
                         "value": ""
                       }
                     ],
                     "filename": ""
-                  }
+                  }]
                 }
             }
           },
@@ -108,12 +109,12 @@
                   {
                     "file_hashes": [
                       {
-                        "algorithm": "",
+                        "algorithm": "sha256",
                         "value": ""
                       }
                     ],
                     "filename": ""
-                  }
+                  }]
                 }
             }
           }

--- a/projects/golang/go/VulnerabilityManagement/eks-distro-golang-vex.json
+++ b/projects/golang/go/VulnerabilityManagement/eks-distro-golang-vex.json
@@ -43,39 +43,15 @@
             "name": "v1.18.10-eks-8",
             "product": {
               "product_id": "eks-distro-golang:v1-18-10-eks-8",
-              "name": "Amazon EKS Distribution Golang version v1.18.10 EKS Release 8",
-              "product_identification_helper": {
-                "hashes": [
-                  {
-                    "file_hashes": [
-                      {
-                        "algorithm": "sha256",
-                        "value": ""
-                      }
-                    ],
-                    "filename": ""
-                  }]
-                }
-              }
+              "name": "Amazon EKS Distribution Golang version v1.18.10 EKS Release 8"
+            }
           },
           {
             "category": "product_version",
             "name": "v1.19.12-eks-9",
             "product": {
               "product_id": "eks-distro-golang:v1-19-12-eks-9",
-              "name": "Amazon EKS Distribution Golang version v1.19.12 EKS Release 9",
-              "product_identification_helper": {
-                "hashes": [
-                  {
-                    "file_hashes": [
-                      {
-                        "algorithm": "sha256",
-                        "value": ""
-                      }
-                    ],
-                    "filename": ""
-                  }]
-                }
+              "name": "Amazon EKS Distribution Golang version v1.19.12 EKS Release 9"
             }
           },
           {
@@ -83,19 +59,7 @@
             "name": "v1.20.7-eks-8",
             "product": {
               "product_id": "eks-distro-golang:v1-20-7-eks-8",
-              "name": "Amazon EKS Distribution Golang version v1.20.7 EKS release 8",
-              "product_identification_helper": {
-                "hashes": [
-                  {
-                    "file_hashes": [
-                      {
-                        "algorithm": "sha256",
-                        "value": ""
-                      }
-                    ],
-                    "filename": ""
-                  }]
-                }
+              "name": "Amazon EKS Distribution Golang version v1.20.7 EKS release 8"
             }
           },
           {
@@ -103,19 +67,7 @@
             "name": "v1.21.0-eks-0",
             "product": {
               "product_id": "eks-distro-golang:v1-21-0",
-              "name": "Amazon EKS Distribution Golang version v1.21.0 EKS release 0",
-              "product_identification_helper": {
-                "hashes": [
-                  {
-                    "file_hashes": [
-                      {
-                        "algorithm": "sha256",
-                        "value": ""
-                      }
-                    ],
-                    "filename": ""
-                  }]
-                }
+              "name": "Amazon EKS Distribution Golang version v1.21.0 EKS release 0"
             }
           }
         ]

--- a/projects/golang/go/VulnerabilityManagement/eks-distro-golang-vex.json
+++ b/projects/golang/go/VulnerabilityManagement/eks-distro-golang-vex.json
@@ -96,6 +96,72 @@
           "url": "https://nvd.nist.gov/vuln/detail/cve-2022-41723"
         }
       ]
+    },
+    {
+      "cve": "CVE-2022-41724",
+      "notes": [
+        {
+          "category": "description",
+          "text": "Large handshake records may cause panics in crypto/tls. Both clients and servers may send large TLS handshake records which cause servers and clients, respectively, to panic when attempting to construct responses. This affects all TLS 1.3 clients, TLS 1.2 clients which explicitly enable session resumption (by setting Config.ClientSessionCache to a non-nil value), and TLS 1.3 servers which request client certificates (by setting Config.ClientAuth >= RequestClientCert).",
+          "title": "CVE description"
+        }
+      ],
+      "product_status": {
+        "fixed": [
+          "eks-distro-golang:v1-18-10-eks-8"
+        ]
+      },
+      "references": [
+        {
+          "category": "external",
+          "summary": "NVD - CVE-2022-41724",
+          "url": "https://nvd.nist.gov/vuln/detail/cve-2022-41724"
+        }
+      ]
+    },
+    {
+      "cve": "CVE-2023-39318",
+      "notes": [
+        {
+          "category": "description",
+          "text": "The html/template package does not properly handle HTML-like \"\" comment tokens, nor hashbang \"#!\" comment tokens, in <script> contexts. This may cause the template parser to improperly interpret the contents of <script> contexts, causing actions to be improperly escaped. This may be leveraged to perform an XSS attack.",
+          "title": "CVE description"
+        }
+      ],
+      "product_status": {
+        "fixed": [
+          "eks-distro-golang:v1-19-12-eks-10"
+        ]
+      },
+      "references": [
+        {
+          "category": "external",
+          "summary": "NVD - CVE-2023-39318",
+          "url": "https://nvd.nist.gov/vuln/detail/cve-2023-39318"
+        }
+      ]
+    },
+    {
+      "cve": "CVE-2023-39319",
+      "notes": [
+        {
+          "category": "description",
+          "text": "The html/template package does not apply the proper rules for handling occurrences of \"<script\", \"<!--\", and \"</script\" within JS literals in <script> contexts. This may cause the template parser to improperly consider script contexts to be terminated early, causing actions to be improperly escaped. This could be leveraged to perform an XSS attack.",
+          "title": "CVE description"
+        }
+      ],
+      "product_status": {
+        "fixed": [
+          "eks-distro-golang:v1-19-12-eks-10"
+        ]
+      },
+      "references": [
+        {
+          "category": "external",
+          "summary": "NVD - CVE-2023-39318",
+          "url": "https://nvd.nist.gov/vuln/detail/cve-2023-39319"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
add additional 1.18 and 1.19 CVEs to VEX document for testing

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
