### PR TITLE
skips go link and compile when running upx

### DIFF
--- a/builder-base/scripts/install_golang.sh
+++ b/builder-base/scripts/install_golang.sh
@@ -98,4 +98,12 @@ mkdir -p ${NEWROOT}/root
 mv /root/sdk ${NEWROOT}/root
 mv ${GOPATH} ${NEWROOT}/${GOPATH}
 
-time upx --best --no-lzma ${NEWROOT}/root/sdk/go${VERSION%-*}/bin/go ${NEWROOT}/root/sdk/go${VERSION%-*}/pkg/tool/linux_$TARGETARCH/{addr2line,asm,cgo,compile,cover,doc,link,objdump,pprof,trace,vet}
+# not upx'ing link + compile since they are often times running conncurrently
+# accoriding to the upx docs, this can increase memory usage, ref:
+# Currently, executables compressed by UPX do not share RAM at runtime
+#   in the way that executables mapped from a file system do.  As a
+#   result, if the same program is run simultaneously by more than one
+#   process, then using the compressed version will require more RAM and/or
+#   swap space.  So, shell programs (bash, csh, etc.)  and ``make''
+#   might not be good candidates for compression.
+time upx --best --no-lzma ${NEWROOT}/root/sdk/go${VERSION%-*}/bin/go ${NEWROOT}/root/sdk/go${VERSION%-*}/pkg/tool/linux_$TARGETARCH/{addr2line,asm,cgo,cover,doc,objdump,pprof,trace,vet}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

After releasing the new builder base when we added the upx compression for a number of the larger executables within this image, we started seeing a couple out of memory exceptions when building a couple of the eks-a components.  We do these builds on small (1cpu 4gb) arm instances in codebuild.  For the time being we bumped those to large and the problem went away.

I think based on the upx docx, which i quoted inline here for reference, since the compile command, and i *think* the link command, are usually running multiple instances, it makes sense that we are seeing this increase in RAM requirement which is triggering a OOM exception in our builds.

I have take this approach to just exclude the 2 we are pretty sure are the culprits.  We should 100% be on the lookout for random failures elsewhere and potentially adjust this approach further.    

Most of the other bins we upx'd previously are not things that are run in large simultaneous batches so I *think* we can leave those until we see evident of issues.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
