### PR TITLE
Add aws signer plugin for notation in the builder base

### DIFF
--- a/builder-base/scripts/install_notation.sh
+++ b/builder-base/scripts/install_notation.sh
@@ -26,6 +26,8 @@ NOTATION_FILENAME="notation_${NOTATION_VERSION}_linux_${TARGETARCH}.tar.gz"
 NOTATION_DOWNLOAD_URL="https://github.com/notaryproject/notation/releases/download/v${NOTATION_VERSION}/${NOTATION_FILENAME}"
 NOTATION_CHECKSUM_URL="https://github.com/notaryproject/notation/releases/download/v${NOTATION_VERSION}/notation_${NOTATION_VERSION}_checksums.txt"
 
+AWS_SIGNER_PLUGIN_NAME="notation-aws-signer-plugin.zip"
+AWS_SIGNER_PLUGIN_URL="https://d2hvyiie56hcat.cloudfront.net/linux/${TARGETARCH}/plugin/latest/${AWS_SIGNER_PLUGIN_NAME}"
 
 function install_notation() {
     wget \
@@ -40,4 +42,15 @@ function install_notation() {
     time upx --best --no-lzma $USR_BIN/notation
 }
 
-[ ${SKIP_INSTALL:-false} != false ] || install_notation
+function install_aws_signer_plugin() {
+    wget \
+        --progress dot:giga \
+        $AWS_SIGNER_PLUGIN_URL
+    unzip $AWS_SIGNER_PLUGIN_NAME
+    mkdir -p $HOME/.config/notation/plugins/com.amazonaws.signer.notation.plugin
+    mv notation-com.amazonaws.signer.notation.plugin $HOME/.config/notation/plugins/com.amazonaws.signer.notation.plugin
+    chmod +x $HOME/.config/notation/plugins/com.amazonaws.signer.notation.plugin/notation-com.amazonaws.signer.notation.plugin
+    rm LICENSE THIRD_PARTY_LICENSES $AWS_SIGNER_PLUGIN_NAME
+}
+
+[ ${SKIP_INSTALL:-false} != false ] || (install_notation && install_aws_signer_plugin)


### PR DESCRIPTION
*Description of changes:*
Add AWS Signer plugin binary for notation CLI.
Download link - https://docs.aws.amazon.com/signer/latest/developerguide/image-signing-prerequisites.html

Followed steps:

Configure AWS Signer Plugin

1. Download latest binary from the link mentioned on above the aws doc site.
2. Copy the binary  to notation plugin location
    - For linux the location is  $HOME/.config/notation/plugins/com.amazonaws.signer.notation.plugin
3. Give execute permission to the plugin
4. Remove downloaded zip folder and other files extracted with that.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
