### PR TITLE
Add infrastructure for generating the golang-debian image using upstream binaries

### DIFF
--- a/projects/golang/go/Makefile
+++ b/projects/golang/go/Makefile
@@ -38,6 +38,11 @@ IMAGE_NAME?=golang-debian
 IMAGE_TAG?=$(GIT_TAG)-$(BUILD_ID)-$(IMAGE_BUILD_ID)
 LATEST_IMAGE=$(IMAGE_REPO)/$(IMAGE_NAME):$(GIT_TAG)
 IMAGE?=$(IMAGE_REPO)/$(IMAGE_NAME):$(IMAGE_TAG),$(LATEST_IMAGE)
+# Variables used in the using upstream binarys in the golang-debian image
+BUILDER_BASE_VERSIONS_YAML=$(BASE_DIRECTORY)/builder-base/versions.yaml
+BUILDER_BASE_GO_VERSION=$(shell grep -E "^GOLANG_VERSION_$(subst .,,$(GO_SOURCE_VERSION))" $(BUILDER_BASE_VERSIONS_YAML))
+GO_BIN_VERSION_WITH_RELEASE=$(subst GOLANG_VERSION_$(subst .,,$(GO_SOURCE_VERSION)): ,,$(BUILDER_BASE_GO_VERSION))
+GO_BIN_VERSION_WITHOUT_RELEASE=$(shell [[ $(GO_BIN_VERSION_WITH_RELEASE) =~ [0-9]+.[0-9]+.[0-9]+ ]] && echo $${BASH_REMATCH[0]})
 
 PUSH_IMAGES?=true
 BUILDKIT_OUTPUT=type=image,oci-mediatypes=true,\"name=$(IMAGE)\",push=$(PUSH_IMAGES)
@@ -98,6 +103,10 @@ validate-go-archive-checksum:
 		fi ; \
 	done
 
+.PHONY: prod-release-images-upstream-bins
+prod-release-images-upstream-bins: export AWS_PROFILE=ecr-public-push
+prod-release-images-upstream-bins: images-upstream-bins
+
 .PHONY: fetch-golang-source-archive
 fetch-golang-source-archive:
 	curl -L -o $(HOME)/rpmbuild/SOURCES/$(GIT_TAG).src.tar.gz https://github.com/golang/go/archive/refs/tags/$(GIT_TAG).tar.gz --create-dirs 
@@ -139,6 +148,33 @@ images:
 		--frontend dockerfile.v0 \
 		--opt platform=$(GOOS)/$(ARCH_LOWER) \
 		--opt build-arg:GOLANG_ARCHIVE_PATH=$(GOOS)/$(ARCH_LOWER)/$(GIT_TAG).$(GOOS)-$(ARCH_LOWER).tar.gz \
+		--local dockerfile=$(PROJECT_DIRECTORY)/docker/debianBase \
+		--local context=$(VERSION_DIRECTORY)/archives \
+		--progress plain \
+		--output $(BUILDKIT_OUTPUT)
+
+.PHONY: fetch-golang-upstream-bins
+fetch-golang-upstream-bins:
+	$(PROJECT_DIRECTORY)/scripts/get_upstream_golang.sh $(VERSION_DIRECTORY)/archives/ $(GO_BIN_VERSION_WITHOUT_RELEASE)
+
+.PHONY: local-images-upstream-bins
+local-images-upstream-bins: PUSH_IMAGES=false
+local-images-upstream-bins: export BUILDKIT_HOST=docker-container://buildkitd
+local-images-upstream-bins: images-upstream-bins
+
+.PHONY: images-upstream-bins
+images-upstream-bins: IMAGE_REPO=$(AWS_ACCOUNT_ID).dkr.ecr.$(AWS_REGION).amazonaws.com
+images-upstream-bins: IMAGE_NAME=golang-debian
+images-upstream-bins: IMAGE_TAG=$(GO_BIN_VERSION_WITHOUT_RELEASE)-$(BUILD_ID)-$(IMAGE_BUILD_ID)
+images-upstream-bins: LATEST_IMAGE=$(IMAGE_REPO)/$(IMAGE_NAME):$(GO_BIN_VERSION_WITHOUT_RELEASE)
+images-upstream-bins: IMAGE=$(IMAGE_REPO)/$(IMAGE_NAME):$(IMAGE_TAG),$(LATEST_IMAGE)
+images-upstream-bins: fetch-golang-upstream-bins buildkit-check
+images-upstream-bins:
+	$(BASE_DIRECTORY)/scripts/buildkit.sh \
+		build \
+		--frontend dockerfile.v0 \
+		--opt platform=$(GOOS)/$(ARCH_LOWER) \
+		--opt build-arg:GOLANG_ARCHIVE_PATH=$(GOOS)/$(ARCH_LOWER)/go$(GO_BIN_VERSION_WITHOUT_RELEASE).$(GOOS)-$(ARCH_LOWER).tar.gz \
 		--local dockerfile=$(PROJECT_DIRECTORY)/docker/debianBase \
 		--local context=$(VERSION_DIRECTORY)/archives \
 		--progress plain \

