### PR TITLE
fixes ansible perms for imagebuilder user

### DIFF
--- a/builder-base/scripts/install_ansible.sh
+++ b/builder-base/scripts/install_ansible.sh
@@ -50,6 +50,8 @@ function instal_ansible() {
         cp --preserve=links /usr/lib/libpython3* ${NEWROOT}/usr/lib
     fi
 
+    chmod 755 ${NEWROOT}/usr/lib/python3.9/site-packages 
+
     rm -rf /root/.cache
 }
 

--- a/builder-base/scripts/install_final.sh
+++ b/builder-base/scripts/install_final.sh
@@ -35,6 +35,7 @@ yum install -y \
     bzip2 \
     cpio \
     curl \
+    diffutils \
     docker \
     gettext \
     git-core \

--- a/builder-base/scripts/validate_components.sh
+++ b/builder-base/scripts/validate_components.sh
@@ -47,6 +47,10 @@ if [ "${FINAL_STAGE_BASE}" = "full-copy-stage" ]; then
     pip3 --version
     packer --version
     ansible --version
+    su - imagebuilder -c "ansible --version"
+    su - imagebuilder -c "ansible-galaxy collection list"
+    su - imagebuilder -c "packer --version"
+    su - imagebuilder -c "packer plugins installed"
 
     node --version
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

In eks-a we use the imagebuilder user instead of root.  This consistently trips us up due to file perms. This fixes the perms and adds a simple validation to make sure the image builder user can run the tools installed with ansible.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
