### PR TITLE
Auto update golang checksums and expected make tests

### DIFF
--- a/builder-base/scripts/download_golang.sh
+++ b/builder-base/scripts/download_golang.sh
@@ -72,9 +72,8 @@ function build::go::download {
     local filename="$outputDir/${arch}/go$version.${arch/\//-}.tar.gz"
     if [ ! -f $filename ]; then
       curl -sSLf --retry 5 "https://go.dev/dl/go$version.${arch/\//-}.tar.gz" -o $filename --create-dirs
-      sha256sum=$(curl -sSLf --retry 5 "https://go.dev/dl/?mode=json" | jq -r --arg tar "go$version.${arch/\//-}.tar.gz" '.[].files[] | if .filename == $tar then .sha256 else "" end' | xargs)
+      ${SCRIPT_ROOT}/update_shasums.sh
 
-      #TODO: Add better way for checking checksums for older version.
       go_major_version=$(if [[ $(echo "$version" | awk -F'.' '{print NF}') -ge 3 ]]; then echo ${version%.*}; else echo ${version%-*}; fi)
       sha256sum -c $SCRIPT_ROOT/../checksums/go-go$go_major_version-${arch##*/}-checksum
     fi

--- a/builder-base/scripts/update_shasums.sh
+++ b/builder-base/scripts/update_shasums.sh
@@ -62,12 +62,12 @@ for TARGETARCH in arm64 amd64; do
   echo "$sha256  helm-v${HELM_VERSION}-linux-$TARGETARCH.tar.gz" >$CHECKSUMS_ROOT/checksums/helm-$TARGETARCH-checksum
 
   # GOLANG
-  #go_active_version=$(curl https://go.dev/dl/?mode=json | jq -r '.[].version' | sed -e "s/^$GO_PREFIX//" | sort)
-  #for v in $go_active_version; do
-  #  go_major_version=$(if [[ $(echo "$v" | awk -F'.' '{print NF}') -ge 3 ]]; then echo ${v%.*}; else echo ${v%-*}; fi)
-  #  sha256=$(curl -sSLf --retry 5 "https://go.dev/dl/?mode=json" | jq -r --arg tar "go$version.linux-${TARGETARCH/\//-}.tar.gz" '.[].files[] | if .filename == $tar then .sha256 else "" end' | xargs)
-  #  echo "$sha256" >"$CHECKSUMS_ROOT/checksums/go-$go_major_version-$TARGETARCH-checksum"
-  #done
+  go_active_version=$(curl https://go.dev/dl/?mode=json | jq -r '.[].version' | sed -e "s/^$GO_PREFIX//" | sort)
+  for v in $go_active_version; do
+    go_major_version=$(if [[ $(echo "$v" | awk -F'.' '{print NF}') -ge 3 ]]; then echo ${v%.*}; else echo ${v%-*}; fi)
+    sha256=$(curl -sSLf --retry 5 "https://go.dev/dl/?mode=json" | jq -r --arg tar "$v.linux-${TARGETARCH/\//-}.tar.gz" '.[].files[] | if .filename == $tar then .sha256 else "" end' | xargs)
+    echo "$sha256 /home/prow/go/src/github.com/aws/eks-distro-build-tooling/builder-base/tmp/golang-downloads/linux/$TARGETARCH/${v}.linux-$TARGETARCH.tar.gz" >"$CHECKSUMS_ROOT/checksums/go-$go_major_version-$TARGETARCH-checksum"
+  done
 
   # GOVC
   echo "$(curl -sSL --retry 5 -v $GOVC_CHECKSUM_URL 2>&1 | grep $GOVC_FILENAME | cut -d ":" -f 2)" >$CHECKSUMS_ROOT/checksums/govc-$TARGETARCH-checksum

--- a/eks-distro-base/Makefile
+++ b/eks-distro-base/Makefile
@@ -837,7 +837,7 @@ check-golang-release:
 
 .PHONY: create-golang-release-pr
 create-golang-release-pr: IMAGE_UPDATE_BRANCH="golang-image-release"
-create-golang-release-pr: open-pr-check
+create-golang-release-pr: update-make-tests-expected open-pr-check
 create-golang-release-pr:
 	$(MAKE_ROOT)/../pr-scripts/create_pr.sh eks-distro-build-tooling 'EKS_DISTRO*_TAG_FILE*' $(IMAGE_UPDATE_BRANCH)
 

--- a/pr-scripts/create_pr.sh
+++ b/pr-scripts/create_pr.sh
@@ -123,6 +123,7 @@ if [[ $JOB_NAME =~ $GOLANG_RELEASE_PERIODIC ]]; then
   git add ./eks-distro-base/golang_versions.yaml
   git add ./builder-base/versions.yaml
   git add ./builder-base/checksums/go*
+  git add ./make-tests/expected/*
 fi
 
 FILES_ADDED=$(git diff --staged --name-only)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
When running the periodic releasing new golang images, we should update the expected make tests files related to golang and the checksums files used for verifying the builder-base

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
