### PR TITLE
update images-upstream-bins to use default env vars to fix image push

### DIFF
--- a/projects/golang/go/Makefile
+++ b/projects/golang/go/Makefile
@@ -163,11 +163,6 @@ local-images-upstream-bins: export BUILDKIT_HOST=docker-container://buildkitd
 local-images-upstream-bins: images-upstream-bins
 
 .PHONY: images-upstream-bins
-images-upstream-bins: IMAGE_REPO=$(AWS_ACCOUNT_ID).dkr.ecr.$(AWS_REGION).amazonaws.com
-images-upstream-bins: IMAGE_NAME=golang-debian
-images-upstream-bins: IMAGE_TAG=$(GO_BIN_VERSION_WITHOUT_RELEASE)-$(BUILD_ID)-$(IMAGE_BUILD_ID)
-images-upstream-bins: LATEST_IMAGE=$(IMAGE_REPO)/$(IMAGE_NAME):$(GO_BIN_VERSION_WITHOUT_RELEASE)
-images-upstream-bins: IMAGE=$(IMAGE_REPO)/$(IMAGE_NAME):$(IMAGE_TAG),$(LATEST_IMAGE)
 images-upstream-bins: fetch-golang-upstream-bins buildkit-check
 images-upstream-bins:
 	$(BASE_DIRECTORY)/scripts/buildkit.sh \


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
