### PR TITLE
Fix Hugo tarball name for ARM64

### DIFF
--- a/builder-base/scripts/install_hugo.sh
+++ b/builder-base/scripts/install_hugo.sh
@@ -25,7 +25,7 @@ source $SCRIPT_ROOT/common_vars.sh
 if [ $TARGETARCH == 'amd64' ]; then 
     HUGO_FILENAME="hugo_extended_${HUGO_VERSION}_Linux-64bit.tar.gz"
 else
-    HUGO_FILENAME="nhugo_extended_${HUGO_VERSION}_Linux-ARM64.tar.gz"
+    HUGO_FILENAME="hugo_extended_${HUGO_VERSION}_Linux-ARM64.tar.gz"
 fi
 HUGO_DOWNLOAD_URL="https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/$HUGO_FILENAME"
 HUGO_CHECKSUM_URL="https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_${HUGO_VERSION}_checksums.txt"


### PR DESCRIPTION
Fixing the Hugo ARM64 GitHub release tarball name.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
