### PR TITLE
Remove EKS-A folks from OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,19 +1,12 @@
 approvers:
-- abhay-krishna
-- abhinavmpandey08
 - adityavenneti
 - bhavi-koduru
 - danbudris
-- jaxesn
 - jngo2
 - kschumy
 - markapruett
-- pokearu
 - rcrozean
-- taneyland
 - TerryHowe
-- vignesh-goutham
-- vivek-koppuru
 - wongma7
 - xdu31
 - zafs23


### PR DESCRIPTION
*Description of changes:*
remove EKS-A folks from owners

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
