### PR TITLE
Use sed instead of gsed in golang automation

### DIFF
--- a/builder-base/scripts/check_upstream_golang.sh
+++ b/builder-base/scripts/check_upstream_golang.sh
@@ -28,7 +28,7 @@ function update::go::version {
 
   local -r cur_builder_base_version=$(cat "${VERSIONS_YAML}" | grep -E "^GOLANG_VERSION_${majorversion//./}")
 
-  gsed -i "s/${cur_builder_base_version}/GOLANG_VERSION_${majorversion//./}: ${version}-0/g" "${VERSIONS_YAML}"
+  sed -i "s/${cur_builder_base_version}/GOLANG_VERSION_${majorversion//./}: ${version}-0/g" "${VERSIONS_YAML}"
 }
 
 function add::go::version {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
`gsed` was used for local testing. Need to use `sed` in the periodic.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
