### PR TITLE
adds ansible collections needed for image builds

### DIFF
--- a/builder-base/Dockerfile
+++ b/builder-base/Dockerfile
@@ -464,7 +464,6 @@ COPY --link --from=ecr-cred-helper /ecr-cred-helper /
 COPY --link --from=yq /yq /
 COPY --link --from=gh_cli /gh-cli /
 COPY --link --from=hugo /hugo /
-COPY --link --from=goss /goss /
 COPY --link --from=govc /govc /
 COPY --link --from=helm /helm /
 COPY --link --from=tuftool /tuftool /
@@ -474,6 +473,7 @@ COPY --link --from=skopeo /skopeo /
 
 FROM minimal-copy-stage as full-copy-stage
 
+COPY --link --from=goss /goss /
 COPY --link --from=packer /packer /
 COPY --link --from=ansible /ansible /
 COPY --link --from=nodejs /nodejs /


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This is something the eks-a image builder requires which has for all this time been downloaded at build time.  This upstream endpoint will go down from time to time, breaking builds unnecessarily. Baking these in will help with stability.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
