### PR TITLE
trigger a new python 3.11 al23 image

### DIFF
--- a/EKS_DISTRO_TAG_FILE.yaml
+++ b/EKS_DISTRO_TAG_FILE.yaml
@@ -68,7 +68,7 @@ al2023:
   eks-distro-minimal-base-nsenter: 2025-01-01-1735689705.2023
   eks-distro-minimal-base-python-3.7: null
   eks-distro-minimal-base-python-3.9: 3.9-2025-04-02-1743620476.2023
-  eks-distro-minimal-base-python-3.11: 3.11-2025-03-13-1741889715.2023
+  eks-distro-minimal-base-python-3.11: null
   eks-distro-minimal-base-nodejs-16: 16-2025-05-01-1746082883.2023
   eks-distro-minimal-base-compiler-base: 2025-04-30-1746043275.2023
   eks-distro-minimal-base-compiler-yum: yum-2025-04-30-1746043275.2023


### PR DESCRIPTION
*Issue #, if available:*

We use this image as the base of the emissary image which also needs to install curl on top.  https://github.com/aws/eks-anywhere-build-tooling/blob/main/projects/emissary-ingress/emissary/docker/linux/emissary/Dockerfile#L10

This started failing recently due to errors like:

`/newroot/usr/bin/openssl: /newroot/lib64/libcrypto.so.3: version `OPENSSL_3.2.0'\'' not found (required by /newroot/usr/bin/openssl)` 

when trying to run ldd on the curl binary and other libraries. Im pretty sure this is due to changes in openssl version recently in al23, but we havent had a new python3.11 build since.  We the emissary build tries to install curl, its getting newer versions of the curl package which depend on the newwer openssl/crypto.

Forcing a new python 3.11 build *should* resolve this downstream.

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
