### PR TITLE
updating eks-d-common file to fix Binary Installation Failure in eks-distro-minimal-base-builder:latest-al23 Image

### DIFF
--- a/eks-distro-base/Dockerfile.minimal-base-iptables
+++ b/eks-distro-base/Dockerfile.minimal-base-iptables
@@ -51,7 +51,13 @@ RUN set -x && \
     install_rpm conntrack-tools \
         ipset \
         kmod \
-        iptables-nft && \
+        iptables-nft \
+        libevent \
+        libnfnetlink \
+        libnetfilter_conntrack \
+        libnetfilter_cthelper \
+        libnetfilter_cttimeout \
+        libnetfilter_queue && \
     if_al2 install_rpm iptables ebtables && \
     if_al2023 install_rpm iptables-legacy ebtables-legacy nftables && \
     if_al2023 yum --installroot $NEWROOT install -y --setopt=install_weak_deps=False pam && \

--- a/eks-distro-base/scripts/eks-d-common
+++ b/eks-distro-base/scripts/eks-d-common
@@ -88,7 +88,8 @@ function build::common::binary_to_libraries() {
     [[ ! $binary == *".so"* ]] && echo "Finding libraries for ${binary}"
 
     # see: https://man7.org/linux/man-pages/man1/ldd.1.html
-    local -r ldd_output=$(LD_LIBRARY_PATH=$ld_library_path ldd "${binary}" 2>&1)
+    local ldd_output_with_path=$(LD_LIBRARY_PATH=$ld_library_path ldd "${binary}" 2>&1)
+    local -r ldd_output=$(if [[ $ldd_output_with_path == *"symbol lookup error"* ]] || [[ $ldd_output_with_path == *"undefined symbol"* ]]; then ldd "${binary}" 2>&1; else echo "$ldd_output_with_path"; fi)
     local needed_libraries=""
     local objdump_fallback="false"
     if [[ $ldd_output == *"core dump"* ]] || [[ $ldd_output == *"Segmentation"* ]] || [[ $ldd_output == *"exited with unknown exit code"* ]] \
@@ -109,7 +110,8 @@ function build::common::binary_to_libraries() {
                 | awk '{print $1}' \
                 `# linux-vdso.so.1 is a special virtual shared object from the kernel` \
                 `# see: http://man7.org/linux/man-pages/man7/vdso.7.html` \
-                | grep -v 'linux-vdso.so.1'
+                | grep -v 'linux-vdso.so.1' \
+                | grep '^/'
             )
         fi
     fi
@@ -122,6 +124,8 @@ function build::common::binary_to_libraries() {
     if [ -n "${needed_libraries}" ]; then
         local full_paths=""
         while IFS= read -r library; do             
+            # Skip empty lines
+            [ -z "$library" ] && continue           
             local full_path=""
 
             # already a full path
@@ -571,4 +575,5 @@ function build::common::install_deps_for_binary() {
         done
     done
 }
+
 


### PR DESCRIPTION
Issue #, if available: Binary installation process was failing with "Exit code 1" error when processing dependencies for bash and other binaries. The error occurred during library dependency detection, where /usr/bin/bash: was incorrectly being treated as a library dependency instead of the actual required libraries.
The issue was caused by incompatible libraries in the NEWROOT directory causing ldd to fail with symbol lookup errors when using a custom LD_LIBRARY_PATH. The error message format /usr/bin/bash: symbol lookup error: ... was being parsed by the pipeline and incorrectly identified as /usr/bin/bash: (a library dependency), leading to downstream failures when trying to find packages for this invalid library name.

Description of changes:
Added fallback mechanism for ldd command: Detects when custom LD_LIBRARY_PATH causes symbol lookup errors and falls back to normal ldd execution
Improved output filtering: Added grep '^/' filter to ensure only valid full library paths are processed
Enhanced loop processing: Added empty line validation to prevent processing of malformed entries

Verified fix resolves the issue by testing binary installation process with both compatible and incompatible library environments. The fallback mechanism correctly handles symbol lookup errors while maintaining normal operation for standard cases.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
