### PR TITLE
Switch eks go readme update to occur on release

### DIFF
--- a/tools/eksDistroBuildToolingOpsTools/pkg/eksGoRelease/updateRelease.go
+++ b/tools/eksDistroBuildToolingOpsTools/pkg/eksGoRelease/updateRelease.go
@@ -50,13 +50,6 @@ func UpdateVersion(ctx context.Context, r *Release, dryrun bool, email, user str
 		return err
 	}
 
-	// Update files for new patch versions of golang
-	if err := updateVersionReadme(gClient, r); err != nil {
-		logger.Error(err, "Update Readme")
-		return err
-	}
-
-	// Since this doesn't require a backport set and pass false
 	if err := updateGoSpec(gClient, r); err != nil {
 		logger.Error(err, "Update Readme")
 		return err


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
When using the `eksGoRelease` commands, readme update makes more sense when officially [releasing the new version](https://github.com/aws/eks-distro-build-tooling/pull/1279/files) rather than [adding the patches and other changes](https://github.com/aws/eks-distro-build-tooling/pull/1273/files).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
