### PR TITLE
improves python 3.9 on al2 builder base

### DIFF
--- a/builder-base/Dockerfile
+++ b/builder-base/Dockerfile
@@ -199,27 +199,11 @@ RUN --mount=type=cache,target=/var/cache/yum,sharing=locked \
 
 # for al2 builds we pull python3.9 from the minimal image build since al2
 # does not ship 3.9
-FROM ${PYTHON_IMAGE} as python-3.9
-ARG ANSIBLE_VERSION
-ENV ANSIBLE_VERSION=$ANSIBLE_VERSION
-ARG PYWINRM_VERSION
-ENV PYWINRM_VERSION=$PYWINRM_VERSION
-RUN python3 -m ensurepip --upgrade && \
-    pip3 install --no-cache-dir ansible-core==$ANSIBLE_VERSION && \
-    pip3 install --no-cache-dir pywinrm==$PYWINRM_VERSION
-
-FROM ${BUILDER_IMAGE} as ansible-al2
-
-COPY --link --from=python-3.9 / /ansible
-# we want python2 to be the version symlinkd to python
-# we also do not want to overwrite the rpm db
-# this will leave the packages pulled in from the python image in
-# a slightly odd state in that they are installed yet not in the rpm db
-RUN set -x && \
-    unlink /ansible/usr/bin/python && \
-    rm -rf /var/lib/
+FROM ${PYTHON_IMAGE} as ansible-al2
 
 FROM ${BUILDER_IMAGE} as ansible-al2023
+
+FROM ansible-${AL_TAG} as ansible
 ARG TARGETARCH
 WORKDIR /workdir
 ARG ANSIBLE_VERSION
@@ -229,11 +213,7 @@ ENV PYWINRM_VERSION=$PYWINRM_VERSION
 COPY ./scripts/install_base_yum_packages.sh ./scripts/remove_yum_packages.sh ./scripts/common_vars.sh \
     ./scripts/install_ansible.sh /
 RUN --mount=type=cache,target=/var/cache/yum,sharing=locked \
-    /install_base_yum_packages.sh && \
-    /install_ansible.sh && \
-    /remove_yum_packages.sh
-
-FROM ansible-${AL_TAG} as ansible
+    /install_ansible.sh
 
 FROM ${BUILDER_IMAGE} as golang-1.16
 ARG TARGETARCH

--- a/builder-base/Makefile
+++ b/builder-base/Makefile
@@ -28,8 +28,8 @@ LATEST_IMAGE=$(shell echo $(LATEST_TAGS) | sed "s/ \+/,/g")
 BASE_IMAGE_REPO?=public.ecr.aws/eks-distro-build-tooling
 BASE_IMAGE_NAME?=eks-distro-minimal-base-kind
 BASE_IMAGE?=$(BASE_IMAGE_REPO)/$(BASE_IMAGE_NAME):$(call BASE_TAG_FROM_TAG_FILE,$(BASE_IMAGE_NAME))
-PYTHON_IMAGE_NAME?=eks-distro-minimal-base-python
-PYTHON_IMAGE?=$(BASE_IMAGE_REPO)/$(PYTHON_IMAGE_NAME):$(call BASE_TAG_FROM_TAG_FILE,$(PYTHON_IMAGE_NAME)-3.9)
+PYTHON_IMAGE_NAME?=python
+PYTHON_IMAGE?=$(BASE_IMAGE_REPO)/$(PYTHON_IMAGE_NAME):$(call BASE_TAG_FROM_TAG_FILE,eks-distro-minimal-base-python-compiler-3.9-yum)
 # using the minimal-base-builder as the base for the download/gcc stages of
 # this build since it doesnt change too often, limiting churn/rebuilds
 BUILDER_IMAGE_NAME?=eks-distro-minimal-base

