### PR TITLE
Bump go versions in the workflows

### DIFF
--- a/.github/workflows/go-coverage.yml
+++ b/.github/workflows/go-coverage.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: "1.19"
+          go-version: "1.23"
       - name: Run go test with coverage
         run: |
           cd tools/eksDistroBuildToolingOpsTools/

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version: "1.21"
+          go-version: "1.23"
       - run: go version
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3


### PR DESCRIPTION
*Issue #, if available:*
Bump outdated go version in the workflows

*Description of changes:*
Bumped from 1.19 to 1.23 so that the latest dependencies can run.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
