### PR TITLE
Fix failing helmchart 

### DIFF
--- a/helm-charts/stable/amazon-eks-pod-identity-webhook/Chart.yaml
+++ b/helm-charts/stable/amazon-eks-pod-identity-webhook/Chart.yaml
@@ -29,7 +29,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.17
+version: 1.0.18
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm-charts/stable/amazon-eks-pod-identity-webhook/templates/Deployment.yaml
+++ b/helm-charts/stable/amazon-eks-pod-identity-webhook/templates/Deployment.yaml
@@ -85,8 +85,8 @@ spec:
   secretName: {{ include "amazon-eks-pod-identity-webhook.secretName" . }} 
   commonName: "pod-identity-webhook.default.svc"
   dnsNames:
+    - "eks-distro-pod-identity-webhook"
     - "eks-distro-pod-identity-webhook.default"
-    - "eks-distro-pod-identity-webhook.default.default"
     - "eks-distro-pod-identity-webhook.default.svc"
     - "eks-distro-pod-identity-webhook.default.svc.local"
   isCA: true

--- a/helm-charts/stable/amazon-eks-pod-identity-webhook/templates/Deployment.yaml
+++ b/helm-charts/stable/amazon-eks-pod-identity-webhook/templates/Deployment.yaml
@@ -85,10 +85,10 @@ spec:
   secretName: {{ include "amazon-eks-pod-identity-webhook.secretName" . }} 
   commonName: "pod-identity-webhook.default.svc"
   dnsNames:
-    {{- include "amazon-eks-pod-identity-webhook.fullname" . | nindent 4 }}
-    {{- include "amazon-eks-pod-identity-webhook.fullname" . | nindent 4 }}.default
-    {{- include "amazon-eks-pod-identity-webhook.fullname" . | nindent 4 }}.default.svc
-    {{- include "amazon-eks-pod-identity-webhook.fullname" . | nindent 4 }}.default.svc.local
+    - "eks-distro-pod-identity-webhook.default"
+    - "eks-distro-pod-identity-webhook.default.default"
+    - "eks-distro-pod-identity-webhook.default.svc"
+    - "eks-distro-pod-identity-webhook.default.svc.local"
   isCA: true
   duration: 2160h # 90d
   renewBefore: 360h # 15d


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This error is fixed by adding `-`, had issues with parsing the parameterized values so just hardcoding for the time being.
```
Error: unable to build kubernetes objects from release manifest: error validating "": error validating data: Val
idationError(Certificate.spec.dnsNames): invalid type for io.cert-manager.v1.Certificate.spec.dnsNames: got "string", expected "array"
```

Newly produced template:
```
# Source: amazon-eks-pod-identity-webhook/templates/Deployment.yaml
apiVersion: cert-manager.io/v1
kind: Certificate
metadata:
  name: eks-distro-pod-identity-webhook
  namespace: default
spec:
  secretName: eks-distro-pod-identity-webhook-cert 
  commonName: "pod-identity-webhook.default.svc"
  dnsNames:
    - "eks-distro-pod-identity-webhook"
    - "eks-distro-pod-identity-webhook.default"
    - "eks-distro-pod-identity-webhook.default.svc"
    - "eks-distro-pod-identity-webhook.default.svc.local"
  isCA: true
  duration: 2160h # 90d
  renewBefore: 360h # 15d
  issuerRef:
    name: selfsigned
    kind: ClusterIssuer
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