--- a/builder-base/scripts/install_ansible.sh
+++ b/builder-base/scripts/install_ansible.sh
@@ -23,16 +23,11 @@ NEWROOT=/ansible
 source $SCRIPT_ROOT/common_vars.sh
 
 function instal_ansible() {
-    local -r deps="python3-pip"
-    yum install -y $deps
-
-    #################### IMAGE BUILDER ####################
-    # Install image-builder build dependencies - pip, Ansible, Packer
-    # Post upgrade, pip3 got renamed to pip and moved locations. It works completely with python3
-    # Symlinking pip3 to pip, to have pip3 commands work successfully
-    if [ "$IS_AL23" = "false" ]; then 
+    if [ "$IS_AL23" = "true" ]; then 
+        local -r deps="python3-pip"
+        yum install -y $deps
+    else
         pip3 install --no-cache-dir -U pip setuptools
-        ln -sf $USR_LOCAL_BIN/pip $USR_BIN/pip3
     fi
 
     ANSIBLE_VERSION="$ANSIBLE_VERSION"
@@ -43,6 +38,17 @@ function instal_ansible() {
     
     rm -rf ${NEWROOT}/usr/*
     mv /root/.local/* ${NEWROOT}/usr
+
+    if [ "$IS_AL23" = "false" ]; then 
+        # pulling only the python folders/bin we need
+        # follows list from minimal image Dockerfile.minimal-base-python
+        mkdir -p $NEWROOT/usr/lib/pkgconfig ${NEWROOT}/usr/{bin,include}
+        cp /usr/bin/{pip3,pip3.9,pydoc3.9,python3,python3.9,python3.9-config} ${NEWROOT}/usr/bin
+        cp -rf /usr/include/python3.9 ${NEWROOT}/usr/include
+        cp /usr/lib/pkgconfig/python-3.9*.pc ${NEWROOT}/usr/lib/pkgconfig
+        cp -rf /usr/lib/python3.9 ${NEWROOT}/usr/lib
+        cp --preserve=links /usr/lib/libpython3* ${NEWROOT}/usr/lib
+    fi
 
     rm -rf /root/.cache
 }

--- a/builder-base/scripts/install_final.sh
+++ b/builder-base/scripts/install_final.sh
@@ -65,16 +65,17 @@ if [ "${FINAL_STAGE_BASE}" = "full-copy-stage" ]; then
     yum install -y \
         gcc \
         openssl-devel \
-        pkgconfig 
+        pkgconfig
 
     # for building containerd
     yum install -y \
         glibc-static \
         libseccomp-static
 
-    # headers for btrfs do not exist in al23. well need to address this in the future
-    # if we want to build containerd with btrfs support on al23
-    if [ "$IS_AL23" = "false" ]; then 
+
+    if [ "$IS_AL23" = "false" ]; then
+        # headers for btrfs do not exist in al23. well need to address this in the future
+        # if we want to build containerd with btrfs support on al23
         yum install -y btrfs-progs-devel
     fi
 
@@ -98,6 +99,13 @@ if [ "${FINAL_STAGE_BASE}" = "full-copy-stage" ]; then
         community.windows
 
     chown -R imagebuilder:imagebuilder /home/imagebuilder
+
+    if [ "$IS_AL23" = "true" ]; then
+        yum install -y python3-pip python
+    else
+        # we built python3.9 from source, ensure libs are all installed
+        yum install -y zlib bzip2 readline sqlite openssl11 tk libffi xz
+    fi
     ##############################################
 fi
 

--- a/builder-base/scripts/validate_components.sh
+++ b/builder-base/scripts/validate_components.sh
@@ -42,6 +42,9 @@ skopeo --version
 
 # node + go + gcc are only included in the standard image
 if [ "${FINAL_STAGE_BASE}" = "full-copy-stage" ]; then
+    python --version
+    python3 --version
+    pip3 --version
     packer --version
     ansible --version
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

My first attempt at adding python3.9 to the al2 builder base was bad. It was copying the entire minimal python image root over top the builder base root. This seemed fine in theory, but since the builder rebuilds bash from source this copy was replacing the built bash 4.3 with the older 4.2. This causes issues in certain builds that require 4.3+.

This new approach targets the specific python bins/libs that we need instead of the whole root.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
