### PR TITLE
Fix target directory for static scripts

### DIFF
--- a/projects/kubernetes/test-infra/docker/linux/deck/Dockerfile
+++ b/projects/kubernetes/test-infra/docker/linux/deck/Dockerfile
@@ -2,10 +2,9 @@ ARG BASE_IMAGE
 FROM $BASE_IMAGE
 
 # Copy local files instead of downloading using external CDN
-COPY docker/linux/deck/static/material/1.3.0/material.min.js /static/material/1.3.0/
-COPY docker/linux/deck/static/material/1.3.0/material.indigo-pink.min.css /static/material/1.3.0/
-
+COPY docker/linux/deck/static/material/1.3.0/material.min.js /var/run/ko/static/material/1.3.0/
+COPY docker/linux/deck/static/material/1.3.0/material.indigo-pink.min.css /var/run/ko/static/material/1.3.0/
 
 # Update HTML references
 RUN find /var/run/ko/template -type f -iname '*.html' -exec sed -i -e 's,https://code.getmdl.io/1.3.0/,/static/material/1.3.0/,g' {} \;
-RUN find /var/run/ko/lenses/podinfo -type f -iname '*.html' -exec sed -i -e 's,https://code.getmdl.io/1.3.0/,/static/material/1.3.0/,g' {} \;
+RUN find /var/run/ko/lenses -type f -iname '*.html' -exec sed -i -e 's,https://code.getmdl.io/1.3.0/,/static/material/1.3.0/,g' {} \;


### PR DESCRIPTION
The static files in the Prow `deck` image are stored in and accessed from the `/var/run/ko/` directory, so ones we copy into the image should also be placed there.

Also included the entire `lenses` folder since I noticed an HTML file using the `code.getmdl.io` CDN in `lenses/common` directory, which wasn't getting replaced.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
