### PR TITLE
fixes attribution retry logic

### DIFF
--- a/generate-attribution/package-lock.json
+++ b/generate-attribution/package-lock.json
@@ -5,32 +5,35 @@
   "packages": {
     "": {
       "dependencies": {
-        "async-retry": "^1.3.1",
-        "csv-parse": "^4.14.1",
-        "follow-redirects": "^1.14.8",
-        "glob": "^8.0.3",
-        "glob-promise": "^5.0.0",
-        "node-html-parser": "^2.0.0"
+        "async-retry": "^1.3.3",
+        "csv-parse": "^5.5.2",
+        "follow-redirects": "^1.15.3",
+        "glob": "^8.1.0",
+        "glob-promise": "^6.0.5",
+        "node-html-parser": "^6.1.10"
       }
     },
     "node_modules/@types/glob": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.2.0.tgz",
-      "integrity": "sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-8.1.0.tgz",
+      "integrity": "sha512-IO+MJPVhoqz+28h1qLAcBEH2+xHMK6MTyHJc7MTnnYb6wsoLR29POVGJ7LycmVXIqyy/4/2ShP5sUwTXuOwb/w==",
       "dependencies": {
-        "@types/minimatch": "*",
+        "@types/minimatch": "^5.1.2",
         "@types/node": "*"
       }
     },
     "node_modules/@types/minimatch": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.5.tgz",
-      "integrity": "sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ=="
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-5.1.2.tgz",
+      "integrity": "sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA=="
     },
     "node_modules/@types/node": {
-      "version": "18.6.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.6.3.tgz",
-      "integrity": "sha512-6qKpDtoaYLM+5+AFChLhHermMQxc3TOEFIDzrZLPRGHPrLEwqFkkT5Kx3ju05g6X7uDPazz3jHbKPX0KzCjntg=="
+      "version": "20.8.6",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.8.6.tgz",
+      "integrity": "sha512-eWO4K2Ji70QzKUqRy6oyJWUeB7+g2cRagT3T/nxYibYcT4y2BDL8lqolRXjTHmkZCdJfIPaY73KbJAZmcryxTQ==",
+      "dependencies": {
+        "undici-types": "~5.25.1"
+      }
     },
     "node_modules/async-retry": {
       "version": "1.3.3",
@@ -45,6 +48,11 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
+    "node_modules/boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww=="
+    },
     "node_modules/brace-expansion": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
@@ -53,15 +61,103 @@
         "balanced-match": "^1.0.0"
       }
     },
+    "node_modules/css-select": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.1.0.tgz",
+      "integrity": "sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.1.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "nth-check": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-what": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.1.0.tgz",
+      "integrity": "sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==",
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
     "node_modules/csv-parse": {
-      "version": "4.16.3",
-      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-4.16.3.tgz",
-      "integrity": "sha512-cO1I/zmz4w2dcKHVvpCr7JVRu8/FymG5OEpmvsZYlccYolPBLoVGKUHgNoc4ZGkFeFlWGEDmMyBM+TTqRdW/wg=="
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-5.5.2.tgz",
+      "integrity": "sha512-YRVtvdtUNXZCMyK5zd5Wty1W6dNTpGKdqQd4EQ8tl/c6KW1aMBB1Kg1ppky5FONKmEqGJ/8WjLlTNLPne4ioVA=="
+    },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ]
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.1.0.tgz",
+      "integrity": "sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.1",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.1.tgz",
-      "integrity": "sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA==",
+      "version": "1.15.3",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.3.tgz",
+      "integrity": "sha512-1VzOtuEM8pC9SFU1E+8KfTjZyMztRsgEfwQl44z8A25uy13jSzTj6dyK2Df52iV0vgHCfBwLhDWevLn95w5v6Q==",
       "funding": [
         {
           "type": "individual",
@@ -83,9 +179,9 @@
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
     },
     "node_modules/glob": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-8.0.3.tgz",
-      "integrity": "sha512-ull455NHSHI/Y1FqGaaYFaLGkNMMJbavMrEGFXG/PGrg6y7sutWHUHrz6gy6WEBH6akM1M414dWKCNs+IhKdiQ==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
+      "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -101,14 +197,14 @@
       }
     },
     "node_modules/glob-promise": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/glob-promise/-/glob-promise-5.0.0.tgz",
