### PR TITLE
Remove EKS-A build-tooling repository from tags automation

### DIFF
--- a/eks-distro-base/README.md
+++ b/eks-distro-base/README.md
@@ -10,7 +10,9 @@ If security updates are found, a new image is built and pushed to
 [ECR](https://gallery.ecr.aws/eks-distro-build-tooling/eks-distro-base).  A PR is then automatically created to update the EKS_DISTRO_BASE_TAG_FILE 
 file in this repo, which is the source of truth of the latest base image versions for each of the listed images ([example](https://github.com/aws/eks-distro-build-tooling/pull/807/files)). 
 
-Once that PR merges, a postsubmit runs to update the dependent EKS_DISTRO_*_TAG_FILEs in [eks-distro](https://github.com/aws/eks-distro) and [eks-anywhere-build-tooling](https://github.com/aws/eks-anywhere-build-tooling) for each of the images that received a package update ([example](https://github.com/aws/eks-anywhere-build-tooling/pull/1820)).
+Once that PR merges, a postsubmit runs to update the dependent EKS_DISTRO_*_TAG_FILEs in [eks-distro](https://github.com/aws/eks-distro) and [eks-anywhere](https://github.com/aws/eks-anywhere) for each of the images that received a package update ([example](https://github.com/aws/eks-anywhere/pull/8597)).
+
+Previously the base images in the [eks-anywhere-build-tooling](https://github.com/aws/eks-anywhere-build-tooling) were also directly updated by this automation (similar to EKS Distro) but now they are managed by their own [version-tracker tool](https://github.com/aws/eks-anywhere-build-tooling/tree/main/tools/version-tracker) which checks daily for new base image tags and opens automatic PRs to update them.
 
 The standard variant is currently the base image for EKS-D versions 1.18-1.21, but is not intended to be the base for future EKS-D versions or new container images.  
 The minimal variants are now recommended where possible.

--- a/eks-distro-base/update_base_image_other_repos.sh
+++ b/eks-distro-base/update_base_image_other_repos.sh
@@ -28,7 +28,7 @@ else
 fi
 
 
-REPOS=(eks-distro eks-anywhere-build-tooling eks-anywhere)
+REPOS=(eks-distro eks-anywhere)
 for repo in "${REPOS[@]}"; do
     ${SCRIPT_ROOT}/../pr-scripts/update_local_branch.sh "$repo"
 


### PR DESCRIPTION
After [this](https://github.com/aws/eks-anywhere-build-tooling/pull/4195) change in eks-anywhere-build-tooling, this automation is no longer required since the new images are polled for and updated.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
