### PR TITLE
Ensure correct Dockerfile is used for deck image builds

### DIFF
--- a/projects/kubernetes/test-infra/Makefile
+++ b/projects/kubernetes/test-infra/Makefile
@@ -27,7 +27,7 @@ prow-controller-manager/images/%: BASE_IMAGE_NAME=k8s-prow/prow-controller-manag
 
 prow-statusreconciler/images/%: BASE_IMAGE_NAME=k8s-prow/status-reconciler
 
-prow-deck/images/%: DOCKERFILE_FOLDER?=./docker/linux/deck
+prow-deck/images/%: DOCKERFILE_FOLDER=./docker/linux/deck
 
 .PHONY: buildkit-check
 buildkit-check:

--- a/projects/kubernetes/test-infra/docker/linux/deck/Dockerfile
+++ b/projects/kubernetes/test-infra/docker/linux/deck/Dockerfile
@@ -2,10 +2,10 @@ ARG BASE_IMAGE
 FROM $BASE_IMAGE
 
 # Copy local files instead of downloading using external CDN
-COPY static/material/1.3.0/material.min.js /static/material/1.3.0/
-COPY static/material/1.3.0/material.indigo-pink.min.css /static/material/1.3.0/
+COPY docker/linux/deck/static/material/1.3.0/material.min.js /static/material/1.3.0/
+COPY docker/linux/deck/static/material/1.3.0/material.indigo-pink.min.css /static/material/1.3.0/
 
 
 # Update HTML references
-RUN find /template -type f -iname '*.html' -exec sed -i -e 's,https://code.getmdl.io/1.3.0/,/static/material/1.3.0/,g' {} \;
-RUN find /lenses/podinfo -type f -iname '*.html' -exec sed -i -e 's,https://code.getmdl.io/1.3.0/,/static/material/1.3.0/,g' {} \;
+RUN find /var/run/ko/template -type f -iname '*.html' -exec sed -i -e 's,https://code.getmdl.io/1.3.0/,/static/material/1.3.0/,g' {} \;
+RUN find /var/run/ko/lenses/podinfo -type f -iname '*.html' -exec sed -i -e 's,https://code.getmdl.io/1.3.0/,/static/material/1.3.0/,g' {} \;


### PR DESCRIPTION
Ensure correct Dockerfile is used for deck image builds

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
