### PR TITLE
Trigger rebuild for iptables base image update

### DIFF
--- a/EKS_DISTRO_TAG_FILE.yaml
+++ b/EKS_DISTRO_TAG_FILE.yaml
@@ -3,13 +3,13 @@ al2:
   eks-distro-minimal-base: 2025-04-01-1743465687.2
   eks-distro-minimal-base-nonroot: 2025-04-01-1743465687.2
   eks-distro-minimal-base-glibc: 2025-10-28-1761678121.2
-  eks-distro-minimal-base-iptables: 2025-10-28-1761678121.2
+  eks-distro-minimal-base-iptables: null
   eks-distro-minimal-base-docker-client: 2025-10-28-1761678121.2
   eks-distro-minimal-base-csi: 2025-10-28-1761678121.2
   eks-distro-minimal-base-csi-ebs: 2025-10-28-1761678121.2
   eks-distro-minimal-base-haproxy: 2025-10-28-1761678121.2
   eks-distro-minimal-base-kind: 2025-10-28-1761678121.2
-  eks-distro-minimal-base-nginx: 2025-10-28-1761678121.2
+  eks-distro-minimal-base-nginx: null
   eks-distro-minimal-base-git: 2025-10-28-1761678121.2
   eks-distro-minimal-base-nsenter: 2025-10-28-1761678121.2
   eks-distro-minimal-base-python-3.7: 3.7-2025-10-28-1761678121.2
@@ -60,13 +60,13 @@ al2023:
   eks-distro-minimal-base: 2025-07-01-1751328074.2023
   eks-distro-minimal-base-nonroot: 2025-07-01-1751328074.2023
   eks-distro-minimal-base-glibc: 2025-09-17-1758135703.2023
-  eks-distro-minimal-base-iptables: 2025-10-16-1760641277.2023
+  eks-distro-minimal-base-iptables: null
   eks-distro-minimal-base-docker-client: 2025-10-16-1760641277.2023
   eks-distro-minimal-base-csi: 2025-10-28-1761678072.2023
   eks-distro-minimal-base-csi-ebs: 2025-09-17-1758135703.2023
   eks-distro-minimal-base-haproxy: 2025-10-16-1760641277.2023
   eks-distro-minimal-base-kind: 2025-10-28-1761678072.2023
-  eks-distro-minimal-base-nginx: 2025-10-16-1760641277.2023
+  eks-distro-minimal-base-nginx: null
   eks-distro-minimal-base-git: 2025-10-16-1760641277.2023
   eks-distro-minimal-base-nsenter: 2025-09-17-1758135703.2023
   eks-distro-minimal-base-python-3.7: null


### PR DESCRIPTION
Set eks-distro-minimal-base-iptables to null for both AL2 and AL2023 to trigger a rebuild of the iptables base images.

Changes:
- al2.eks-distro-minimal-base-iptables: null
- al2023.eks-distro-minimal-base-iptables: null

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
