### PR TITLE
Add check_no_shell test for minimal images

### DIFF
--- a/eks-distro-base/Makefile
+++ b/eks-distro-base/Makefile
@@ -16,6 +16,7 @@ IMAGE_REPO?=$(AWS_ACCOUNT_ID).dkr.ecr.$(AWS_REGION).amazonaws.com
 JOB_TYPE?=
 TEST_IMAGE_REPO?=localhost:5000
 IGNORE_NO_CACHE?=false
+SECURITY?=
 # ******************** Helpers ******************************
 # For replacing commas or with commas, it needs to be in a var
 COMMA=,

--- a/eks-distro-base/tests/Dockerfile
+++ b/eks-distro-base/tests/Dockerfile
@@ -52,3 +52,8 @@ COPY --from=iptables-wrapper-tests-builder /iptables-wrappers/bin/tests /
 
 CMD ["iptables"]
 
+FROM ${BASE_IMAGE} as check-no-shell
+
+CMD ["/bin/sh", "-c", "exit 0"]
+
+


### PR DESCRIPTION
*Description of changes:*

Add shell detection tests to minimal base images to prevent accidental shell inclusion via package dependencies. Adds check_no_shell() test function to 8 images that should not contain shells: 
```
minimal-base, nonroot, glibc, iptables, csi-ebs, docker-client, haproxy, and nsenter. 
```
Test attempts to execute /bin/sh and fails if successful. Verified test passes without shell and fails when 
shell is present.

Does not apply to all minimal images. Some minimal images contain shells.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