-      "integrity": "sha512-YQ7+beqmmQ3yUzybHoxnj7XMImztIdusIFate36/aB1gEWugR1qZI9a2u1A5mt6gYRqYldipZ7NB9s1UEq3vzw==",
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/glob-promise/-/glob-promise-6.0.5.tgz",
+      "integrity": "sha512-uUzvxo60yo/vMLXZHCNAlfdM5U5A07jCnUO8xTK44Z0Vc58poGDXhDx8ju1DmPdprOORh+4Lpog64hl+AJ5piA==",
       "dependencies": {
-        "@types/glob": "^7.2.0"
+        "@types/glob": "^8.0.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=16"
       },
       "funding": {
         "type": "individual",
@@ -141,9 +237,9 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "node_modules/minimatch": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.0.tgz",
-      "integrity": "sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==",
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
@@ -152,11 +248,23 @@
       }
     },
     "node_modules/node-html-parser": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/node-html-parser/-/node-html-parser-2.2.1.tgz",
-      "integrity": "sha512-Vccqb62t6t7DkMVwqPQgb0NWO+gUMMDm+1X3LzqbtXLqjilCTtUYTlniKk08yuA1zIhEFVzu/dozpqs5KZbRFQ==",
+      "version": "6.1.10",
+      "resolved": "https://registry.npmjs.org/node-html-parser/-/node-html-parser-6.1.10.tgz",
+      "integrity": "sha512-6/uWdWxjQWQ7tMcFK2wWlrflsQUzh1HsEzlIf2j5+TtzfhT2yUvg3DwZYAmjEHeR3uX74ko7exjHW69J0tOzIg==",
       "dependencies": {
+        "css-select": "^5.1.0",
         "he": "1.2.0"
+      }
+    },
+    "node_modules/nth-check": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+      "dependencies": {
+        "boolbase": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
       }
     },
     "node_modules/once": {
@@ -175,6 +283,11 @@
         "node": ">= 4"
       }
     },
+    "node_modules/undici-types": {
+      "version": "5.25.3",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.25.3.tgz",
+      "integrity": "sha512-Ga1jfYwRn7+cP9v8auvEXN1rX3sWqlayd4HP7OKk4mZWylEmu3KzXDUGrQUN6Ol7qo1gPvB2e5gX6udnyEPgdA=="
+    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
@@ -183,23 +296,26 @@
   },
   "dependencies": {
     "@types/glob": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.2.0.tgz",
-      "integrity": "sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-8.1.0.tgz",
+      "integrity": "sha512-IO+MJPVhoqz+28h1qLAcBEH2+xHMK6MTyHJc7MTnnYb6wsoLR29POVGJ7LycmVXIqyy/4/2ShP5sUwTXuOwb/w==",
       "requires": {
-        "@types/minimatch": "*",
+        "@types/minimatch": "^5.1.2",
         "@types/node": "*"
       }
     },
     "@types/minimatch": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.5.tgz",
-      "integrity": "sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ=="
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-5.1.2.tgz",
+      "integrity": "sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA=="
     },
     "@types/node": {
-      "version": "18.6.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.6.3.tgz",
-      "integrity": "sha512-6qKpDtoaYLM+5+AFChLhHermMQxc3TOEFIDzrZLPRGHPrLEwqFkkT5Kx3ju05g6X7uDPazz3jHbKPX0KzCjntg=="
+      "version": "20.8.6",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.8.6.tgz",
+      "integrity": "sha512-eWO4K2Ji70QzKUqRy6oyJWUeB7+g2cRagT3T/nxYibYcT4y2BDL8lqolRXjTHmkZCdJfIPaY73KbJAZmcryxTQ==",
+      "requires": {
+        "undici-types": "~5.25.1"
+      }
     },
     "async-retry": {
       "version": "1.3.3",
@@ -214,6 +330,11 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
+    "boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww=="
+    },
     "brace-expansion": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
@@ -222,15 +343,70 @@
         "balanced-match": "^1.0.0"
       }
     },
