### PR TITLE
Fix coverage test; point minimal build version to Go 1.22

### DIFF
--- a/.github/workflows/go-coverage.yml
+++ b/.github/workflows/go-coverage.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: "1.23"
+          go-version: "1.22"
       - name: Run go test with coverage
         run: |
           cd tools/eksDistroBuildToolingOpsTools/

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version: "1.23"
+          go-version: "1.22"
       - run: go version
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3

--- a/eks-distro-base/iptables-wrappers/go.mod
+++ b/eks-distro-base/iptables-wrappers/go.mod
@@ -1,3 +1,3 @@
 module github.com/kubernetes-sigs/iptables-wrappers
 
-go 1.23
+go 1.22

--- a/release/Makefile
+++ b/release/Makefile
@@ -8,7 +8,7 @@ else
 GOBIN=$(shell go env GOBIN)
 endif
 
-export PATH:=/go/go1.19/bin:$(PATH)
+export PATH:=/go/go1.22/bin:$(PATH)
 
 all: build
 

--- a/release/go.mod
+++ b/release/go.mod
@@ -1,6 +1,6 @@
 module github.com/aws/eks-distro-build-tooling/release
 
-go 1.20
+go 1.22
 
 require (
 	github.com/aws/aws-sdk-go v1.38.40

--- a/tools/eksDistroBuildToolingOpsTools/go.mod
+++ b/tools/eksDistroBuildToolingOpsTools/go.mod
@@ -1,6 +1,6 @@
 module github.com/aws/eks-distro-build-tooling/tools/eksDistroBuildToolingOpsTools
 
-go 1.19
+go 1.22
 
 require (
 	github.com/aws/aws-sdk-go v1.44.331


### PR DESCRIPTION
*Issue #, if available:*
Test coverage was failing because it was looking for `crypto/ecdh` in 1.19, which it doesn't exist.

*Description of changes:*
Point the minimal versions in the build process to Go 1.22. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
