### PR TITLE
Trigger builder-base update for iptables

### DIFF
--- a/EKS_DISTRO_TAG_FILE.yaml
+++ b/EKS_DISTRO_TAG_FILE.yaml
@@ -3,7 +3,7 @@ al2:
   eks-distro-minimal-base: 2024-08-13-1723575672.2
   eks-distro-minimal-base-nonroot: 2024-08-13-1723575672.2
   eks-distro-minimal-base-glibc: 2024-12-20-1734721295.2
-  eks-distro-minimal-base-iptables: 2024-12-20-1734721295.2
+  eks-distro-minimal-base-iptables: null
   eks-distro-minimal-base-docker-client: 2024-12-20-1734721295.2
   eks-distro-minimal-base-csi: 2025-01-10-1736535672.2
   eks-distro-minimal-base-csi-ebs: 2024-12-20-1734721295.2
@@ -54,7 +54,7 @@ al2023:
   eks-distro-minimal-base: 2025-01-01-1735689705.2023
   eks-distro-minimal-base-nonroot: 2025-01-01-1735689705.2023
   eks-distro-minimal-base-glibc: 2025-01-01-1735689705.2023
-  eks-distro-minimal-base-iptables: 2025-01-01-1735689705.2023
+  eks-distro-minimal-base-iptables: null
   eks-distro-minimal-base-docker-client: 2025-01-01-1735689705.2023
   eks-distro-minimal-base-csi: 2025-01-10-1736535671.2023
   eks-distro-minimal-base-csi-ebs: 2025-01-01-1735689705.2023


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

We have identified a CVE in kube-proxy, which uses the base image public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-iptables:latest-al23. To address this, we need to create a new image with an updated Go patch version.

![image](https://github.com/user-attachments/assets/868fd91b-07cb-4b39-b334-373457e5ccff)



Reproduce:

```
trivy image public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-iptables:latest-al23

trivy image public.ecr.aws/eks-distro/kubernetes/kube-proxy:v1.31.4-eks-1-31-latest

```



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
