### PR TITLE
Correct golang release automation prowjob name

### DIFF
--- a/pr-scripts/create_pr.sh
+++ b/pr-scripts/create_pr.sh
@@ -33,7 +33,7 @@ OTHER_CLONE_ROOT=${OTHER_CLONE_ROOT:-${SCRIPT_ROOT}/../../..}
 
 MINIMAL_IMAGE_REBUILD_PJ_NAME="quarterly-minimal-image-rebuild"
 
-GOLANG_RELEASE_PERIODIC="check-golang-upstream-release"
+GOLANG_RELEASE_PERIODIC="check-upstream-golang-release"
 
 CHANGED_FILE="tag file(s)"
 CHANGED_COMPONENT="base image"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The golang pr name expected the wrong Prowjob name for automation.

From prowjobs automation
```
...
  job: check-upstream-golang-release
  namespace: default
  pod_spec:
...
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
