### PR TITLE
Cp files from main repo to fork during golang periodic

### DIFF
--- a/pr-scripts/create_pr.sh
+++ b/pr-scripts/create_pr.sh
@@ -119,7 +119,12 @@ if [[ $JOB_NAME =~ $MINIMAL_IMAGE_REBUILD_PJ_NAME ]]; then
   git add ../EKS_DISTRO_TAG_FILE.yaml
 fi
 if [[ $JOB_NAME =~ $GOLANG_RELEASE_PERIODIC ]]; then
-  git diff --name-only
+  # sync expected files changed during the previous make calls in aws/eks-distro-build-tooling to pr-bot fork
+  cp ${SCRIPT_ROOT}/../EKS_DISTRO_TAG_FILE.yaml ./EKS_DISTRO_TAG_FILE.yaml
+  cp ${SCRIPT_ROOT}/../eks-distro-base/golang_versions.yaml ./eks-distro-base/golang_versions.yaml
+  cp ${SCRIPT_ROOT}/../builder-base/versions.yaml ./builder-base/versions.yaml
+  cp ${SCRIPT_ROOT}/../builder-base/checksums/go* ./builder-base/checksums/go*
+  cp ${SCRIPT_ROOT}/../eks-distro-base/make-tests/expected/*golang* ./eks-distro-base/make-tests/expected/*golang*
   git add ./EKS_DISTRO_TAG_FILE.yaml
   git add ./eks-distro-base/golang_versions.yaml
   git add ./builder-base/versions.yaml

--- a/pr-scripts/create_pr.sh
+++ b/pr-scripts/create_pr.sh
@@ -120,15 +120,15 @@ if [[ $JOB_NAME =~ $MINIMAL_IMAGE_REBUILD_PJ_NAME ]]; then
 fi
 if [[ $JOB_NAME =~ $GOLANG_RELEASE_PERIODIC ]]; then
   # sync expected files changed during the previous make calls in aws/eks-distro-build-tooling to pr-bot fork
-  cp -rf ${SCRIPT_ROOT}/../EKS_DISTRO_TAG_FILE.yaml ./EKS_DISTRO_TAG_FILE.yaml
-  cp -rf ${SCRIPT_ROOT}/../eks-distro-base/golang_versions.yaml ./eks-distro-base/golang_versions.yaml
-  cp -rf ${SCRIPT_ROOT}/../builder-base/versions.yaml ./builder-base/versions.yaml
-  cp -rf ${SCRIPT_ROOT}/../builder-base/checksums/go-* ./builder-base/checksums/go-*
-  cp -rf ${SCRIPT_ROOT}/../eks-distro-base/make-tests/expected/*golang* ./eks-distro-base/make-tests/expected/*golang*
+  cp -f ${SCRIPT_ROOT}/../EKS_DISTRO_TAG_FILE.yaml ./EKS_DISTRO_TAG_FILE.yaml
+  cp -f ${SCRIPT_ROOT}/../eks-distro-base/golang_versions.yaml ./eks-distro-base/golang_versions.yaml
+  cp -f ${SCRIPT_ROOT}/../builder-base/versions.yaml ./builder-base/versions.yaml
+  cp -rf ${SCRIPT_ROOT}/../builder-base/checksums ./builder-base/checksums
+  cp -rf ${SCRIPT_ROOT}/../eks-distro-base/make-tests/expected ./eks-distro-base/make-tests/expected/
   git add ./EKS_DISTRO_TAG_FILE.yaml
   git add ./eks-distro-base/golang_versions.yaml
   git add ./builder-base/versions.yaml
-  git add ./builder-base/checksums/go*
+  git add ./builder-base/checksums/go-*
   git add ./eks-distro-base/make-tests/expected/*golang*
 fi
 

--- a/pr-scripts/create_pr.sh
+++ b/pr-scripts/create_pr.sh
@@ -120,11 +120,11 @@ if [[ $JOB_NAME =~ $MINIMAL_IMAGE_REBUILD_PJ_NAME ]]; then
 fi
 if [[ $JOB_NAME =~ $GOLANG_RELEASE_PERIODIC ]]; then
   # sync expected files changed during the previous make calls in aws/eks-distro-build-tooling to pr-bot fork
-  cp ${SCRIPT_ROOT}/../EKS_DISTRO_TAG_FILE.yaml ./EKS_DISTRO_TAG_FILE.yaml
-  cp ${SCRIPT_ROOT}/../eks-distro-base/golang_versions.yaml ./eks-distro-base/golang_versions.yaml
-  cp ${SCRIPT_ROOT}/../builder-base/versions.yaml ./builder-base/versions.yaml
-  cp ${SCRIPT_ROOT}/../builder-base/checksums/go* ./builder-base/checksums/go*
-  cp ${SCRIPT_ROOT}/../eks-distro-base/make-tests/expected/*golang* ./eks-distro-base/make-tests/expected/*golang*
+  cp -rf ${SCRIPT_ROOT}/../EKS_DISTRO_TAG_FILE.yaml ./EKS_DISTRO_TAG_FILE.yaml
+  cp -rf ${SCRIPT_ROOT}/../eks-distro-base/golang_versions.yaml ./eks-distro-base/golang_versions.yaml
+  cp -rf ${SCRIPT_ROOT}/../builder-base/versions.yaml ./builder-base/versions.yaml
+  cp -rf ${SCRIPT_ROOT}/../builder-base/checksums/go-* ./builder-base/checksums/go-*
+  cp -rf ${SCRIPT_ROOT}/../eks-distro-base/make-tests/expected/*golang* ./eks-distro-base/make-tests/expected/*golang*
   git add ./EKS_DISTRO_TAG_FILE.yaml
   git add ./eks-distro-base/golang_versions.yaml
   git add ./builder-base/versions.yaml


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Make targets run against the base `aws/eks-distro-build-tooling` repo. Other make targets using the `create-pr` target 
sync the changes using other scripts. For time being we can copy the expected files during this periodic only not using a sync script. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
