### PR TITLE
Run make tests before updating in Golang PR 

### DIFF
--- a/eks-distro-base/Makefile
+++ b/eks-distro-base/Makefile
@@ -837,7 +837,7 @@ check-golang-release:
 
 .PHONY: create-golang-release-pr
 create-golang-release-pr: IMAGE_UPDATE_BRANCH="golang-image-release"
-create-golang-release-pr: update-make-tests-expected open-pr-check
+create-golang-release-pr: run-make-tests update-make-tests-expected open-pr-check
 create-golang-release-pr:
 	$(MAKE_ROOT)/../pr-scripts/create_pr.sh eks-distro-build-tooling 'EKS_DISTRO*_TAG_FILE*' $(IMAGE_UPDATE_BRANCH)
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Adding `make run-make-tests` will generate the `actual` files expected during the `make update-make-tests-expected` target

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