--- a/projects/golang/go/docker/debianBase/Dockerfile
+++ b/projects/golang/go/docker/debianBase/Dockerfile
@@ -11,7 +11,7 @@ COPY --from=go-untar /usr/local/go/ /usr/local/go/
 
 
 ENV GOPATH /go
-ENV PATH /usr/local/go/bin:$GOPATH/bin:$PATH
+ENV PATH /usr/local/go/go/bin:$GOPATH/bin:$PATH
 
 RUN set -eux; \
 	apt-get update; \

--- a/projects/golang/go/scripts/get_upstream_golang.sh
+++ b/projects/golang/go/scripts/get_upstream_golang.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -x
+set -e
+set -o pipefail
+
+SCRIPT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+BASE_DIRECTORY="$(git rev-parse --show-toplevel)"
+GO_PREFIX="go"
+ARCHITECTURE="linux/amd64" # Currently only build golang-debian image for amd64, if other arches are needed add
+
+OUTPUT_DIR="$1"
+GO_BIN_VERSION="$2"
+
+source ${BASE_DIRECTORY}/builder-base/scripts/common_vars.sh
+
+# Download from upstream and validate CHECKSUMs
+function build::go::download {
+  # Set up specific go version by using go get, additional versions apart from default can be installed by calling
+  # the function again with the specific parameter.
+  local version=${1}
+  local outputDir=${2}
+  local archs=${3}
+
+  for arch in ${archs/,/ }; do
+    local filename="$outputDir/${arch}/go$version.${arch/\//-}.tar.gz"
+    if [ ! -f $filename ]; then
+      curl -sSLf --retry 5 "https://go.dev/dl/go$version.${arch/\//-}.tar.gz" -o $filename --create-dirs
+      sha256sum=$(curl -sSLf --retry 5 "https://go.dev/dl/?mode=json" | jq -r --arg tar "go$version.${arch/\//-}.tar.gz" '.[].files[] | if .filename == $tar then .sha256 else "" end' | xargs)
+
+      if [[ $(sha256sum ${filename} | cut -d ' ' -f1) != "${sha256sum}" ]]; then
+        echo "CHECKSUMs don't match"
+        exit 1
+      fi
+    fi
+  done
+}
+
+# strip the release version off the end of
+build::go::download "${GO_BIN_VERSION}" "$OUTPUT_DIR" "$ARCHITECTURE"

--- a/projects/golang/go/scripts/prow_release_images.sh
+++ b/projects/golang/go/scripts/prow_release_images.sh
@@ -31,8 +31,6 @@ fi
 BASE_DIRECTORY=$(git rev-parse --show-toplevel)
 cd ${BASE_DIRECTORY} || exit
 
-RELEASE_VERSION="${1:-prod-release-images}"
-
 cat <<EOF >awscliconfig
 [default]
 output=json
@@ -49,5 +47,4 @@ export AWS_CONFIG_FILE=$(pwd)/awscliconfig
 export AWS_PROFILE=ecr-public-push
 unset AWS_ROLE_ARN AWS_WEB_IDENTITY_TOKEN_FILE
 
-make -C ${BASE_DIRECTORY}/projects/golang/go $RELEASE_VERSION
-
+make -C ${BASE_DIRECTORY}/projects/golang/go "prod-release-images-upstream-bins"

--- a/projects/golang/go/scripts/prow_release_images.sh
+++ b/projects/golang/go/scripts/prow_release_images.sh
@@ -14,24 +14,26 @@
 # limitations under the License.
 
 if [ "$ARCHITECTURE" == "ARM64" ]; then
-    echo "Won't perform image release for ARM64 arch"
-    exit 0
+  echo "Won't perform image release for ARM64 arch"
+  exit 0
 fi
 
 if [ "$AWS_ROLE_ARN" == "" ]; then
-    echo "Empty AWS_ROLE_ARN"
-    exit 1
+  echo "Empty AWS_ROLE_ARN"
+  exit 1
 fi
 
 if [ "$ECR_PUBLIC_PUSH_ROLE_ARN" == "" ]; then
-    echo "Empty ECR_PUBLIC_PUSH_ROLE_ARN"
-    exit 1
+  echo "Empty ECR_PUBLIC_PUSH_ROLE_ARN"
+  exit 1
 fi
 
 BASE_DIRECTORY=$(git rev-parse --show-toplevel)
 cd ${BASE_DIRECTORY} || exit
 