+    "css-select": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.1.0.tgz",
+      "integrity": "sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==",
+      "requires": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.1.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "nth-check": "^2.0.1"
+      }
+    },
+    "css-what": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.1.0.tgz",
+      "integrity": "sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw=="
+    },
     "csv-parse": {
-      "version": "4.16.3",
-      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-4.16.3.tgz",
-      "integrity": "sha512-cO1I/zmz4w2dcKHVvpCr7JVRu8/FymG5OEpmvsZYlccYolPBLoVGKUHgNoc4ZGkFeFlWGEDmMyBM+TTqRdW/wg=="
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-5.5.2.tgz",
+      "integrity": "sha512-YRVtvdtUNXZCMyK5zd5Wty1W6dNTpGKdqQd4EQ8tl/c6KW1aMBB1Kg1ppky5FONKmEqGJ/8WjLlTNLPne4ioVA=="
+    },
+    "dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "requires": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      }
+    },
+    "domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw=="
+    },
+    "domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "requires": {
+        "domelementtype": "^2.3.0"
+      }
+    },
+    "domutils": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.1.0.tgz",
+      "integrity": "sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==",
+      "requires": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      }
+    },
+    "entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="
     },
     "follow-redirects": {
-      "version": "1.15.1",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.1.tgz",
-      "integrity": "sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA=="
+      "version": "1.15.3",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.3.tgz",
+      "integrity": "sha512-1VzOtuEM8pC9SFU1E+8KfTjZyMztRsgEfwQl44z8A25uy13jSzTj6dyK2Df52iV0vgHCfBwLhDWevLn95w5v6Q=="
     },
     "fs.realpath": {
       "version": "1.0.0",
@@ -238,9 +414,9 @@
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
     },
     "glob": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-8.0.3.tgz",
-      "integrity": "sha512-ull455NHSHI/Y1FqGaaYFaLGkNMMJbavMrEGFXG/PGrg6y7sutWHUHrz6gy6WEBH6akM1M414dWKCNs+IhKdiQ==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
+      "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -250,11 +426,11 @@
       }
     },
     "glob-promise": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/glob-promise/-/glob-promise-5.0.0.tgz",
-      "integrity": "sha512-YQ7+beqmmQ3yUzybHoxnj7XMImztIdusIFate36/aB1gEWugR1qZI9a2u1A5mt6gYRqYldipZ7NB9s1UEq3vzw==",
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/glob-promise/-/glob-promise-6.0.5.tgz",
+      "integrity": "sha512-uUzvxo60yo/vMLXZHCNAlfdM5U5A07jCnUO8xTK44Z0Vc58poGDXhDx8ju1DmPdprOORh+4Lpog64hl+AJ5piA==",
       "requires": {
-        "@types/glob": "^7.2.0"
+        "@types/glob": "^8.0.0"
       }
     },
     "he": {
@@ -277,19 +453,28 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "minimatch": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.0.tgz",
-      "integrity": "sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==",
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
       "requires": {
         "brace-expansion": "^2.0.1"
       }
     },
     "node-html-parser": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/node-html-parser/-/node-html-parser-2.2.1.tgz",
