### PR TITLE
chore(ci): use minimal github token permissions

### DIFF
--- a/.github/workflows/kopsRelease.yaml
+++ b/.github/workflows/kopsRelease.yaml
@@ -6,6 +6,8 @@ on:
 
 jobs:
   kops_release:
+    permissions:
+      issues: write
     name: kOps Release Check
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Use minimal GitHub Token permissions for kopsRelease.yaml workflow.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
