### PR TITLE
add workflow step to create issue on new kOps releases

### DIFF
--- a/.github/workflows/kopsRelease.yaml
+++ b/.github/workflows/kopsRelease.yaml
@@ -1,0 +1,23 @@
+name: kOps Release Check
+on:
+  schedule:
+  # Every day
+  - cron: '0 0 * * *'
+
+jobs:
+  kops_release:
+    name: kOps Release Check
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check for release
+      id: release-check
+      run: |
+        echo wasRelease=$(curl -s https://api.github.com/repos/kubernetes/kops/releases/latest | jq -r '.published_at|fromdateiso8601 > now-86400') >> $GITHUB_OUTPUT
+    - name: Create issue
+      if: ${{ steps.release-check.outputs.wasRelease == 'true' }}
+      uses: imjohnbo/issue-bot@v3
+      with:
+        labels: "external"
+        title: "Notice of kOps Release"
+        body: |-
+          A kOps release was detected as having occurred in the last 24h. The kOps project needs updating


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Found [this workflow](https://github.com/vmware-tanzu/sonobuoy/blob/main/.github/workflows/k8sRelease.yaml) for monitoring projects for releases. Wanted to try it out here since we require a new release of kops

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
