### PR TITLE
Bump go version for iptables-wrappers to 1.23

### DIFF
--- a/eks-distro-base/iptables-wrappers/go.mod
+++ b/eks-distro-base/iptables-wrappers/go.mod
@@ -1,3 +1,3 @@
 module github.com/kubernetes-sigs/iptables-wrappers
 
-go 1.19
+go 1.23


### PR DESCRIPTION
Bump go version for iptables-wrappers

*Issue #, if available:*
Outdated go version is causing test coverage failures: https://github.com/aws/eks-distro-build-tooling/actions/runs/12286979132/job/34288142977?pr=1576

*Description of changes:*
Bump to the go 1.23

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
