### PR TITLE
Restore filtering + from release candidate k8s versions

### DIFF
--- a/release/pkg/kube_reader.go
+++ b/release/pkg/kube_reader.go
@@ -68,6 +68,7 @@ func parseKubeGitVersionContent(input io.Reader) (*kubeGitVersionFile, error) {
 		case "KUBE_GIT_VERSION":
 			resp.KubeGitVersion = value
 		case "KUBE_GIT_MAJOR":
+			value = strings.ReplaceAll(value, "+", "")
 			val, err := strconv.Atoi(value)
 			if err != nil {
 				return nil, errors.Wrapf(err, "Could not parse '%s'", value)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Add the filtering of `+` values in minor version release candidates. This failed and required reverting last time due to additional println which made their way into the yaml files. This shouldn't be the case here, but we can watch for this as a previously known issue.
https://github.com/aws/eks-distro-build-tooling/pull/1095 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
