### PR TITLE
Correct a few issues with the golang tooling

### DIFF
--- a/tools/eksDistroBuildToolingOpsTools/pkg/eksGoRelease/githubRelease.go
+++ b/tools/eksDistroBuildToolingOpsTools/pkg/eksGoRelease/githubRelease.go
@@ -164,9 +164,9 @@ func bumpRelease(gClient git.Client, r *Release) error {
 		logger.Error(err, "Reading file", "file", releasePath)
 		return err
 	}
-	// We need to check there isn't a \n character if there is we only take the first value
-	if len(content) > 1 {
-		content = content[0:1]
+	// Check if there is a new line character at the end of the file, if so take all but the newline
+	if content[len(content)-1:] == "\n" {
+		content = content[0 : len(content)-1]
 	}
 	cr, err := strconv.Atoi(content)
 	if err != nil {
@@ -329,7 +329,7 @@ func createReleasePR(ctx context.Context, dryrun bool, r *Release, ghUser github
 		SourceOwner: ghUser.User(),
 		SourceRepo:  constants.EksdBuildToolingRepoName,
 		PrRepo:      constants.EksdBuildToolingRepoName,
-		PrRepoOwner: ghUser.User(),
+		PrRepoOwner: constants.AwsOrgName,
 	}
 	prm := prManager.New(retrier, githubClient, prmOpts)
 

--- a/tools/eksDistroBuildToolingOpsTools/pkg/eksGoRelease/versionReadmeFmt.txt
+++ b/tools/eksDistroBuildToolingOpsTools/pkg/eksGoRelease/versionReadmeFmt.txt
@@ -19,4 +19,4 @@ Tracking Tag: `go%s`
 The patches in `./patches` include relevant utility fixes for go `%s`.
 
 ### Spec
-The RPM spec file in `./rpmbuild/SPECS` is sourced from the go %s SRPM available on Fedora, and modified to include the relevant patches and build the `go%s` source."
+The RPM spec file in `./rpmbuild/SPECS` is sourced from the go %s SRPM available on Fedora, and modified to include the relevant patches and build the `go%s` source.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The logic for bumping releases needed to account for `\n`, but also had to account for larger releases. Revert the PR open repo to be `aws`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
