### PR TITLE
Fix check golang

### DIFF
--- a/eks-distro-base/Makefile
+++ b/eks-distro-base/Makefile
@@ -836,6 +836,7 @@ check-golang-release:
 	${MAKE_ROOT}/scripts/check_upstream_golang
 
 .PHONY: create-golang-release-pr
+create-golang-release-pr: open-pr-check "golang-image-release"
 create-golang-release-pr:
 	$(MAKE_ROOT)/../pr-scripts/create_pr.sh eks-distro-build-tooling 'EKS_DISTRO*_TAG_FILE*' 'golang-image-release'
 

--- a/eks-distro-base/Makefile
+++ b/eks-distro-base/Makefile
@@ -836,9 +836,10 @@ check-golang-release:
 	${MAKE_ROOT}/scripts/check_upstream_golang
 
 .PHONY: create-golang-release-pr
-create-golang-release-pr: open-pr-check "golang-image-release"
+create-golang-release-pr: IMAGE_UPDATE_BRANCH="golang-image-release"
+create-golang-release-pr: open-pr-check
 create-golang-release-pr:
-	$(MAKE_ROOT)/../pr-scripts/create_pr.sh eks-distro-build-tooling 'EKS_DISTRO*_TAG_FILE*' 'golang-image-release'
+	$(MAKE_ROOT)/../pr-scripts/create_pr.sh eks-distro-build-tooling 'EKS_DISTRO*_TAG_FILE*' $(IMAGE_UPDATE_BRANCH)
 
 
 ########### DO NOT EDIT #############################


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The period for checking for new releases of golang is failing due to the missing file `golang_versions.yaml` not existing in the local repo. 
```
+ git add ./eks-distro-base/golang_versions.yaml
fatal: pathspec './eks-distro-base/golang_versions.yaml' did not match any files
make: *** [create-golang-release-pr] Error 128
make: Leaving directory `/home/prow/go/src/github.com/aws/eks-distro-build-tooling/eks-distro-base'
```

There is an additional make target [open-pr-check](https://github.com/aws/eks-distro-build-tooling/blob/a843551b08db58b336d44bdeef3c883c68b73497/eks-distro-base/Makefile#L450) that needs to be called similarly to the `make update` call: https://github.com/aws/eks-distro-build-tooling/blob/a843551b08db58b336d44bdeef3c883c68b73497/eks-distro-base/Makefile#L776-L778

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
