### PR TITLE
if al2023, then install nftables

### DIFF
--- a/eks-distro-base/Dockerfile.minimal-base-iptables
+++ b/eks-distro-base/Dockerfile.minimal-base-iptables
@@ -53,7 +53,7 @@ RUN set -x && \
         kmod \
         iptables-nft && \
     if_al2 install_rpm iptables ebtables && \
-    if_al2023 install_rpm iptables-legacy ebtables-legacy && \
+    if_al2023 install_rpm iptables-legacy ebtables-legacy nftables && \
     # The original iptables-wrapper.sh script assumed that there were both iptables and ip6tables 
     # alternatives setup since the upstream image was based on debian which sets them up that way
     # AL2 follows RHEL which uses a single alternaive setup for both iptables and ip6tables


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

For supporting the nftables-based backend beta feature in EKS 1.31 for kube-proxy, we'll need to install ntables into the al2023 image used to build kube-proxy.
This PR is a *very* tiny change to allow the nftables binary to be installed

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
