### PR TITLE
Fix new golang minor version release automation path

### DIFF
--- a/eks-distro-base/scripts/check_upstream_golang
+++ b/eks-distro-base/scripts/check_upstream_golang
@@ -30,7 +30,7 @@ function update::go::version {
   if [[ -z $(MINORVERSION=$minorversion yq 'eval(.golang.variants[] | select(. == env(MINORVERSION)))' $VERSIONS_YAML) ]]; then
     MINORVERSION=$minorversion yq '.golang.variants += env(MINORVERSION)' -i $VERSIONS_YAML
     # Update make-tests GO_VERSION_OVERRIDES
-    sed -i -E "s/(GO_VERSION_OVERRIDES=.*$)/$(grep 'GO_VERSION_OVERRIDES=' ${SCRIPT_ROOT}/../make-tests/make-dry-run | sed -E "s/\"$/  GOLANG_${MINORVERSION}_FULL_VERSION=${MINORVERSION}-mock\"/")/g" ${SCRIPT_ROOT}/make-tests/make-dry-run
+    sed -i -E "s/(GO_VERSION_OVERRIDES=.*$)/$(grep 'GO_VERSION_OVERRIDES=' ${SCRIPT_ROOT}/../make-tests/make-dry-run | sed -E "s/\"$/  GOLANG_${minorversion}_FULL_VERSION=${minorversion}-mock\"/")/g" ${SCRIPT_ROOT}/../make-tests/make-dry-run
   fi
 
   # Patch Version update if needed


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
use `minorversion` instead of `MINORVERSION` in `sed` command. `MINORVERSION` is used in yq and not being persisted as expected. `minorversion` should accomplish same thing and shows as set correctly in logs.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
