### PR TITLE
fixes PR body when opening PRs in other repos for minimal images

### DIFF
--- a/eks-distro-base/update_base_image_other_repos.sh
+++ b/eks-distro-base/update_base_image_other_repos.sh
@@ -27,31 +27,31 @@ else
     ORIGIN_ORG=$REPO_OWNER
 fi
 
-EXTRA_PR_BODY=""
 
 REPOS=(eks-distro eks-anywhere-build-tooling eks-anywhere)
 for repo in "${REPOS[@]}"; do
     ${SCRIPT_ROOT}/../pr-scripts/update_local_branch.sh "$repo"
-done
-while IFS=, read -r key
-do
-    key=${key:2} # strip leading - space
-    while IFS=, read -r image
+
+    EXTRA_PR_BODY=""
+    while IFS=, read -r key
     do
-        image=${image:2} # strip leading - space
-        BASE_IMAGE_TAG_FILE="$(echo ${image^^} | tr '-' '_')_TAG_FILE"
+        key=${key:2} # strip leading - space
+        while IFS=, read -r image
+        do
+            image=${image:2} # strip leading - space
+            BASE_IMAGE_TAG_FILE="$(echo ${image^^} | tr '-' '_')_TAG_FILE"
 
-        if [[ "$key" == "al2023" ]]; then
-            BASE_IMAGE_TAG_FILE="$(echo ${image^^} | tr '-' '_')_AL2023_TAG_FILE"
-        fi
+            if [[ "$key" == "al2023" ]]; then
+                BASE_IMAGE_TAG_FILE="$(echo ${image^^} | tr '-' '_')_AL2023_TAG_FILE"
+            fi
 
-        IMAGE_TAG=$(yq e ".$key.\"$image\"" $SCRIPT_ROOT/../EKS_DISTRO_TAG_FILE.yaml)
-        # we will set the tag to null to trigger new builds. we dont want PRs being open setting
-        # tag file values to null
-        if [[ "${IMAGE_TAG}" = "null" ]]; then
-            continue
-        fi
-        for repo in "${REPOS[@]}"; do
+            IMAGE_TAG=$(yq e ".$key.\"$image\"" $SCRIPT_ROOT/../EKS_DISTRO_TAG_FILE.yaml)
+            # we will set the tag to null to trigger new builds. we dont want PRs being open setting
+            # tag file values to null
+            if [[ "${IMAGE_TAG}" = "null" ]]; then
+                continue
+            fi
+
             ${SCRIPT_ROOT}/../pr-scripts/update_image_tag.sh "$repo" '.*' $IMAGE_TAG $BASE_IMAGE_TAG_FILE
 
             if [ "$(git -C ${OTHER_CLONE_ROOT}/${ORIGIN_ORG}/${repo} status --porcelain -- $BASE_IMAGE_TAG_FILE | wc -l)" -gt 0 ]; then
@@ -60,10 +60,9 @@ do
                     EXTRA_PR_BODY+="\n${BASE_IMAGE_TAG_FILE}\nThe following yum packages were updated:\n\`\`\`bash\n${UPDATE_PACKAGES}\n\`\`\`\n"
                 fi
             fi
-        done
-    done < <(yq e ".$key | keys" $SCRIPT_ROOT/../EKS_DISTRO_TAG_FILE.yaml)
-done < <(yq e "keys" $SCRIPT_ROOT/../EKS_DISTRO_TAG_FILE.yaml)
 
-for repo in "${REPOS[@]}"; do
+        done < <(yq e ".$key | keys" $SCRIPT_ROOT/../EKS_DISTRO_TAG_FILE.yaml)
+    done < <(yq e "keys" $SCRIPT_ROOT/../EKS_DISTRO_TAG_FILE.yaml)
+
    ${SCRIPT_ROOT}/../pr-scripts/create_pr.sh "$repo" 'EKS_DISTRO*_TAG_FILE' "image-tag-update" "$EXTRA_PR_BODY"
 done

--- a/pr-scripts/create_pr.sh
+++ b/pr-scripts/create_pr.sh
@@ -77,7 +77,7 @@ else
 fi
 
 if [ -n "${EXTRA_PR_BODY}" ]; then
-    PR_BODY+="${EXTRA_PR_BODY}"
+    printf "${EXTRA_PR_BODY}" >> $PR_BODY_FILE
 fi
 
 # Adding this here to include the "do-not-merge/hold" label. Trying to use the gh client with the --label arg will not succeed


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Originally when PRs were opened like [this](https://github.com/aws/eks-anywhere-build-tooling/pull/2634) within the PR body the packages in the image which changed were included.  This code all still mostly exists, but at some point we broke it due to preparing the PR body in a file and reading the file in, overwriting the variable after we added the extra bit of body text.

I also tweaked the loop which creates these PRs so that the PR bodies only include the changes for the images which are used in that repo.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