-      "integrity": "sha512-Vccqb62t6t7DkMVwqPQgb0NWO+gUMMDm+1X3LzqbtXLqjilCTtUYTlniKk08yuA1zIhEFVzu/dozpqs5KZbRFQ==",
+      "version": "6.1.10",
+      "resolved": "https://registry.npmjs.org/node-html-parser/-/node-html-parser-6.1.10.tgz",
+      "integrity": "sha512-6/uWdWxjQWQ7tMcFK2wWlrflsQUzh1HsEzlIf2j5+TtzfhT2yUvg3DwZYAmjEHeR3uX74ko7exjHW69J0tOzIg==",
       "requires": {
+        "css-select": "^5.1.0",
         "he": "1.2.0"
+      }
+    },
+    "nth-check": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+      "requires": {
+        "boolbase": "^1.0.0"
       }
     },
     "once": {
@@ -304,6 +489,11 @@
       "version": "0.13.1",
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
       "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg=="
+    },
+    "undici-types": {
+      "version": "5.25.3",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.25.3.tgz",
+      "integrity": "sha512-Ga1jfYwRn7+cP9v8auvEXN1rX3sWqlayd4HP7OKk4mZWylEmu3KzXDUGrQUN6Ol7qo1gPvB2e5gX6udnyEPgdA=="
     },
     "wrappy": {
       "version": "1.0.2",

--- a/generate-attribution/package.json
+++ b/generate-attribution/package.json
@@ -1,10 +1,10 @@
 {
   "dependencies": {
-    "async-retry": "^1.3.1",
-    "csv-parse": "^4.14.1",
-    "follow-redirects": "^1.14.8",
-    "glob": "^8.0.3",
-    "glob-promise": "^5.0.0",
-    "node-html-parser": "^2.0.0"
+    "async-retry": "^1.3.3",
+    "csv-parse": "^5.5.2",
+    "follow-redirects": "^1.15.3",
+    "glob": "^8.1.0",
+    "glob-promise": "^6.0.5",
+    "node-html-parser": "^6.1.10"
   }
 }

--- a/generate-attribution/tests/cases/containernetworking/plugins/ATTRIBUTION.txt
+++ b/generate-attribution/tests/cases/containernetworking/plugins/ATTRIBUTION.txt
@@ -308,7 +308,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 https://github.com/golang/go
 
 ** golang.org/x/sys/unix; version v0.0.0-20190616124812-15dcb6c0061f --
-https://go.googlesource.com/sys
+https://golang.org/x/sys
 
 Copyright (c) 2009 The Go Authors. All rights reserved.
 

--- a/generate-attribution/tests/cases/coredns/coredns/ATTRIBUTION.txt
+++ b/generate-attribution/tests/cases/coredns/coredns/ATTRIBUTION.txt
@@ -450,22 +450,22 @@ https://github.com/aws/aws-sdk-go
 https://github.com/golang/go
 
 ** golang.org/x/crypto; version v0.0.0-20201002170205-7f63de1d35b0 --
-https://go.googlesource.com/crypto
+https://golang.org/x/crypto
 
 ** golang.org/x/net; version v0.0.0-20200707034311-ab3426394381 --
-https://go.googlesource.com/net
+https://golang.org/x/net
 
 ** golang.org/x/oauth2; version v0.0.0-20200107190931-bf48bf16ab8d --
-https://go.googlesource.com/oauth2
+https://golang.org/x/oauth2
 
 ** golang.org/x/sys; version v0.0.0-20201015000850-e3ed0017c211 --
-https://go.googlesource.com/sys
+https://golang.org/x/sys
 
 ** golang.org/x/text; version v0.3.3 --
-https://go.googlesource.com/text
+https://golang.org/x/text
 
 ** golang.org/x/time/rate; version v0.0.0-20191024005414-555d28b269f0 --
-https://go.googlesource.com/time
+https://golang.org/x/time
 
 Copyright (c) 2009 The Go Authors. All rights reserved.
 
@@ -705,7 +705,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ------
 
 ** github.com/imdario/mergo; version v0.3.9 --
-https://github.com/imdario/mergo
+https://github.com/darccio/mergo
 
 Copyright (c) 2013 Dario Castañé. All rights reserved.
 Copyright (c) 2012 The Go Authors. All rights reserved.
@@ -845,7 +845,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ------
 
 ** golang.org/x/xerrors; version v0.0.0-20191204190536-9bdfabe68543 --
-https://go.googlesource.com/xerrors
+https://golang.org/x/xerrors
 
 Copyright (c) 2019 The Go Authors. All rights reserved.
 

--- a/generate-attribution/tests/cases/etcd-io/etcd/ATTRIBUTION.txt
+++ b/generate-attribution/tests/cases/etcd-io/etcd/ATTRIBUTION.txt
@@ -606,19 +606,19 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 https://github.com/golang/go
 
 ** golang.org/x/crypto; version v0.0.0-20190308221718-c2843e01d9a2 --
-https://go.googlesource.com/crypto
+https://golang.org/x/crypto
 
 ** golang.org/x/net; version v0.0.0-20190813141303-74dc4d7220e7 --
-https://go.googlesource.com/net
+https://golang.org/x/net
 
 ** golang.org/x/sys/unix; version v0.0.0-20190826190057-c7b8b68b1456 --
-https://go.googlesource.com/sys
+https://golang.org/x/sys
 
 ** golang.org/x/text; version v0.3.3 --
-https://go.googlesource.com/text
+https://golang.org/x/text
 
 ** golang.org/x/time/rate; version v0.0.0-20180412165947-fbb02b2291d2 --
-https://go.googlesource.com/time
+https://golang.org/x/time
 
 Copyright (c) 2009 The Go Authors. All rights reserved.
 

--- a/generate-attribution/tests/cases/fluxcd/source-controller/ATTRIBUTION.txt
+++ b/generate-attribution/tests/cases/fluxcd/source-controller/ATTRIBUTION.txt
@@ -1354,34 +1354,34 @@ https://github.com/ProtonMail/go-crypto
 https://github.com/golang/go
 
 ** golang.org/x/crypto; version v0.7.0 --
-https://go.googlesource.com/crypto
+https://golang.org/x/crypto
 
 ** golang.org/x/exp; version v0.0.0-20220823124025-807a23277127 --
-https://go.googlesource.com/exp
+https://golang.org/x/exp
 
 ** golang.org/x/mod/sumdb/note; version v0.9.0 --
-https://go.googlesource.com/mod
+https://golang.org/x/mod
 
 ** golang.org/x/net; version v0.8.0 --
-https://go.googlesource.com/net
+https://golang.org/x/net
 
 ** golang.org/x/oauth2; version v0.6.0 --
-https://go.googlesource.com/oauth2
+https://golang.org/x/oauth2
 
 ** golang.org/x/sync; version v0.1.0 --
-https://go.googlesource.com/sync
+https://golang.org/x/sync
 
 ** golang.org/x/sys; version v0.6.0 --
-https://go.googlesource.com/sys
+https://golang.org/x/sys
 
 ** golang.org/x/term; version v0.6.0 --
-https://go.googlesource.com/term
+https://golang.org/x/term
 
 ** golang.org/x/text; version v0.8.0 --
-https://go.googlesource.com/text
+https://golang.org/x/text
 
 ** golang.org/x/time/rate; version v0.3.0 --
-https://go.googlesource.com/time
+https://golang.org/x/time
 
 ** k8s.io/apimachinery/third_party/forked/golang; version v0.26.3 --
 https://github.com/kubernetes/apimachinery
@@ -1875,7 +1875,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ------
 
 ** github.com/imdario/mergo; version v0.3.13 --
-https://github.com/imdario/mergo
+https://github.com/darccio/mergo
 
 Copyright (c) 2013 Dario Castañé. All rights reserved.
 Copyright (c) 2012 The Go Authors. All rights reserved.
@@ -2152,7 +2152,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ------
 
 ** golang.org/x/xerrors; version v0.0.0-20220907171357-04be3eba64a2 --
-https://go.googlesource.com/xerrors
+https://golang.org/x/xerrors
 
 Copyright (c) 2019 The Go Authors. All rights reserved.
 

--- a/generate-attribution/tests/cases/kubernetes-csi/external-attacher/ATTRIBUTION.txt
+++ b/generate-attribution/tests/cases/kubernetes-csi/external-attacher/ATTRIBUTION.txt
@@ -529,7 +529,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ------
 
 ** github.com/imdario/mergo; version v0.3.9 --
-https://github.com/imdario/mergo
+https://github.com/darccio/mergo
 
 Copyright (c) 2013 Dario Castañé. All rights reserved.
 Copyright (c) 2012 The Go Authors. All rights reserved.
@@ -636,22 +636,22 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 https://github.com/golang/go
 
 ** golang.org/x/crypto/ssh/terminal; version v0.0.0-20200622213623-75b288015ac9 --
-https://go.googlesource.com/crypto
+https://golang.org/x/crypto
 
 ** golang.org/x/net; version v0.0.0-20200707034311-ab3426394381 --
-https://go.googlesource.com/net
+https://golang.org/x/net
 
 ** golang.org/x/oauth2; version v0.0.0-20191202225959-858c2ad4c8b6 --
-https://go.googlesource.com/oauth2
+https://golang.org/x/oauth2
 
 ** golang.org/x/sys; version v0.0.0-20200622214017-ed371f2e16b4 --
-https://go.googlesource.com/sys
+https://golang.org/x/sys
 
 ** golang.org/x/text; version v0.3.3 --
-https://go.googlesource.com/text
+https://golang.org/x/text
 
 ** golang.org/x/time/rate; version v0.0.0-20191024005414-555d28b269f0 --
-https://go.googlesource.com/time
+https://golang.org/x/time
 
 Copyright (c) 2009 The Go Authors. All rights reserved.
 

--- a/generate-attribution/tests/cases/kubernetes-csi/external-provisioner/ATTRIBUTION.txt
+++ b/generate-attribution/tests/cases/kubernetes-csi/external-provisioner/ATTRIBUTION.txt
@@ -574,7 +574,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ------
 
 ** github.com/imdario/mergo; version v0.3.9 --
-https://github.com/imdario/mergo
+https://github.com/darccio/mergo
 
 Copyright (c) 2013 Dario Castañé. All rights reserved.
 Copyright (c) 2012 The Go Authors. All rights reserved.
@@ -717,22 +717,22 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 https://github.com/golang/go
 
 ** golang.org/x/crypto; version v0.0.0-20200622213623-75b288015ac9 --
-https://go.googlesource.com/crypto
+https://golang.org/x/crypto
 
 ** golang.org/x/net; version v0.0.0-20200707034311-ab3426394381 --
-https://go.googlesource.com/net
+https://golang.org/x/net
 
 ** golang.org/x/oauth2; version v0.0.0-20200107190931-bf48bf16ab8d --
-https://go.googlesource.com/oauth2
+https://golang.org/x/oauth2
 
 ** golang.org/x/sys; version v0.0.0-20200622214017-ed371f2e16b4 --
-https://go.googlesource.com/sys
+https://golang.org/x/sys
 
 ** golang.org/x/text; version v0.3.3 --
-https://go.googlesource.com/text
+https://golang.org/x/text
 
 ** golang.org/x/time/rate; version v0.0.0-20200416051211-89c76fbcd5d1 --
-https://go.googlesource.com/time
+https://golang.org/x/time
 
 Copyright (c) 2009 The Go Authors. All rights reserved.
 

--- a/generate-attribution/tests/cases/kubernetes-csi/external-resizer/ATTRIBUTION.txt
+++ b/generate-attribution/tests/cases/kubernetes-csi/external-resizer/ATTRIBUTION.txt
@@ -469,7 +469,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ------
 
 ** github.com/imdario/mergo; version v0.3.9 --
-https://github.com/imdario/mergo
+https://github.com/darccio/mergo
 
 Copyright (c) 2013 Dario Castañé. All rights reserved.
 Copyright (c) 2012 The Go Authors. All rights reserved.
@@ -576,22 +576,22 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 https://github.com/golang/go
 
 ** golang.org/x/crypto/ssh/terminal; version v0.0.0-20200622213623-75b288015ac9 --
-https://go.googlesource.com/crypto
+https://golang.org/x/crypto
 
 ** golang.org/x/net; version v0.0.0-20200707034311-ab3426394381 --
-https://go.googlesource.com/net
+https://golang.org/x/net
 
 ** golang.org/x/oauth2; version v0.0.0-20191202225959-858c2ad4c8b6 --
-https://go.googlesource.com/oauth2
+https://golang.org/x/oauth2
 
 ** golang.org/x/sys; version v0.0.0-20200622214017-ed371f2e16b4 --
-https://go.googlesource.com/sys
+https://golang.org/x/sys
 
 ** golang.org/x/text; version v0.3.3 --
-https://go.googlesource.com/text
+https://golang.org/x/text
 
 ** golang.org/x/time/rate; version v0.0.0-20191024005414-555d28b269f0 --
-https://go.googlesource.com/time
+https://golang.org/x/time
 
 Copyright (c) 2009 The Go Authors. All rights reserved.
 

--- a/generate-attribution/tests/cases/kubernetes-csi/external-snapshotter/ATTRIBUTION.txt
+++ b/generate-attribution/tests/cases/kubernetes-csi/external-snapshotter/ATTRIBUTION.txt
@@ -469,7 +469,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ------
 
 ** github.com/imdario/mergo; version v0.3.9 --
-https://github.com/imdario/mergo
+https://github.com/darccio/mergo
 
 Copyright (c) 2013 Dario Castañé. All rights reserved.
 Copyright (c) 2012 The Go Authors. All rights reserved.
@@ -576,22 +576,22 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 https://github.com/golang/go
 
 ** golang.org/x/crypto/ssh/terminal; version v0.0.0-20200622213623-75b288015ac9 --
-https://go.googlesource.com/crypto
+https://golang.org/x/crypto
 
 ** golang.org/x/net; version v0.0.0-20200707034311-ab3426394381 --
-https://go.googlesource.com/net
+https://golang.org/x/net
 
 ** golang.org/x/oauth2; version v0.0.0-20200107190931-bf48bf16ab8d --
-https://go.googlesource.com/oauth2
+https://golang.org/x/oauth2
 
 ** golang.org/x/sys; version v0.0.0-20200622214017-ed371f2e16b4 --
-https://go.googlesource.com/sys
+https://golang.org/x/sys
 
 ** golang.org/x/text; version v0.3.3 --
-https://go.googlesource.com/text
+https://golang.org/x/text
 
 ** golang.org/x/time/rate; version v0.0.0-20200416051211-89c76fbcd5d1 --
-https://go.googlesource.com/time
+https://golang.org/x/time
 
 Copyright (c) 2009 The Go Authors. All rights reserved.
 

--- a/generate-attribution/tests/cases/kubernetes-csi/livenessprobe/ATTRIBUTION.txt
+++ b/generate-attribution/tests/cases/kubernetes-csi/livenessprobe/ATTRIBUTION.txt
@@ -379,13 +379,13 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 https://github.com/golang/go
 
 ** golang.org/x/net; version v0.0.0-20191209160850-c0dbc17a3553 --
-https://go.googlesource.com/net
+https://golang.org/x/net
 
 ** golang.org/x/sys/unix; version v0.0.0-20191220220014-0732a990476f --
-https://go.googlesource.com/sys
+https://golang.org/x/sys
 
 ** golang.org/x/text; version v0.3.3 --
-https://go.googlesource.com/text
+https://golang.org/x/text
 
 Copyright (c) 2009 The Go Authors. All rights reserved.
 

--- a/generate-attribution/tests/cases/kubernetes-csi/node-driver-registrar/ATTRIBUTION.txt
+++ b/generate-attribution/tests/cases/kubernetes-csi/node-driver-registrar/ATTRIBUTION.txt
@@ -304,13 +304,13 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 https://github.com/golang/go
 
 ** golang.org/x/net; version v0.0.0-20200707034311-ab3426394381 --
-https://go.googlesource.com/net
+https://golang.org/x/net
 
 ** golang.org/x/sys; version v0.0.0-20200622214017-ed371f2e16b4 --
-https://go.googlesource.com/sys
+https://golang.org/x/sys
 
 ** golang.org/x/text; version v0.3.3 --
-https://go.googlesource.com/text
+https://golang.org/x/text
 
 Copyright (c) 2009 The Go Authors. All rights reserved.
 

--- a/generate-attribution/tests/cases/kubernetes-sigs/aws-iam-authenticator/ATTRIBUTION.txt
+++ b/generate-attribution/tests/cases/kubernetes-sigs/aws-iam-authenticator/ATTRIBUTION.txt
@@ -389,22 +389,22 @@ https://github.com/aws/aws-sdk-go
 https://github.com/golang/go
 
 ** golang.org/x/crypto/ssh/terminal; version v0.0.0-20200220183623-bac4c82f6975 --
-https://go.googlesource.com/crypto
+https://golang.org/x/crypto
 
 ** golang.org/x/net; version v0.0.0-20200202094626-16171245cfb2 --
-https://go.googlesource.com/net
+https://golang.org/x/net
 
 ** golang.org/x/oauth2; version v0.0.0-20190604053449-0f29369cfe45 --
-https://go.googlesource.com/oauth2
+https://golang.org/x/oauth2
 
 ** golang.org/x/sys/unix; version v0.0.0-20190813064441-fde4db37ae7a --
-https://go.googlesource.com/sys
+https://golang.org/x/sys
 
 ** golang.org/x/text; version v0.3.2 --
-https://go.googlesource.com/text
+https://golang.org/x/text
 
 ** golang.org/x/time/rate; version v0.0.0-20190308202827-9d24e82272b4 --
-https://go.googlesource.com/time
+https://golang.org/x/time
 
 Copyright (c) 2009 The Go Authors. All rights reserved.
 
@@ -612,7 +612,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ------
 
 ** github.com/imdario/mergo; version v0.3.5 --
-https://github.com/imdario/mergo
+https://github.com/darccio/mergo
 
 Copyright (c) 2013 Dario Castañé. All rights reserved.
 Copyright (c) 2012 The Go Authors. All rights reserved.

--- a/generate-attribution/tests/cases/kubernetes-sigs/cri-tools/ATTRIBUTION.txt
+++ b/generate-attribution/tests/cases/kubernetes-sigs/cri-tools/ATTRIBUTION.txt
@@ -528,22 +528,22 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 https://github.com/golang/go
 
 ** golang.org/x/crypto/ssh/terminal; version v0.0.0-20201002170205-7f63de1d35b0 --
-https://go.googlesource.com/crypto
+https://golang.org/x/crypto
 
 ** golang.org/x/net; version v0.0.0-20201110031124-69a78807bb2b --
-https://go.googlesource.com/net
+https://golang.org/x/net
 
 ** golang.org/x/oauth2; version v0.0.0-20200107190931-bf48bf16ab8d --
-https://go.googlesource.com/oauth2
+https://golang.org/x/oauth2
 
 ** golang.org/x/sys; version v0.0.0-20201112073958-5cba982894dd --
-https://go.googlesource.com/sys
+https://golang.org/x/sys
 
 ** golang.org/x/text; version v0.3.4 --
-https://go.googlesource.com/text
+https://golang.org/x/text
 
 ** golang.org/x/time/rate; version v0.0.0-20200630173020-3af7569d3a1e --
-https://go.googlesource.com/time
+https://golang.org/x/time
 
 Copyright (c) 2009 The Go Authors. All rights reserved.
 

--- a/generate-attribution/tests/cases/kubernetes-sigs/metrics-server/ATTRIBUTION.txt
+++ b/generate-attribution/tests/cases/kubernetes-sigs/metrics-server/ATTRIBUTION.txt
@@ -621,7 +621,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ------
 
 ** github.com/imdario/mergo; version v0.3.5 --
-https://github.com/imdario/mergo
+https://github.com/darccio/mergo
 
 Copyright (c) 2013 Dario Castañé. All rights reserved.
 Copyright (c) 2012 The Go Authors. All rights reserved.
@@ -816,25 +816,25 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 https://github.com/golang/go
 
 ** golang.org/x/crypto; version v0.0.0-20200622213623-75b288015ac9 --
-https://go.googlesource.com/crypto
+https://golang.org/x/crypto
 
 ** golang.org/x/net; version v0.0.0-20200707034311-ab3426394381 --
-https://go.googlesource.com/net
+https://golang.org/x/net
 
 ** golang.org/x/oauth2; version v0.0.0-20191202225959-858c2ad4c8b6 --
-https://go.googlesource.com/oauth2
+https://golang.org/x/oauth2
 
 ** golang.org/x/sync/singleflight; version v0.0.0-20190911185100-cd5d95a43a6e --
-https://go.googlesource.com/sync
+https://golang.org/x/sync
 
 ** golang.org/x/sys; version v0.0.0-20200625212154-ddb9806d33ae --
-https://go.googlesource.com/sys
+https://golang.org/x/sys
 
 ** golang.org/x/text; version v0.3.3 --
-https://go.googlesource.com/text
+https://golang.org/x/text
 
 ** golang.org/x/time/rate; version v0.0.0-20191024005414-555d28b269f0 --
-https://go.googlesource.com/time
+https://golang.org/x/time
 
 Copyright (c) 2009 The Go Authors. All rights reserved.
 

--- a/generate-attribution/tests/cases/kubernetes/kubernetes-1-19/ATTRIBUTION.txt
+++ b/generate-attribution/tests/cases/kubernetes/kubernetes-1-19/ATTRIBUTION.txt
@@ -937,28 +937,28 @@ https://github.com/liggitt/tabwriter
 https://github.com/golang/go
 
 ** golang.org/x/crypto; version v0.0.0-20200622213623-75b288015ac9 --
-https://go.googlesource.com/crypto
+https://golang.org/x/crypto
 
 ** golang.org/x/net; version v0.0.0-20201110031124-69a78807bb2b --
-https://go.googlesource.com/net
+https://golang.org/x/net
 
 ** golang.org/x/oauth2; version v0.0.0-20191202225959-858c2ad4c8b6 --
-https://go.googlesource.com/oauth2
+https://golang.org/x/oauth2
 
 ** golang.org/x/sync/singleflight; version v0.0.0-20190911185100-cd5d95a43a6e --
-https://go.googlesource.com/sync
+https://golang.org/x/sync
 
 ** golang.org/x/sys; version v0.0.0-20201112073958-5cba982894dd --
-https://go.googlesource.com/sys
+https://golang.org/x/sys
 
 ** golang.org/x/text; version v0.3.3 --
-https://go.googlesource.com/text
+https://golang.org/x/text
 
 ** golang.org/x/time/rate; version v0.0.0-20191024005414-555d28b269f0 --
-https://go.googlesource.com/time
+https://golang.org/x/time
 
 ** golang.org/x/tools/container/intsets; version v0.0.0-20200616133436-c1934b75d054 --
-https://go.googlesource.com/tools
+https://golang.org/x/tools
 
 ** k8s.io/utils/inotify; version v0.0.0-20200729134348-d5654de09c73 --
 https://github.com/kubernetes/utils
@@ -1300,7 +1300,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ------
 
 ** github.com/imdario/mergo; version v0.3.5 --
-https://github.com/imdario/mergo
+https://github.com/darccio/mergo
 
 Copyright (c) 2013 Dario Castañé. All rights reserved.
 Copyright (c) 2012 The Go Authors. All rights reserved.
@@ -1930,7 +1930,7 @@ https://gopkg.in/natefinch/lumberjack.v2
 Copyright (c) 2014 Nate Finch 
 
 ** vbom.ml/util/sortorder; version v0.0.0-20160121211510-db5cfe13f5cc --
-https://github.com/fvbommel/util
+https://vbom.ml/util
 Copyright (c) 2015 Frits van Bommel
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

We will occasionally see timeouts when requesting the go-import url.  This code has largely been unchanged for 2 years, but turns out the retry logic was just wrong and when the timeouts would occur, they would sometimes result in uncaught exceptions.  This looks like a big change, but for the most part its just changing the old promise still methods to better utilize async/await and actually work in terms of retrying.

Since I was here, went ahead and updated the dependencies and updated some of the expected output files due to changes in upstream repo names.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
