### PR TITLE
Add commitBranch variable to avoid duplicate prs

### DIFF
--- a/tools/eksDistroBuildToolingOpsTools/pkg/eksGoRelease/createPatch.go
+++ b/tools/eksDistroBuildToolingOpsTools/pkg/eksGoRelease/createPatch.go
@@ -44,7 +44,8 @@ func BackportToRelease(ctx context.Context, r *Release, dryrun bool, cve, commit
 	}
 
 	// Create new branch
-	if err := gClient.Branch(r.EksGoReleaseVersion()); err != nil {
+	commitBranch := r.EksGoReleaseVersion()
+	if err := gClient.Branch(commitBranch); err != nil {
 		logger.Error(err, "git branch", "branch name", r.EksGoReleaseVersion(), "repo", forkUrl, "client", gClient)
 		return err
 	}
@@ -72,7 +73,7 @@ func BackportToRelease(ctx context.Context, r *Release, dryrun bool, cve, commit
 		// no longer update gospec with patch file since no patch was created
 		if !dryrun {
 			prFailureDescription := fmt.Sprintf(backportPRDescriptionFailureFmt, cve, r.EksGoReleaseVersion(), commit)
-			if err := createReleasePR(ctx, dryrun, r, ghUser, gClient, prSubject, prFailureDescription, commitMsg); err != nil {
+			if err := createReleasePR(ctx, dryrun, r, ghUser, gClient, prSubject, prFailureDescription, commitMsg, commitBranch); err != nil {
 				logger.Error(err, "Create Release PR")
 				return err
 			}
@@ -81,7 +82,7 @@ func BackportToRelease(ctx context.Context, r *Release, dryrun bool, cve, commit
 
 	if !dryrun {
 		prSuccessDescription := fmt.Sprintf(backportPRDescriptionSuccessFmt, cve, commit, r.EksGoReleaseVersion())
-		if err := createReleasePR(ctx, dryrun, r, ghUser, gClient, prSubject, prSuccessDescription, commitMsg); err != nil {
+		if err := createReleasePR(ctx, dryrun, r, ghUser, gClient, prSubject, prSuccessDescription, commitMsg, commitBranch); err != nil {
 			logger.Error(err, "Create Release PR")
 		}
 	}

--- a/tools/eksDistroBuildToolingOpsTools/pkg/eksGoRelease/githubRelease.go
+++ b/tools/eksDistroBuildToolingOpsTools/pkg/eksGoRelease/githubRelease.go
@@ -311,7 +311,7 @@ func addTempFilesForNewMinorVersion(gClient git.Client, r *Release) error {
 	return nil
 }
 
-func createReleasePR(ctx context.Context, dryrun bool, r *Release, ghUser github.GitHubUser, gClient git.Client, prSubject, prDescription, commitMsg string) error {
+func createReleasePR(ctx context.Context, dryrun bool, r *Release, ghUser github.GitHubUser, gClient git.Client, prSubject, prDescription, commitMsg, commitBranch string) error {
 	if dryrun {
 		logger.V(3).Info("running in dryrun mode no pr created")
 		return nil
@@ -334,7 +334,7 @@ func createReleasePR(ctx context.Context, dryrun bool, r *Release, ghUser github
 	prm := prManager.New(retrier, githubClient, prmOpts)
 
 	prOpts := &prManager.CreatePrOpts{
-		CommitBranch:  r.EksGoReleaseVersion(),
+		CommitBranch:  commitBranch,
 		BaseBranch:    "main",
 		AuthorName:    ghUser.User(),
 		AuthorEmail:   ghUser.Email(),

--- a/tools/eksDistroBuildToolingOpsTools/pkg/eksGoRelease/newVersion.go
+++ b/tools/eksDistroBuildToolingOpsTools/pkg/eksGoRelease/newVersion.go
@@ -37,7 +37,8 @@ func NewMinorRelease(ctx context.Context, r *Release, dryrun bool, email, user s
 	}
 
 	// Create new branch
-	if err := gClient.Branch(r.EksGoReleaseVersion()); err != nil {
+	commitBranch := r.EksGoReleaseVersion()
+	if err := gClient.Branch(commitBranch); err != nil {
 		logger.Error(err, "git branch", "branch name", r.EksGoReleaseVersion(), "repo", forkUrl, "client", gClient)
 		return err
 	}
@@ -67,7 +68,7 @@ func NewMinorRelease(ctx context.Context, r *Release, dryrun bool, email, user s
 	prSubject := fmt.Sprintf(newMinorVersionPRSubjectFmt, r.GoSemver())
 	prDescription := fmt.Sprintf(newMinorVersionPRDescriptionFmt, r.EksGoReleaseVersion())
 	commitMsg := fmt.Sprintf(newMinorVersionCommitMsgFmt, r.GoSemver())
-	if err := createReleasePR(ctx, dryrun, r, ghUser, gClient, prSubject, prDescription, commitMsg); err != nil {
+	if err := createReleasePR(ctx, dryrun, r, ghUser, gClient, prSubject, prDescription, commitMsg, commitBranch); err != nil {
 		logger.Error(err, "Create Release PR")
 	}
 	return nil

--- a/tools/eksDistroBuildToolingOpsTools/pkg/eksGoRelease/release.go
+++ b/tools/eksDistroBuildToolingOpsTools/pkg/eksGoRelease/release.go
@@ -43,7 +43,8 @@ func ReleaseArtifacts(ctx context.Context, r *Release, dryrun bool, email, user 
 	}
 
 	// Create new branch
-	if err := gClient.Branch(fmt.Sprintf("release-%s", r.GoMinorVersion())); err != nil {
+	commitBranch := fmt.Sprintf("release-%s", r.GoMinorVersion())
+	if err := gClient.Branch(commitBranch); err != nil {
 		logger.Error(err, "git branch", "branch name", r.GoMinorVersion(), "repo", forkUrl, "client", gClient)
 		return err
 	}
@@ -58,7 +59,7 @@ func ReleaseArtifacts(ctx context.Context, r *Release, dryrun bool, email, user 
 	prSubject := fmt.Sprintf(releasePRSubjectFmt, r.EksGoReleaseVersion())
 	prDescription := fmt.Sprintf(releasePRDescriptionFmt, r.EksGoReleaseVersion())
 	commitMsg := fmt.Sprintf(releasePRCommitFmt, r.EksGoReleaseVersion())
-	if err := createReleasePR(ctx, dryrun, r, ghUser, gClient, prSubject, prDescription, commitMsg); err != nil {
+	if err := createReleasePR(ctx, dryrun, r, ghUser, gClient, prSubject, prDescription, commitMsg, commitBranch); err != nil {
 		logger.Error(err, "Create Release PR")
 	}
 	return nil

--- a/tools/eksDistroBuildToolingOpsTools/pkg/eksGoRelease/updateRelease.go
+++ b/tools/eksDistroBuildToolingOpsTools/pkg/eksGoRelease/updateRelease.go
@@ -44,7 +44,8 @@ func UpdateVersion(ctx context.Context, r *Release, dryrun bool, email, user str
 	}
 
 	// Create new branch
-	if err := gClient.Branch(r.EksGoReleaseVersion()); err != nil {
+	commitBranch := r.EksGoReleaseVersion()
+	if err := gClient.Branch(commitBranch); err != nil {
 		logger.Error(err, "git branch", "branch name", r.EksGoReleaseVersion(), "repo", forkUrl, "client", gClient)
 		return err
 	}
@@ -70,7 +71,7 @@ func UpdateVersion(ctx context.Context, r *Release, dryrun bool, email, user str
 	prSubject := fmt.Sprintf(updatePRSubjectFmt, r.GoSemver())
 	prDescription := fmt.Sprintf(updatePRDescriptionFmt, r.EksGoReleaseVersion())
 	commitMsg := fmt.Sprintf(updatePRCommitFmt, r.GoSemver())
-	if err := createReleasePR(ctx, dryrun, r, ghUser, gClient, prSubject, prDescription, commitMsg); err != nil {
+	if err := createReleasePR(ctx, dryrun, r, ghUser, gClient, prSubject, prDescription, commitMsg, commitBranch); err != nil {
 		logger.Error(err, "Create Release PR")
 	}
 	return nil

--- a/tools/eksDistroBuildToolingOpsTools/pkg/prManager/prManager.go
+++ b/tools/eksDistroBuildToolingOpsTools/pkg/prManager/prManager.go
@@ -216,7 +216,7 @@ func (p *PrCreator) CreatePr(ctx context.Context, opts *CreatePrOpts) (string, e
 	if opts.CommitMessage != "" {
 		ref, err := p.getRef(ctx, opts.CommitBranch, opts.BaseBranch)
 		if err != nil {
-			return "", fmt.Errorf("creating pull request: get/create the commit reference: %s\n", err)
+			return "", fmt.Errorf("creating pull request: get/create the commit reference: %s", err)
 		}
 		if ref == nil {
 			return "", fmt.Errorf("creating pull request: the reference is nil")
@@ -224,11 +224,11 @@ func (p *PrCreator) CreatePr(ctx context.Context, opts *CreatePrOpts) (string, e
 
 		tree, err := p.getTree(ctx, ref, opts.SourceFileBody, opts.DestFileGitPath)
 		if err != nil {
-			return "", fmt.Errorf("creating the tree based on the provided files: %s\n", err)
+			return "", fmt.Errorf("creating the tree based on the provided files: %s", err)
 		}
 
 		if err := p.pushCommit(ctx, ref, tree, opts.AuthorName, opts.AuthorEmail, opts.CommitMessage); err != nil {
-			return "", fmt.Errorf("creating the commit: %s\n", err)
+			return "", fmt.Errorf("creating the commit: %s", err)
 		}
 	}
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Add `commitBranch` variable to ensure the correct branch is used to open update prs vs release prs.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
