### PR TITLE
Skipping the kubernetes-csi/external-snapshotter images to update

### DIFF
--- a/release/pkg/assets_snapshotter.go
+++ b/release/pkg/assets_snapshotter.go
@@ -31,7 +31,7 @@ func (r *ReleaseConfig) GetSnapshotterComponent(spec distrov1alpha1.ReleaseSpec)
 		return nil, errors.Cause(err)
 	}
 	assets := []distrov1alpha1.Asset{}
-	binaries := []string{"csi-snapshotter", "snapshot-controller", "snapshot-validation-webhook"}
+	binaries := []string{"csi-snapshotter", "snapshot-controller"}
 	for _, binary := range binaries {
 		assets = append(assets, distrov1alpha1.Asset{
 			Name:        fmt.Sprintf("%s-image", binary),

--- a/release/pkg/generate_spec.go
+++ b/release/pkg/generate_spec.go
@@ -18,6 +18,7 @@ import (
 	"net/url"
 	"strings"
 	"time"
+	"fmt"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ecrpublic"

--- a/release/pkg/generate_spec.go
+++ b/release/pkg/generate_spec.go
@@ -18,7 +18,6 @@ import (
 	"net/url"
 	"strings"
 	"time"
-	"fmt"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ecrpublic"

--- a/release/pkg/generate_spec.go
+++ b/release/pkg/generate_spec.go
@@ -87,11 +87,6 @@ func UpdateImageDigests(ecrPublicClient *ecrpublic.ECRPublic, r *ReleaseConfig, 
 				releaseUriSplit := strings.Split(asset.Image.URI, ":")
 				repoName := strings.Replace(releaseUriSplit[0], r.ContainerImageRepository+"/", "", -1)
 				imageTag = releaseUriSplit[1]
-				// Skip updating digest for the specific repository kubernetes-csi/external-snapshotter/snapshot-validation-webhook
-				if repoName == "kubernetes-csi/external-snapshotter/snapshot-validation-webhook" {
-					fmt.Printf("Skipping digest update for %s:%s\n", repoName, imageTag)
-					continue
-				}
 				describeImagesOutput, err := ecrPublicClient.DescribeImages(
 					&ecrpublic.DescribeImagesInput{
 						ImageIds: []*ecrpublic.ImageIdentifier{

--- a/release/pkg/generate_spec.go
+++ b/release/pkg/generate_spec.go
@@ -86,6 +86,11 @@ func UpdateImageDigests(ecrPublicClient *ecrpublic.ECRPublic, r *ReleaseConfig, 
 				releaseUriSplit := strings.Split(asset.Image.URI, ":")
 				repoName := strings.Replace(releaseUriSplit[0], r.ContainerImageRepository+"/", "", -1)
 				imageTag = releaseUriSplit[1]
+				// Skip updating digest for the specific repository kubernetes-csi/external-snapshotter/snapshot-validation-webhook
+				if repoName == "kubernetes-csi/external-snapshotter/snapshot-validation-webhook" {
+					fmt.Printf("Skipping digest update for %s:%s\n", repoName, imageTag)
+					continue
+				}
 				describeImagesOutput, err := ecrPublicClient.DescribeImages(
 					&ecrpublic.DescribeImagesInput{
 						ImageIds: []*ecrpublic.ImageIdentifier{


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Skipping to update the images. for mpvarma/update-checking-csi-snapshotter as this image is bumped but not published to the external repo. 
```
Error updating image digests: ImageNotFoundException: The image with imageId {imageDigest:'null', imageTag:'v8.2.0-eks-1-29-30'} does not exist within the repository with name 'kubernetes-csi/external-snapshotter/snapshot-validation-webhook' in the registry with id '316434458148'
```
https://prow.eks.amazonaws.com/view/s3/prowdataclusterstack-316434458-prowbucket7c73355c-1n9f9v93wpjcm/logs/dev-release-1-29-postsubmit/1869869112969138176#2:build-container-build-log.txt%3A8080

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
