### PR TITLE
Handle creation of RELEASE file in new Go version Release

### DIFF
--- a/tools/eksDistroBuildToolingOpsTools/pkg/eksGoRelease/githubRelease.go
+++ b/tools/eksDistroBuildToolingOpsTools/pkg/eksGoRelease/githubRelease.go
@@ -161,20 +161,24 @@ func bumpRelease(gClient git.Client, r *Release) error {
 
 	content, err := gClient.ReadFile(releasePath)
 	if err != nil {
-		logger.Error(err, "Reading file", "file", releasePath)
-		return err
+		if !strings.Contains(err.Error(), "file not found") {
+			logger.Error(err, "Reading file", "file", releasePath)
+			return err
+		}
+		r.Release = 0
+	} else {
+		// Check if there is a new line character at the end of the file, if so take all but the newline
+		if content[len(content)-1:] == "\n" {
+			content = content[0 : len(content)-1]
+		}
+		cr, err := strconv.Atoi(content)
+		if err != nil {
+			logger.Error(err, "Converting current release to int")
+			return err
+		}
+		// Increment release
+		r.Release = cr + 1
 	}
-	// Check if there is a new line character at the end of the file, if so take all but the newline
-	if content[len(content)-1:] == "\n" {
-		content = content[0 : len(content)-1]
-	}
-	cr, err := strconv.Atoi(content)
-	if err != nil {
-		logger.Error(err, "Converting current release to int")
-		return err
-	}
-	// Increment release
-	r.Release = cr + 1
 	logger.V(4).Info("release bumped to", "release", r.Release)
 
 	return nil
@@ -187,7 +191,13 @@ func updateRelease(gClient git.Client, r *Release) error {
 	releaseContent := fmt.Sprintf("%d", r.ReleaseNumber())
 	logger.V(4).Info("Update RELEASE", "path", releasePath, "content", releaseContent)
 	if err := gClient.ModifyFile(releasePath, []byte(releaseContent)); err != nil {
-		return err
+		if !strings.Contains(err.Error(), "file not found") {
+			return err
+		}
+		releaseContent = fmt.Sprintf("%d", 0)
+		if err := gClient.CreateFile(releasePath, []byte(releaseContent)); err != nil {
+			return err
+		}
 	}
 	if err := gClient.Add(releasePath); err != nil {
 		logger.Error(err, "git add", "file", releasePath)

--- a/tools/eksDistroBuildToolingOpsTools/pkg/eksGoRelease/githubRelease.go
+++ b/tools/eksDistroBuildToolingOpsTools/pkg/eksGoRelease/githubRelease.go
@@ -279,7 +279,7 @@ func updateGoSpec(gClient git.Client, r *Release) error {
 
 func addTempFilesForNewMinorVersion(gClient git.Client, r *Release) error {
 	// Add golang.spec
-	specFilePath := fmt.Sprintf(rpmSourcePathFmt, constants.EksGoProjectPath, r.GoMinorVersion(), goSpecFile)
+	specFilePath := fmt.Sprintf(specPathFmt, constants.EksGoProjectPath, r.GoMinorVersion(), goSpecFile)
 	rf, err := gClient.ReadFile(newReleaseFile)
 	if err != nil {
 		logger.Error(err, "Reading newRelease.txt file")


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Handle creation of RELEASE file in new Go version Release

When we run
```
./eksGoRelease release --eksGoReleases=1.22.0 -e jasondu31.coding@gmail.com -u xdu31
```
It errors out with the follow error:
```
finding filename	{"filename": "projects/golang/go/1.22/RELEASE", "error": "file not found"}
Reading file	{"file": "projects/golang/go/1.22/RELEASE", "error": "file not found"}
increment release	{"error": "file not found"}
Error: you have failed this automation: file not found
```
This happens when it is a new Go version release

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
