### PR TITLE
Skip digest updates for external CSI components

### DIFF
--- a/release/pkg/generate_spec.go
+++ b/release/pkg/generate_spec.go
@@ -82,6 +82,10 @@ func UpdateImageDigests(ecrPublicClient *ecrpublic.ECRPublic, r *ReleaseConfig, 
 		assets := componentDer.Assets
 		for _, asset := range assets {
 			if asset.Image != nil {
+				// Skip digest updates for external CSI components
+				if strings.Contains(asset.Image.URI, "public.ecr.aws/csi-components/") {
+					continue
+				}
 				var imageTag string
 				releaseUriSplit := strings.Split(asset.Image.URI, ":")
 				repoName := strings.Replace(releaseUriSplit[0], r.ContainerImageRepository+"/", "", -1)


### PR DESCRIPTION
https://prow.eks.amazonaws.com/log?container=build-container&id=1953229388086513664&job=dev-release-1-34-postsubmit

```
go build -o bin/eks-distro-release main.go
make[1]: Leaving directory `/home/prow/go/src/github.com/aws/eks-distro/eks-distro-build-tooling/release'
+ DESTINATION=./kubernetes-1-34/kubernetes-1-34-eks-1.yaml
+ ./eks-distro-build-tooling/release/bin/eks-distro-release release --image-repository public.ecr.aws/h1r8a7l5 --release-branch 1-34 --release-number 1 --dev-release=true
+ tee ./kubernetes-1-34/kubernetes-1-34-eks-1.yaml
Error updating image digests: RepositoryNotFoundException: The repository with name 'public.ecr.aws/csi-components/csi-node-driver-registrar' does not exist in the registry with id '316434458148'
make: *** [upload] Error 1
{"component":"entrypoint","error":"wrapped process failed: exit status 2","file":"k8s.io/test-infra/prow/entrypoint/run.go:79","func":"k8s.io/test-infra/prow/entrypoint.Options.Run","level":"error","msg":"Error executing test process","severity":"error","time":"2025-08-06T23:35:38Z"}
```

CSI components are now hosted in public.ecr.aws/csi-components/ registry and are external to EKS-D. The release tooling was failing when trying to fetch digests from the EKS-D registry for these external images.