-cat << EOF > awscliconfig
+RELEASE_VERSION="${1:-prod-release-images}"
+
+cat <<EOF >awscliconfig
 [default]
 output=json
 region=${AWS_REGION:-${AWS_DEFAULT_REGION:-us-west-2}}
@@ -47,4 +49,5 @@ export AWS_CONFIG_FILE=$(pwd)/awscliconfig
 export AWS_PROFILE=ecr-public-push
 unset AWS_ROLE_ARN AWS_WEB_IDENTITY_TOKEN_FILE
 
-make -C ${BASE_DIRECTORY}/projects/golang/go prod-release-images
+make -C ${BASE_DIRECTORY}/projects/golang/go $RELEASE_VERSION
+


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
These changes were tested using the new `make local-images-upstream-bins` which is identical to the final call except `PUSH_IMAGES=false`. Both of these based of the make targets for building the current debian images with new variables and scripts used pulling upstream binaries instead of the EKS Go s3 images previously generated. 

Output from the `make local-images-upstream-bins` command calling the new `get_upstream_golang.sh`. This script checks the builder-base files for referencing which version of golang the debian images should use. From here the Makefile and Dockerfile create the relevant image using the tags. Using the existing postsubmits we can trigger off a merge of the `eks-distro-base/golang_versions.yaml` (this file should be used as it will be updated with the same automation that update the `builder-base/versions.yaml` but only will be updated when golang versions are updated), instead of the `docker/debianBase/RELEASE` file.

```
[...]/eks-distro-build-tooling/projects/golang/go/scripts/get_upstream_golang.sh [...]/eks-distro-build-tooling/projects/golang/go/1.22/archives/ 1.22.5
+ set -e
+ set -o pipefail
+++ dirname [...]/eks-distro-build-tooling/projects/golang/go/scripts/get_upstream_golang.sh
++ cd [...]/eks-distro-build-tooling/projects/golang/go/scripts
++ pwd -P
+ SCRIPT_ROOT=[...]/eks-distro-build-tooling/projects/golang/go/scripts
++ git rev-parse --show-toplevel
+ BASE_DIRECTORY=[...]/eks-distro-build-tooling
+ GO_PREFIX=go
+ ARCHITECTURE=linux/amd64
+ OUTPUT_DIR=[...]/eks-distro-build-tooling/projects/golang/go/1.22/archives/
+ GO_BIN_VERSION=1.22.5
+ source [...]/eks-distro-build-tooling/builder-base/scripts/common_vars.sh
++ set -e
++ set -o pipefail
++ TARGETARCH=amd64
++ USR=/usr
++ USR_LOCAL=/usr/local
++ USR_BIN=/usr/bin
++ USR_LOCAL_BIN=/usr/local/bin
++ BASE_DIR=
++ IS_AL23=false
++ '[' -f /etc/yum.repos.d/amazonlinux.repo ']'
++ '[' false '!=' false ']'
++ mkdir -p /usr/bin /usr/local/bin
+ build::go::download 1.22.5 [...]/eks-distro-build-tooling/projects/golang/go/1.22/archives/ linux/amd64
+ local version=1.22.5
+ local outputDir=[...]/eks-distro-build-tooling/projects/golang/go/1.22/archives/
+ local archs=linux/amd64
+ for arch in ${archs/,/ }
+ local filename=[...]/eks-distro-build-tooling/projects/golang/go/1.22/archives//linux/amd64/go1.22.5.linux-amd64.tar.gz
+ '[' '!' -f [...]/eks-distro-build-tooling/projects/golang/go/1.22/archives//linux/amd64/go1.22.5.linux-amd64.tar.gz ']'
...
```
Relevant output from buildkit and docker:
```
/Users/rcrozean/repos/rcrozean/eks-distro-build-tooling/scripts/buildkit.sh \
		build \
		--frontend dockerfile.v0 \
		--opt platform=linux/amd64 \
		--opt build-arg:GOLANG_ARCHIVE_PATH=linux/amd64/go1.22.5.linux-amd64.tar.gz \
		--local dockerfile=/Users/rcrozean/repos/rcrozean/eks-distro-build-tooling/projects/golang/go/docker/debianBase \
		--local context=/Users/rcrozean/repos/rcrozean/eks-distro-build-tooling/projects/golang/go/1.22/archives \
		--progress plain \
		--output type=image,oci-mediatypes=true,\"name=.dkr.ecr..amazonaws.com/golang-debian:1.22.5-5-25,.dkr.ecr..amazonaws.com/golang-debian:1.22.5\",push=false
...
#11 14.15 + chmod -R 777 /go
#11 14.15 + go version
#11 14.15 go version go1.22.5 linux/amd64
#11 DONE 14.8s
...
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
