### PR TITLE
Remove pod-infra-container patch for kops

### DIFF
--- a/projects/kubernetes/kops/patches/0004-remove-pod-infra-container.patch
+++ b/projects/kubernetes/kops/patches/0004-remove-pod-infra-container.patch
@@ -1,0 +1,8324 @@
+From c3ec223d6e50efb7c1a97c12445174f4b2b9fdf6 Mon Sep 17 00:00:00 2001
+From: Ganesh Putta <ganiredi@amazon.com>
+Date: Wed, 10 Dec 2025 13:07:50 -0600
+Subject: [PATCH] Remove podInfraContainerImage and add sandboxImage to
+ containerd config
+
+Cherry-pick of https://github.com/kubernetes/kops/pull/17657
+
+This change removes the deprecated podInfraContainerImage field from
+KubeletConfigSpec and adds sandboxImage to ContainerdConfig. The pause
+container image is now configured via containerd's sandboxImage setting
+instead of the kubelet's --pod-infra-container-image flag, which aligns
+with the containerd-native approach for specifying the sandbox image.
+
+---
+ k8s/crds/kops.k8s.io_clusters.yaml              | 13 +++++++++----
+ k8s/crds/kops.k8s.io_instancegroups.yaml        |  8 ++++++--
+ nodeup/pkg/model/containerd.go                  |  4 ++--
+ .../tests/containerdbuilder/complex/tasks.yaml  |  2 +-
+ .../tests/containerdbuilder/flatcar/tasks.yaml  |  2 +-
+ .../tests/containerdbuilder/simple/tasks.yaml   |  2 +-
+ pkg/apis/kops/componentconfig.go                |  3 ++-
+ pkg/apis/kops/containerdconfig.go               |  2 ++
+ pkg/apis/kops/v1alpha2/componentconfig.go       |  3 ++-
+ pkg/apis/kops/v1alpha2/containerdconfig.go      |  2 ++
+ .../kops/v1alpha2/zz_generated.conversion.go    |  2 ++
+ pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go |  5 +++++
+ pkg/apis/kops/v1alpha3/componentconfig.go       |  3 ++-
+ pkg/apis/kops/v1alpha3/containerdconfig.go      |  2 ++
+ .../kops/v1alpha3/zz_generated.conversion.go    |  2 ++
+ pkg/apis/kops/v1alpha3/zz_generated.deepcopy.go |  5 +++++
+ pkg/apis/kops/validation/validation.go          |  8 ++++++++
+ pkg/apis/kops/zz_generated.deepcopy.go          |  5 +++++
+ pkg/model/components/containerd.go              | 17 +++++++++++++++--
+ pkg/model/components/kubelet.go                 |  9 ---------
+ ...ters.additionalobjects.example.com_user_data |  2 +-
+ ...odes.additionalobjects.example.com_user_data |  2 +-
+ ...aws_s3_object_cluster-completed.spec_content |  3 +--
+ ...bject_nodeupconfig-master-us-test-1a_content |  2 +-
+ .../aws_s3_object_nodeupconfig-nodes_content    |  2 +-
+ ...ver.apiservers.minimal.example.com_user_data |  2 +-
+ ...est-1a.masters.minimal.example.com_user_data |  2 +-
+ ...template_nodes.minimal.example.com_user_data |  2 +-
+ ...aws_s3_object_cluster-completed.spec_content |  3 +--
+ ...aws_s3_object_nodeupconfig-apiserver_content |  2 +-
+ ...bject_nodeupconfig-master-us-test-1a_content |  2 +-
+ .../aws_s3_object_nodeupconfig-nodes_content    |  2 +-
+ ...est-1a.masters.minimal.example.com_user_data |  2 +-
+ ...template_nodes.minimal.example.com_user_data |  2 +-
+ ...aws_s3_object_cluster-completed.spec_content |  3 +--
+ ...bject_nodeupconfig-master-us-test-1a_content |  2 +-
+ .../aws_s3_object_nodeupconfig-nodes_content    |  2 +-
+ ...asters.bastionuserdata.example.com_user_data |  2 +-
+ ..._nodes.bastionuserdata.example.com_user_data |  2 +-
+ ...aws_s3_object_cluster-completed.spec_content |  3 +--
+ .../aws_s3_object_nodeupconfig-bastion_content  |  2 +-
+ ...bject_nodeupconfig-master-us-test-1a_content |  2 +-
+ .../aws_s3_object_nodeupconfig-nodes_content    |  2 +-
+ ...iority-expander-custom.example.com_user_data |  2 +-
+ ...iority-expander-custom.example.com_user_data |  2 +-
+ ...iority-expander-custom.example.com_user_data |  2 +-
+ ...iority-expander-custom.example.com_user_data |  2 +-
+ ...aws_s3_object_cluster-completed.spec_content |  3 +--
+ ...bject_nodeupconfig-master-us-test-1a_content |  2 +-
+ ...ect_nodeupconfig-nodes-high-priority_content |  2 +-
+ ...ject_nodeupconfig-nodes-low-priority_content |  2 +-
+ .../aws_s3_object_nodeupconfig-nodes_content    |  2 +-
+ ....cas-priority-expander.example.com_user_data |  2 +-
+ ....cas-priority-expander.example.com_user_data |  2 +-
+ ....cas-priority-expander.example.com_user_data |  2 +-
+ ....cas-priority-expander.example.com_user_data |  2 +-
+ ...aws_s3_object_cluster-completed.spec_content |  3 +--
+ ...bject_nodeupconfig-master-us-test-1a_content |  2 +-
+ ...ect_nodeupconfig-nodes-high-priority_content |  2 +-
+ ...ject_nodeupconfig-nodes-low-priority_content |  2 +-
+ .../aws_s3_object_nodeupconfig-nodes_content    |  2 +-
+ ...est-1a.masters.complex.example.com_user_data |  2 +-
+ ...template_nodes.complex.example.com_user_data |  2 +-
+ ...aws_s3_object_cluster-completed.spec_content |  3 +--
+ ...bject_nodeupconfig-master-us-test-1a_content |  2 +-
+ .../aws_s3_object_nodeupconfig-nodes_content    |  2 +-
+ ...aws_s3_object_cluster-completed.spec_content |  3 +--
+ ...bject_nodeupconfig-master-us-test-1a_content |  2 +-
+ .../aws_s3_object_nodeupconfig-nodes_content    |  2 +-
+ ...-1a.masters.containerd.example.com_user_data |  2 +-
+ ...plate_nodes.containerd.example.com_user_data |  2 +-
+ ...aws_s3_object_cluster-completed.spec_content |  3 +--
+ ...bject_nodeupconfig-master-us-test-1a_content |  2 +-
+ .../aws_s3_object_nodeupconfig-nodes_content    |  2 +-
+ .../update_cluster/containerd/assets.yaml       |  4 ++--
+ ...-1a.masters.containerd.example.com_user_data |  2 +-
+ ...plate_nodes.containerd.example.com_user_data |  2 +-
+ ...aws_s3_object_cluster-completed.spec_content |  3 +--
+ ...bject_nodeupconfig-master-us-test-1a_content |  2 +-
+ .../aws_s3_object_nodeupconfig-nodes_content    |  2 +-
+ ...us-test-1a.masters.123.example.com_user_data |  2 +-
+ ...nch_template_nodes.123.example.com_user_data |  2 +-
+ ...aws_s3_object_cluster-completed.spec_content |  3 +--
+ ...bject_nodeupconfig-master-us-test-1a_content |  2 +-
+ .../aws_s3_object_nodeupconfig-nodes_content    |  2 +-
+ ...a.masters.existing-iam.example.com_user_data |  2 +-
+ ...b.masters.existing-iam.example.com_user_data |  2 +-
+ ...c.masters.existing-iam.example.com_user_data |  2 +-
+ ...ate_nodes.existing-iam.example.com_user_data |  2 +-
+ ...aws_s3_object_cluster-completed.spec_content |  3 +--
+ ...bject_nodeupconfig-master-us-test-1a_content |  2 +-
+ ...bject_nodeupconfig-master-us-test-1b_content |  2 +-
+ ...bject_nodeupconfig-master-us-test-1c_content |  2 +-
+ .../aws_s3_object_nodeupconfig-nodes_content    |  2 +-
+ ...-1a.masters.existingsg.example.com_user_data |  2 +-
+ ...-1b.masters.existingsg.example.com_user_data |  2 +-
+ ...-1c.masters.existingsg.example.com_user_data |  2 +-
+ ...plate_nodes.existingsg.example.com_user_data |  2 +-
+ ...aws_s3_object_cluster-completed.spec_content |  3 +--
+ ...bject_nodeupconfig-master-us-test-1a_content |  2 +-
+ ...bject_nodeupconfig-master-us-test-1b_content |  2 +-
+ ...bject_nodeupconfig-master-us-test-1c_content |  2 +-
+ .../aws_s3_object_nodeupconfig-nodes_content    |  2 +-
+ ...est-1a.masters.minimal.example.com_user_data |  2 +-
+ ...template_nodes.minimal.example.com_user_data |  2 +-
+ ...aws_s3_object_cluster-completed.spec_content |  3 +--
+ ...bject_nodeupconfig-master-us-test-1a_content |  2 +-
+ .../aws_s3_object_nodeupconfig-nodes_content    |  2 +-
+ ...est-1a.masters.minimal.example.com_user_data |  2 +-
+ ...template_nodes.minimal.example.com_user_data |  2 +-
+ ...aws_s3_object_cluster-completed.spec_content |  3 +--
+ ...bject_nodeupconfig-master-us-test-1a_content |  2 +-
+ .../aws_s3_object_nodeupconfig-nodes_content    |  2 +-
+ ...-1a.masters.externallb.example.com_user_data |  2 +-
+ ...plate_nodes.externallb.example.com_user_data |  2 +-
+ ...aws_s3_object_cluster-completed.spec_content |  3 +--
+ ...bject_nodeupconfig-master-us-test-1a_content |  2 +-
+ .../aws_s3_object_nodeupconfig-nodes_content    |  2 +-
+ ...sters.externalpolicies.example.com_user_data |  2 +-
+ ...nodes.externalpolicies.example.com_user_data |  2 +-
+ ...aws_s3_object_cluster-completed.spec_content |  3 +--
+ ...bject_nodeupconfig-master-us-test-1a_content |  2 +-
+ .../aws_s3_object_nodeupconfig-nodes_content    |  2 +-
+ ...-us-test-1a.masters.ha.example.com_user_data |  2 +-
+ ...-us-test-1b.masters.ha.example.com_user_data |  2 +-
+ ...-us-test-1c.masters.ha.example.com_user_data |  2 +-
+ ...unch_template_nodes.ha.example.com_user_data |  2 +-
+ ...aws_s3_object_cluster-completed.spec_content |  3 +--
+ ...bject_nodeupconfig-master-us-test-1a_content |  2 +-
+ ...bject_nodeupconfig-master-us-test-1b_content |  2 +-
+ ...bject_nodeupconfig-master-us-test-1c_content |  2 +-
+ .../aws_s3_object_nodeupconfig-nodes_content    |  2 +-
+ ...aws_s3_object_cluster-completed.spec_content |  3 +--
+ ...bject_nodeupconfig-master-us-test1-a_content |  2 +-
+ ...bject_nodeupconfig-master-us-test1-b_content |  2 +-
+ ...bject_nodeupconfig-master-us-test1-c_content |  2 +-
+ .../aws_s3_object_nodeupconfig-nodes_content    |  2 +-
+ ...est1-a-ha-gce-example-com_metadata_user-data |  2 +-
+ ...est1-b-ha-gce-example-com_metadata_user-data |  2 +-
+ ...est1-c-ha-gce-example-com_metadata_user-data |  2 +-
+ ..._nodes-ha-gce-example-com_metadata_user-data |  2 +-
+ ...est-1a.masters.minimal.example.com_user_data |  2 +-
+ ...template_nodes.minimal.example.com_user_data |  2 +-
+ ...aws_s3_object_cluster-completed.spec_content |  3 +--
+ ...bject_nodeupconfig-master-us-test-1a_content |  2 +-
+ .../aws_s3_object_nodeupconfig-nodes_content    |  2 +-
+ ...est-1a.masters.minimal.example.com_user_data |  2 +-
+ ...template_nodes.minimal.example.com_user_data |  2 +-
+ ...aws_s3_object_cluster-completed.spec_content |  3 +--
+ ...nodeupconfig-karpenter-nodes-default_content |  2 +-
+ ...g-karpenter-nodes-single-machinetype_content |  2 +-
+ ...bject_nodeupconfig-master-us-test-1a_content |  2 +-
+ .../aws_s3_object_nodeupconfig-nodes_content    |  2 +-
+ ...est-1a.masters.minimal.example.com_user_data |  2 +-
+ ...template_nodes.minimal.example.com_user_data |  2 +-
+ ...aws_s3_object_cluster-completed.spec_content |  3 +--
+ ...bject_nodeupconfig-master-us-test-1a_content |  2 +-
+ .../aws_s3_object_nodeupconfig-nodes_content    |  2 +-
+ ...est-1a.masters.minimal.example.com_user_data |  2 +-
+ ...template_nodes.minimal.example.com_user_data |  2 +-
+ ...aws_s3_object_cluster-completed.spec_content |  3 +--
+ ...bject_nodeupconfig-master-us-test-1a_content |  2 +-
+ .../aws_s3_object_nodeupconfig-nodes_content    |  2 +-
+ ...aws_s3_object_cluster-completed.spec_content |  3 +--
+ ...bject_nodeupconfig-master-us-test1-a_content |  2 +-
+ .../aws_s3_object_nodeupconfig-nodes_content    |  2 +-
+ ...st1-a-minimal-example-com_metadata_user-data |  2 +-
+ ...nodes-minimal-example-com_metadata_user-data |  2 +-
+ ...1a.masters.many-addons.example.com_user_data |  2 +-
+ ...late_nodes.many-addons.example.com_user_data |  2 +-
+ ...aws_s3_object_cluster-completed.spec_content |  3 +--
+ ...bject_nodeupconfig-master-us-test-1a_content |  2 +-
+ .../aws_s3_object_nodeupconfig-nodes_content    |  2 +-
+ ...est-1a.masters.minimal.example.com_user_data |  2 +-
+ ...template_nodes.minimal.example.com_user_data |  2 +-
+ ...aws_s3_object_cluster-completed.spec_content |  3 +--
+ ...bject_nodeupconfig-master-us-test-1a_content |  2 +-
+ .../aws_s3_object_nodeupconfig-nodes_content    |  2 +-
+ ...est-1a.masters.minimal.example.com_user_data |  2 +-
+ ...template_nodes.minimal.example.com_user_data |  2 +-
+ ...aws_s3_object_cluster-completed.spec_content |  3 +--
+ ...bject_nodeupconfig-master-us-test-1a_content |  2 +-
+ .../aws_s3_object_nodeupconfig-nodes_content    |  2 +-
+ ...est-1a.masters.minimal.example.com_user_data |  2 +-
+ ...template_nodes.minimal.example.com_user_data |  2 +-
+ ...aws_s3_object_cluster-completed.spec_content |  3 +--
+ ...bject_nodeupconfig-master-us-test-1a_content |  2 +-
+ .../aws_s3_object_nodeupconfig-nodes_content    |  2 +-
+ ...est-1a.masters.minimal.example.com_user_data |  2 +-
+ ...template_nodes.minimal.example.com_user_data |  2 +-
+ ...aws_s3_object_cluster-completed.spec_content |  3 +--
+ ...bject_nodeupconfig-master-us-test-1a_content |  2 +-
+ .../aws_s3_object_nodeupconfig-nodes_content    |  2 +-
+ ...1a.masters.minimal-aws.example.com_user_data |  2 +-
+ ...late_nodes.minimal-aws.example.com_user_data |  2 +-
+ ...aws_s3_object_cluster-completed.spec_content |  3 +--
+ ...bject_nodeupconfig-master-us-test-1a_content |  2 +-
+ .../aws_s3_object_nodeupconfig-nodes_content    |  2 +-
+ ...est-1a.masters.minimal.example.com_user_data |  2 +-
+ ...template_nodes.minimal.example.com_user_data |  2 +-
+ ...aws_s3_object_cluster-completed.spec_content |  3 +--
+ ...bject_nodeupconfig-master-us-test-1a_content |  2 +-
+ .../aws_s3_object_nodeupconfig-nodes_content    |  2 +-
+ ...a.masters.minimal-etcd.example.com_user_data |  2 +-
+ ...ate_nodes.minimal-etcd.example.com_user_data |  2 +-
+ ...aws_s3_object_cluster-completed.spec_content |  3 +--
+ ...bject_nodeupconfig-master-us-test-1a_content |  2 +-
+ .../aws_s3_object_nodeupconfig-nodes_content    |  2 +-
+ ...est-1a.masters.minimal.example.com_user_data |  2 +-
+ ...template_nodes.minimal.example.com_user_data |  2 +-
+ ...aws_s3_object_cluster-completed.spec_content |  3 +--
+ ...bject_nodeupconfig-master-us-test-1a_content |  2 +-
+ .../aws_s3_object_nodeupconfig-nodes_content    |  2 +-
+ ...a.masters.minimal-ipv6.example.com_user_data |  2 +-
+ ...ate_nodes.minimal-ipv6.example.com_user_data |  2 +-
+ ...aws_s3_object_cluster-completed.spec_content |  3 +--
+ ...bject_nodeupconfig-master-us-test-1a_content |  2 +-
+ .../aws_s3_object_nodeupconfig-nodes_content    |  2 +-
+ ...a.masters.minimal-ipv6.example.com_user_data |  2 +-
+ ...ate_nodes.minimal-ipv6.example.com_user_data |  2 +-
+ ...aws_s3_object_cluster-completed.spec_content |  3 +--
+ ...bject_nodeupconfig-master-us-test-1a_content |  2 +-
+ .../aws_s3_object_nodeupconfig-nodes_content    |  2 +-
+ ...a.masters.minimal-ipv6.example.com_user_data |  2 +-
+ ...ate_nodes.minimal-ipv6.example.com_user_data |  2 +-
+ ...aws_s3_object_cluster-completed.spec_content |  3 +--
+ ...bject_nodeupconfig-master-us-test-1a_content |  2 +-
+ .../aws_s3_object_nodeupconfig-nodes_content    |  2 +-
+ ...a.masters.minimal-ipv6.example.com_user_data |  2 +-
+ ...ate_nodes.minimal-ipv6.example.com_user_data |  2 +-
+ ...aws_s3_object_cluster-completed.spec_content |  3 +--
+ ...bject_nodeupconfig-master-us-test-1a_content |  2 +-
+ .../aws_s3_object_nodeupconfig-nodes_content    |  2 +-
+ ...a.masters.minimal-ipv6.example.com_user_data |  2 +-
+ ...ate_nodes.minimal-ipv6.example.com_user_data |  2 +-
+ ...aws_s3_object_cluster-completed.spec_content |  3 +--
+ ...bject_nodeupconfig-master-us-test-1a_content |  2 +-
+ .../aws_s3_object_nodeupconfig-nodes_content    |  2 +-
+ ...g.cluster-name.minimal.example.com_user_data |  2 +-
+ ...g.cluster-name.minimal.example.com_user_data |  2 +-
+ ...aws_s3_object_cluster-completed.spec_content |  3 +--
+ ...bject_nodeupconfig-master-us-test-1a_content |  2 +-
+ .../aws_s3_object_nodeupconfig-nodes_content    |  2 +-
+ ...sters.minimal-warmpool.example.com_user_data |  2 +-
+ ...nodes.minimal-warmpool.example.com_user_data |  2 +-
+ ...aws_s3_object_cluster-completed.spec_content |  1 +
+ ...aws_s3_object_cluster-completed.spec_content |  3 +--
+ ...bject_nodeupconfig-master-us-test1-a_content |  2 +-
+ .../aws_s3_object_nodeupconfig-nodes_content    |  2 +-
+ ...a-minimal-gce-example-com_metadata_user-data |  2 +-
+ ...s-minimal-gce-example-com_metadata_user-data |  2 +-
+ ...aws_s3_object_cluster-completed.spec_content |  3 +--
+ ...bject_nodeupconfig-master-us-test1-a_content |  2 +-
+ .../aws_s3_object_nodeupconfig-nodes_content    |  2 +-
+ ...a-minimal-gce-example-com_metadata_user-data |  2 +-
+ ...s-minimal-gce-example-com_metadata_user-data |  2 +-
+ ...aws_s3_object_cluster-completed.spec_content |  3 +--
+ ...bject_nodeupconfig-master-us-test1-a_content |  2 +-
+ .../aws_s3_object_nodeupconfig-nodes_content    |  2 +-
+ ...nimal-gce-ilb-example-com_metadata_user-data |  2 +-
+ ...nimal-gce-ilb-example-com_metadata_user-data |  2 +-
+ ...aws_s3_object_cluster-completed.spec_content |  3 +--
+ ...bject_nodeupconfig-master-us-test1-a_content |  2 +-
+ .../aws_s3_object_nodeupconfig-nodes_content    |  2 +-
+ ...ery-long-name-example-com_metadata_user-data |  2 +-
+ ...ery-long-name-example-com_metadata_user-data |  2 +-
+ ...aws_s3_object_cluster-completed.spec_content |  3 +--
+ ...bject_nodeupconfig-master-us-test1-a_content |  2 +-
+ .../aws_s3_object_nodeupconfig-nodes_content    |  2 +-
+ ...ong-name-example-com_metadata_startup-script |  2 +-
+ ...ong-name-example-com_metadata_startup-script |  2 +-
+ ...aws_s3_object_cluster-completed.spec_content |  3 +--
+ ...bject_nodeupconfig-master-us-test1-a_content |  2 +-
+ .../aws_s3_object_nodeupconfig-nodes_content    |  2 +-
+ ...nimal-gce-plb-example-com_metadata_user-data |  2 +-
+ ...nimal-gce-plb-example-com_metadata_user-data |  2 +-
+ ...aws_s3_object_cluster-completed.spec_content |  3 +--
+ ...bject_nodeupconfig-master-us-test1-a_content |  2 +-
+ .../aws_s3_object_nodeupconfig-nodes_content    |  2 +-
+ ...l-gce-private-example-com_metadata_user-data |  2 +-
+ ...l-gce-private-example-com_metadata_user-data |  2 +-
+ ...-test-1a.masters.minimal.k8s.local_user_data |  2 +-
+ ...h_template_nodes.minimal.k8s.local_user_data |  2 +-
+ ...aws_s3_object_cluster-completed.spec_content |  3 +--
+ ...bject_nodeupconfig-master-us-test-1a_content |  2 +-
+ .../aws_s3_object_nodeupconfig-nodes_content    |  2 +-
+ ...-test-1a.masters.minimal.k8s.local_user_data |  2 +-
+ ...h_template_nodes.minimal.k8s.local_user_data |  2 +-
+ ...aws_s3_object_cluster-completed.spec_content |  3 +--
+ ...bject_nodeupconfig-master-us-test-1a_content |  2 +-
+ .../aws_s3_object_nodeupconfig-nodes_content    |  2 +-
+ ...aws_s3_object_cluster-completed.spec_content |  3 +--
+ ...s_s3_object_nodeupconfig-master-fsn1_content |  2 +-
+ ...ws_s3_object_nodeupconfig-nodes-fsn1_content |  2 +-
+ .../data/hcloud_server_master-fsn1_user_data    |  2 +-
+ .../data/hcloud_server_nodes-fsn1_user_data     |  2 +-
+ ...aws_s3_object_cluster-completed.spec_content |  3 +--
+ ..._nodeupconfig-control-plane-fr-par-1_content |  2 +-
+ ...3_object_nodeupconfig-nodes-fr-par-1_content |  2 +-
+ ...ce_server_control-plane-fr-par-1-0_user_data |  2 +-
+ ...y_instance_server_nodes-fr-par-1-0_user_data |  2 +-
+ ...masters.mixedinstances.example.com_user_data |  2 +-
+ ...masters.mixedinstances.example.com_user_data |  2 +-
+ ...masters.mixedinstances.example.com_user_data |  2 +-
+ ...e_nodes.mixedinstances.example.com_user_data |  2 +-
+ ...aws_s3_object_cluster-completed.spec_content |  3 +--
+ ...bject_nodeupconfig-master-us-test-1a_content |  2 +-
+ ...bject_nodeupconfig-master-us-test-1b_content |  2 +-
+ ...bject_nodeupconfig-master-us-test-1c_content |  2 +-
+ .../aws_s3_object_nodeupconfig-nodes_content    |  2 +-
+ ...masters.mixedinstances.example.com_user_data |  2 +-
+ ...masters.mixedinstances.example.com_user_data |  2 +-
+ ...masters.mixedinstances.example.com_user_data |  2 +-
+ ...e_nodes.mixedinstances.example.com_user_data |  2 +-
+ ...aws_s3_object_cluster-completed.spec_content |  3 +--
+ ...bject_nodeupconfig-master-us-test-1a_content |  2 +-
+ ...bject_nodeupconfig-master-us-test-1b_content |  2 +-
+ ...bject_nodeupconfig-master-us-test-1c_content |  2 +-
+ .../aws_s3_object_nodeupconfig-nodes_content    |  2 +-
+ ...cessor.longclustername.example.com_user_data |  2 +-
+ ...cessor.longclustername.example.com_user_data |  2 +-
+ ...aws_s3_object_cluster-completed.spec_content |  3 +--
+ ...bject_nodeupconfig-master-us-test-1a_content |  2 +-
+ .../aws_s3_object_nodeupconfig-nodes_content    |  2 +-
+ ...cessor.longclustername.example.com_user_data |  2 +-
+ ...cessor.longclustername.example.com_user_data |  2 +-
+ ...aws_s3_object_cluster-completed.spec_content |  3 +--
+ ...bject_nodeupconfig-master-us-test-1a_content |  2 +-
+ .../aws_s3_object_nodeupconfig-nodes_content    |  2 +-
+ ...est-1a.masters.minimal.example.com_user_data |  2 +-
+ ...template_nodes.minimal.example.com_user_data |  2 +-
+ ...aws_s3_object_cluster-completed.spec_content |  3 +--
+ ...bject_nodeupconfig-master-us-test-1a_content |  2 +-
+ .../aws_s3_object_nodeupconfig-nodes_content    |  2 +-
+ ...ters.private-shared-ip.example.com_user_data |  2 +-
+ ...odes.private-shared-ip.example.com_user_data |  2 +-
+ ...aws_s3_object_cluster-completed.spec_content |  3 +--
+ ...bject_nodeupconfig-master-us-test-1a_content |  2 +-
+ .../aws_s3_object_nodeupconfig-nodes_content    |  2 +-
+ ....private-shared-subnet.example.com_user_data |  2 +-
+ ....private-shared-subnet.example.com_user_data |  2 +-
+ ...aws_s3_object_cluster-completed.spec_content |  3 +--
+ ...bject_nodeupconfig-master-us-test-1a_content |  2 +-
+ .../aws_s3_object_nodeupconfig-nodes_content    |  2 +-
+ ....masters.privatecalico.example.com_user_data |  2 +-
+ ...te_nodes.privatecalico.example.com_user_data |  2 +-
+ ...aws_s3_object_cluster-completed.spec_content |  3 +--
+ ...bject_nodeupconfig-master-us-test-1a_content |  2 +-
+ .../aws_s3_object_nodeupconfig-nodes_content    |  2 +-
+ ....masters.privatecilium.example.com_user_data |  2 +-
+ ...te_nodes.privatecilium.example.com_user_data |  2 +-
+ ...aws_s3_object_cluster-completed.spec_content |  3 +--
+ ...bject_nodeupconfig-master-us-test-1a_content |  2 +-
+ .../aws_s3_object_nodeupconfig-nodes_content    |  2 +-
+ ....masters.privatecilium.example.com_user_data |  2 +-
+ ...te_nodes.privatecilium.example.com_user_data |  2 +-
+ ...aws_s3_object_cluster-completed.spec_content |  3 +--
+ ...bject_nodeupconfig-master-us-test-1a_content |  2 +-
+ .../aws_s3_object_nodeupconfig-nodes_content    |  2 +-
+ ....masters.privatecilium.example.com_user_data |  2 +-
+ ...te_nodes.privatecilium.example.com_user_data |  2 +-
+ ...aws_s3_object_cluster-completed.spec_content |  3 +--
+ ...bject_nodeupconfig-master-us-test-1a_content |  2 +-
+ .../aws_s3_object_nodeupconfig-nodes_content    |  2 +-
+ ....privateciliumadvanced.example.com_user_data |  2 +-
+ ....privateciliumadvanced.example.com_user_data |  2 +-
+ ...aws_s3_object_cluster-completed.spec_content |  3 +--
+ ...bject_nodeupconfig-master-us-test-1a_content |  2 +-
+ .../aws_s3_object_nodeupconfig-nodes_content    |  2 +-
+ ...1a.masters.privatedns1.example.com_user_data |  2 +-
+ ...late_nodes.privatedns1.example.com_user_data |  2 +-
+ ...aws_s3_object_cluster-completed.spec_content |  3 +--
+ ...bject_nodeupconfig-master-us-test-1a_content |  2 +-
+ .../aws_s3_object_nodeupconfig-nodes_content    |  2 +-
+ ...1a.masters.privatedns2.example.com_user_data |  2 +-
+ ...late_nodes.privatedns2.example.com_user_data |  2 +-
+ ...aws_s3_object_cluster-completed.spec_content |  3 +--
+ ...bject_nodeupconfig-master-us-test-1a_content |  2 +-
+ .../aws_s3_object_nodeupconfig-nodes_content    |  2 +-
+ ...masters.privateflannel.example.com_user_data |  2 +-
+ ...e_nodes.privateflannel.example.com_user_data |  2 +-
+ ...aws_s3_object_cluster-completed.spec_content |  3 +--
+ ...bject_nodeupconfig-master-us-test-1a_content |  2 +-
+ .../aws_s3_object_nodeupconfig-nodes_content    |  2 +-
+ ...masters.privatekindnet.example.com_user_data |  2 +-
+ ...e_nodes.privatekindnet.example.com_user_data |  2 +-
+ ...aws_s3_object_cluster-completed.spec_content |  3 +--
+ ...bject_nodeupconfig-master-us-test-1a_content |  2 +-
+ .../aws_s3_object_nodeupconfig-nodes_content    |  2 +-
+ ....masters.privatekopeio.example.com_user_data |  2 +-
+ ...te_nodes.privatekopeio.example.com_user_data |  2 +-
+ ...aws_s3_object_cluster-completed.spec_content |  3 +--
+ ...bject_nodeupconfig-master-us-test-1a_content |  2 +-
+ .../aws_s3_object_nodeupconfig-nodes_content    |  2 +-
+ ...est-1a.masters.minimal.example.com_user_data |  2 +-
+ ...template_nodes.minimal.example.com_user_data |  2 +-
+ ...aws_s3_object_cluster-completed.spec_content |  3 +--
+ ...bject_nodeupconfig-master-us-test-1a_content |  2 +-
+ .../aws_s3_object_nodeupconfig-nodes_content    |  2 +-
+ ...a.masters.sharedsubnet.example.com_user_data |  2 +-
+ ...ate_nodes.sharedsubnet.example.com_user_data |  2 +-
+ ...aws_s3_object_cluster-completed.spec_content |  3 +--
+ ...bject_nodeupconfig-master-us-test-1a_content |  2 +-
+ .../aws_s3_object_nodeupconfig-nodes_content    |  2 +-
+ ...t-1a.masters.sharedvpc.example.com_user_data |  2 +-
+ ...mplate_nodes.sharedvpc.example.com_user_data |  2 +-
+ ...aws_s3_object_cluster-completed.spec_content |  3 +--
+ ...bject_nodeupconfig-master-us-test-1a_content |  2 +-
+ .../aws_s3_object_nodeupconfig-nodes_content    |  2 +-
+ ...a.masters.minimal-ipv6.example.com_user_data |  2 +-
+ ...ate_nodes.minimal-ipv6.example.com_user_data |  2 +-
+ ...aws_s3_object_cluster-completed.spec_content |  3 +--
+ ...bject_nodeupconfig-master-us-test-1a_content |  2 +-
+ .../aws_s3_object_nodeupconfig-nodes_content    |  2 +-
+ ...t-1a.masters.unmanaged.example.com_user_data |  2 +-
+ ...mplate_nodes.unmanaged.example.com_user_data |  2 +-
+ ...aws_s3_object_cluster-completed.spec_content |  3 +--
+ ...bject_nodeupconfig-master-us-test-1a_content |  2 +-
+ .../aws_s3_object_nodeupconfig-nodes_content    |  2 +-
+ ...est-1a.masters.minimal.example.com_user_data |  2 +-
+ ...template_nodes.minimal.example.com_user_data |  2 +-
+ ...aws_s3_object_cluster-completed.spec_content |  3 +--
+ ...bject_nodeupconfig-master-us-test-1a_content |  2 +-
+ .../aws_s3_object_nodeupconfig-nodes_content    |  2 +-
+ 424 files changed, 479 insertions(+), 502 deletions(-)
+
+diff --git a/k8s/crds/kops.k8s.io_clusters.yaml b/k8s/crds/kops.k8s.io_clusters.yaml
+index 8cddc44034..ad3ad970b3 100644
+--- a/k8s/crds/kops.k8s.io_clusters.yaml
++++ b/k8s/crds/kops.k8s.io_clusters.yaml
+@@ -992,6 +992,9 @@ spec:
+                         description: Version used to pick the runc package.
+                         type: string
+                     type: object
++                  sandboxImage:
++                    description: SandboxImage is the image used for the sandbox container.
++                    type: string
+                   selinuxEnabled:
+                     description: SelinuxEnabled enables SELinux support
+                     type: boolean
+@@ -4322,8 +4325,9 @@ spec:
+                       In cluster mode, this is obtained from the master.
+                     type: string
+                   podInfraContainerImage:
+-                    description: PodInfraContainerImage is the image whose network/ipc
+-                      containers in each pod will use.
++                    description: |-
++                      PodInfraContainerImage is the image whose network/ipc containers in each pod will use.
++                      DEPRECATED: Image garbage collector will get sandbox image information from CRI.
+                     type: string
+                   podManifestPath:
+                     description: config is the path to the config file or directory
+@@ -4775,8 +4779,9 @@ spec:
+                       In cluster mode, this is obtained from the master.
+                     type: string
+                   podInfraContainerImage:
+-                    description: PodInfraContainerImage is the image whose network/ipc
+-                      containers in each pod will use.
++                    description: |-
++                      PodInfraContainerImage is the image whose network/ipc containers in each pod will use.
++                      DEPRECATED: Image garbage collector will get sandbox image information from CRI.
+                     type: string
+                   podManifestPath:
+                     description: config is the path to the config file or directory
+diff --git a/k8s/crds/kops.k8s.io_instancegroups.yaml b/k8s/crds/kops.k8s.io_instancegroups.yaml
+index 87435bef0c..604345cd55 100644
+--- a/k8s/crds/kops.k8s.io_instancegroups.yaml
++++ b/k8s/crds/kops.k8s.io_instancegroups.yaml
+@@ -227,6 +227,9 @@ spec:
+                         description: Version used to pick the runc package.
+                         type: string
+                     type: object
++                  sandboxImage:
++                    description: SandboxImage is the image used for the sandbox container.
++                    type: string
+                   selinuxEnabled:
+                     description: SelinuxEnabled enables SELinux support
+                     type: boolean
+@@ -711,8 +714,9 @@ spec:
+                       In cluster mode, this is obtained from the master.
+                     type: string
+                   podInfraContainerImage:
+-                    description: PodInfraContainerImage is the image whose network/ipc
+-                      containers in each pod will use.
++                    description: |-
++                      PodInfraContainerImage is the image whose network/ipc containers in each pod will use.
++                      DEPRECATED: Image garbage collector will get sandbox image information from CRI.
+                     type: string
+                   podManifestPath:
+                     description: config is the path to the config file or directory
+diff --git a/nodeup/pkg/model/containerd.go b/nodeup/pkg/model/containerd.go
+index 820eaaeab4..49da7ec4d2 100644
+--- a/nodeup/pkg/model/containerd.go
++++ b/nodeup/pkg/model/containerd.go
+@@ -493,8 +493,8 @@ func (b *ContainerdBuilder) buildContainerdConfig() (string, error) {
+ 	if containerd.SeLinuxEnabled {
+ 		config.SetPath([]string{"plugins", "io.containerd.grpc.v1.cri", "enable_selinux"}, true)
+ 	}
+-	if b.NodeupConfig.KubeletConfig.PodInfraContainerImage != "" {
+-		config.SetPath([]string{"plugins", "io.containerd.grpc.v1.cri", "sandbox_image"}, b.NodeupConfig.KubeletConfig.PodInfraContainerImage)
++	if containerd.SandboxImage != nil {
++		config.SetPath([]string{"plugins", "io.containerd.grpc.v1.cri", "sandbox_image"}, fi.ValueOf(containerd.SandboxImage))
+ 	}
+ 	for name, endpoints := range containerd.RegistryMirrors {
+ 		config.SetPath([]string{"plugins", "io.containerd.grpc.v1.cri", "registry", "mirrors", name, "endpoint"}, endpoints)
+diff --git a/nodeup/pkg/model/tests/containerdbuilder/complex/tasks.yaml b/nodeup/pkg/model/tests/containerdbuilder/complex/tasks.yaml
+index e6875764e1..9be680a125 100644
+--- a/nodeup/pkg/model/tests/containerdbuilder/complex/tasks.yaml
++++ b/nodeup/pkg/model/tests/containerdbuilder/complex/tasks.yaml
+@@ -26,7 +26,7 @@ contents: |
+   [plugins]
+ 
+     [plugins."io.containerd.grpc.v1.cri"]
+-      sandbox_image = "registry.k8s.io/pause:3.9"
++      sandbox_image = "registry.k8s.io/pause:3.10.1"
+ 
+       [plugins."io.containerd.grpc.v1.cri".cni]
+         conf_template = "/etc/containerd/config-cni.template"
+diff --git a/nodeup/pkg/model/tests/containerdbuilder/flatcar/tasks.yaml b/nodeup/pkg/model/tests/containerdbuilder/flatcar/tasks.yaml
+index c83c382d5d..8992217693 100644
+--- a/nodeup/pkg/model/tests/containerdbuilder/flatcar/tasks.yaml
++++ b/nodeup/pkg/model/tests/containerdbuilder/flatcar/tasks.yaml
+@@ -26,7 +26,7 @@ contents: |
+   [plugins]
+ 
+     [plugins."io.containerd.grpc.v1.cri"]
+-      sandbox_image = "registry.k8s.io/pause:3.9"
++      sandbox_image = "registry.k8s.io/pause:3.10.1"
+ 
+       [plugins."io.containerd.grpc.v1.cri".cni]
+         conf_template = "/etc/containerd/config-cni.template"
+diff --git a/nodeup/pkg/model/tests/containerdbuilder/simple/tasks.yaml b/nodeup/pkg/model/tests/containerdbuilder/simple/tasks.yaml
+index 2caad6e486..198d562079 100644
+--- a/nodeup/pkg/model/tests/containerdbuilder/simple/tasks.yaml
++++ b/nodeup/pkg/model/tests/containerdbuilder/simple/tasks.yaml
+@@ -26,7 +26,7 @@ contents: |
+   [plugins]
+ 
+     [plugins."io.containerd.grpc.v1.cri"]
+-      sandbox_image = "registry.k8s.io/pause:3.9"
++      sandbox_image = "registry.k8s.io/pause:3.10.1"
+ 
+       [plugins."io.containerd.grpc.v1.cri".cni]
+         conf_template = "/etc/containerd/config-cni.template"
+diff --git a/pkg/apis/kops/componentconfig.go b/pkg/apis/kops/componentconfig.go
+index d9d55c9371..0f1900ec56 100644
+--- a/pkg/apis/kops/componentconfig.go
++++ b/pkg/apis/kops/componentconfig.go
+@@ -57,7 +57,8 @@ type KubeletConfigSpec struct {
+ 	// HostnameOverride is the hostname used to identify the kubelet instead of the actual hostname.
+ 	HostnameOverride string `json:"hostnameOverride,omitempty" flag:"hostname-override"`
+ 	// PodInfraContainerImage is the image whose network/ipc containers in each pod will use.
+-	PodInfraContainerImage string `json:"podInfraContainerImage,omitempty" flag:"pod-infra-container-image"`
++	// DEPRECATED: Image garbage collector will get sandbox image information from CRI.
++	PodInfraContainerImage string `json:"podInfraContainerImage,omitempty"`
+ 	// SeccompDefault enables the use of `RuntimeDefault` as the default seccomp profile for all workloads.
+ 	SeccompDefault *bool `json:"seccompDefault,omitempty" flag:"seccomp-default"`
+ 	// SeccompProfileRoot is the directory path for seccomp profiles.
+diff --git a/pkg/apis/kops/containerdconfig.go b/pkg/apis/kops/containerdconfig.go
+index 9efe761517..4175097ffe 100644
+--- a/pkg/apis/kops/containerdconfig.go
++++ b/pkg/apis/kops/containerdconfig.go
+@@ -54,6 +54,8 @@ type ContainerdConfig struct {
+ 	SeLinuxEnabled bool `json:"selinuxEnabled,omitempty"`
+ 	// NRI configures the Node Resource Interface.
+ 	NRI *NRIConfig `json:"nri,omitempty"`
++	// SandboxImage is the image used for the sandbox container.
++	SandboxImage *string `json:"sandboxImage,omitempty"`
+ }
+ 
+ type NRIConfig struct {
+diff --git a/pkg/apis/kops/v1alpha2/componentconfig.go b/pkg/apis/kops/v1alpha2/componentconfig.go
+index e6ec17229c..c7e916c436 100644
+--- a/pkg/apis/kops/v1alpha2/componentconfig.go
++++ b/pkg/apis/kops/v1alpha2/componentconfig.go
+@@ -57,7 +57,8 @@ type KubeletConfigSpec struct {
+ 	// HostnameOverride is the hostname used to identify the kubelet instead of the actual hostname.
+ 	HostnameOverride string `json:"hostnameOverride,omitempty" flag:"hostname-override"`
+ 	// PodInfraContainerImage is the image whose network/ipc containers in each pod will use.
+-	PodInfraContainerImage string `json:"podInfraContainerImage,omitempty" flag:"pod-infra-container-image"`
++	// DEPRECATED: Image garbage collector will get sandbox image information from CRI.
++	PodInfraContainerImage string `json:"podInfraContainerImage,omitempty"`
+ 	// SeccompDefault enables the use of `RuntimeDefault` as the default seccomp profile for all workloads.
+ 	SeccompDefault *bool `json:"seccompDefault,omitempty" flag:"seccomp-default"`
+ 	// SeccompProfileRoot is the directory path for seccomp profiles.
+diff --git a/pkg/apis/kops/v1alpha2/containerdconfig.go b/pkg/apis/kops/v1alpha2/containerdconfig.go
+index e4430b7908..d872355c25 100644
+--- a/pkg/apis/kops/v1alpha2/containerdconfig.go
++++ b/pkg/apis/kops/v1alpha2/containerdconfig.go
+@@ -51,6 +51,8 @@ type ContainerdConfig struct {
+ 	SeLinuxEnabled bool `json:"selinuxEnabled,omitempty"`
+ 	// NRI configures the Node Resource Interface.
+ 	NRI *NRIConfig `json:"nri,omitempty"`
++	// SandboxImage is the image used for the sandbox container.
++	SandboxImage *string `json:"sandboxImage,omitempty"`
+ }
+ 
+ type NRIConfig struct {
+diff --git a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+index 5428af1ca2..3702f8f62d 100644
+--- a/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
++++ b/pkg/apis/kops/v1alpha2/zz_generated.conversion.go
+@@ -3286,6 +3286,7 @@ func autoConvert_v1alpha2_ContainerdConfig_To_kops_ContainerdConfig(in *Containe
+ 	} else {
+ 		out.NRI = nil
+ 	}
++	out.SandboxImage = in.SandboxImage
+ 	return nil
+ }
+ 
+@@ -3341,6 +3342,7 @@ func autoConvert_kops_ContainerdConfig_To_v1alpha2_ContainerdConfig(in *kops.Con
+ 	} else {
+ 		out.NRI = nil
+ 	}
++	out.SandboxImage = in.SandboxImage
+ 	return nil
+ }
+ 
+diff --git a/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go b/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
+index 63ec34abfa..e8aa7ab755 100644
+--- a/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
++++ b/pkg/apis/kops/v1alpha2/zz_generated.deepcopy.go
+@@ -1557,6 +1557,11 @@ func (in *ContainerdConfig) DeepCopyInto(out *ContainerdConfig) {
+ 		*out = new(NRIConfig)
+ 		(*in).DeepCopyInto(*out)
+ 	}
++	if in.SandboxImage != nil {
++		in, out := &in.SandboxImage, &out.SandboxImage
++		*out = new(string)
++		**out = **in
++	}
+ 	return
+ }
+ 
+diff --git a/pkg/apis/kops/v1alpha3/componentconfig.go b/pkg/apis/kops/v1alpha3/componentconfig.go
+index 09df4167a9..34e05ca240 100644
+--- a/pkg/apis/kops/v1alpha3/componentconfig.go
++++ b/pkg/apis/kops/v1alpha3/componentconfig.go
+@@ -57,7 +57,8 @@ type KubeletConfigSpec struct {
+ 	// HostnameOverride is not admin-configurable.
+ 	HostnameOverride string `json:"-"`
+ 	// PodInfraContainerImage is the image whose network/ipc containers in each pod will use.
+-	PodInfraContainerImage string `json:"podInfraContainerImage,omitempty" flag:"pod-infra-container-image"`
++	// DEPRECATED: Image garbage collector will get sandbox image information from CRI.
++	PodInfraContainerImage string `json:"podInfraContainerImage,omitempty"`
+ 	// SeccompDefault enables the use of `RuntimeDefault` as the default seccomp profile for all workloads.
+ 	SeccompDefault *bool `json:"seccompDefault,omitempty" flag:"seccomp-default"`
+ 	// SeccompProfileRoot is the directory path for seccomp profiles.
+diff --git a/pkg/apis/kops/v1alpha3/containerdconfig.go b/pkg/apis/kops/v1alpha3/containerdconfig.go
+index be69f3e9a7..473b9945ef 100644
+--- a/pkg/apis/kops/v1alpha3/containerdconfig.go
++++ b/pkg/apis/kops/v1alpha3/containerdconfig.go
+@@ -51,6 +51,8 @@ type ContainerdConfig struct {
+ 	SeLinuxEnabled bool `json:"selinuxEnabled,omitempty"`
+ 	// NRI configures the Node Resource Interface.
+ 	NRI *NRIConfig `json:"nri,omitempty"`
++	// SandboxImage is the image used for the sandbox container.
++	SandboxImage *string `json:"sandboxImage,omitempty"`
+ }
+ 
+ type NRIConfig struct {
+diff --git a/pkg/apis/kops/v1alpha3/zz_generated.conversion.go b/pkg/apis/kops/v1alpha3/zz_generated.conversion.go
+index 65aecd8991..3aecf68ef5 100644
+--- a/pkg/apis/kops/v1alpha3/zz_generated.conversion.go
++++ b/pkg/apis/kops/v1alpha3/zz_generated.conversion.go
+@@ -3530,6 +3530,7 @@ func autoConvert_v1alpha3_ContainerdConfig_To_kops_ContainerdConfig(in *Containe
+ 	} else {
+ 		out.NRI = nil
+ 	}
++	out.SandboxImage = in.SandboxImage
+ 	return nil
+ }
+ 
+@@ -3585,6 +3586,7 @@ func autoConvert_kops_ContainerdConfig_To_v1alpha3_ContainerdConfig(in *kops.Con
+ 	} else {
+ 		out.NRI = nil
+ 	}
++	out.SandboxImage = in.SandboxImage
+ 	return nil
+ }
+ 
+diff --git a/pkg/apis/kops/v1alpha3/zz_generated.deepcopy.go b/pkg/apis/kops/v1alpha3/zz_generated.deepcopy.go
+index b3c024f466..3881b136cc 100644
+--- a/pkg/apis/kops/v1alpha3/zz_generated.deepcopy.go
++++ b/pkg/apis/kops/v1alpha3/zz_generated.deepcopy.go
+@@ -1458,6 +1458,11 @@ func (in *ContainerdConfig) DeepCopyInto(out *ContainerdConfig) {
+ 		*out = new(NRIConfig)
+ 		(*in).DeepCopyInto(*out)
+ 	}
++	if in.SandboxImage != nil {
++		in, out := &in.SandboxImage, &out.SandboxImage
++		*out = new(string)
++		**out = **in
++	}
+ 	return
+ }
+ 
+diff --git a/pkg/apis/kops/validation/validation.go b/pkg/apis/kops/validation/validation.go
+index 4673b505d2..d8ee5bfacc 100644
+--- a/pkg/apis/kops/validation/validation.go
++++ b/pkg/apis/kops/validation/validation.go
+@@ -911,6 +911,14 @@ func validateKubelet(k *kops.KubeletConfigSpec, c *kops.Cluster, kubeletPath *fi
+ 			}
+ 		}
+ 
++		{
++			if k.PodInfraContainerImage != "" {
++				allErrs = append(allErrs, field.Forbidden(
++					kubeletPath.Child("podInfraContainerImage"),
++					"pod-infra-container-image flag was deprecated in 1.24 and removed in 1.35, use containerd.sandboxImage instead"))
++			}
++		}
++
+ 		{
+ 			// Flag removed in 1.10
+ 			if k.RequireKubeconfig != nil {
+diff --git a/pkg/apis/kops/zz_generated.deepcopy.go b/pkg/apis/kops/zz_generated.deepcopy.go
+index 9ca9ca1ae8..5a23df7da7 100644
+--- a/pkg/apis/kops/zz_generated.deepcopy.go
++++ b/pkg/apis/kops/zz_generated.deepcopy.go
+@@ -1578,6 +1578,11 @@ func (in *ContainerdConfig) DeepCopyInto(out *ContainerdConfig) {
+ 		*out = new(NRIConfig)
+ 		(*in).DeepCopyInto(*out)
+ 	}
++	if in.SandboxImage != nil {
++		in, out := &in.SandboxImage, &out.SandboxImage
++		*out = new(string)
++		**out = **in
++	}
+ 	return
+ }
+ 
+diff --git a/pkg/model/components/containerd.go b/pkg/model/components/containerd.go
+index eda4e46124..1b77891191 100644
+--- a/pkg/model/components/containerd.go
++++ b/pkg/model/components/containerd.go
+@@ -22,6 +22,10 @@ import (
+ 	"k8s.io/kops/upup/pkg/fi/loader"
+ )
+ 
++const (
++	DefaultSandboxImage = "registry.k8s.io/pause:3.10.1"
++)
++
+ // ContainerdOptionsBuilder adds options for containerd to the model
+ type ContainerdOptionsBuilder struct {
+ 	*OptionsContext
+@@ -39,7 +43,7 @@ func (b *ContainerdOptionsBuilder) BuildOptions(o *kops.Cluster) error {
+ 
+ 	containerd := clusterSpec.Containerd
+ 
+-	// Set version based on Kubernetes version
++	// Set the version based on Kubernetes version
+ 	if fi.ValueOf(containerd.Version) == "" {
+ 		switch {
+ 		case b.IsKubernetesLT("1.27.2"):
+@@ -54,9 +58,18 @@ func (b *ContainerdOptionsBuilder) BuildOptions(o *kops.Cluster) error {
+ 			}
+ 		}
+ 	}
+-	// Set default log level to INFO
++	// Set the default log level to INFO
+ 	containerd.LogLevel = fi.PtrTo("info")
+ 
++	// Set the sandbox image used to scope pod shared resources used by the pod's containers.
++	if fi.ValueOf(containerd.SandboxImage) == "" {
++		image, err := b.AssetBuilder.RemapImage(DefaultSandboxImage)
++		if err != nil {
++			return err
++		}
++		containerd.SandboxImage = fi.PtrTo(image)
++	}
++
+ 	if containerd.NvidiaGPU != nil && fi.ValueOf(containerd.NvidiaGPU.Enabled) && containerd.NvidiaGPU.DriverPackage == "" {
+ 		containerd.NvidiaGPU.DriverPackage = kops.NvidiaDefaultDriverPackage
+ 	}
+diff --git a/pkg/model/components/kubelet.go b/pkg/model/components/kubelet.go
+index 37246ec7cd..8ec2243fbe 100644
+--- a/pkg/model/components/kubelet.go
++++ b/pkg/model/components/kubelet.go
+@@ -164,15 +164,6 @@ func (b *KubeletOptionsBuilder) configureKubelet(cluster *kops.Cluster, kubelet
+ 		kubelet.CloudProvider = "external"
+ 	}
+ 
+-	// Prevent image GC from pruning the pause image
+-	// https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/2040-kubelet-cri#pinned-images
+-	image := "registry.k8s.io/pause:3.9"
+-	var err error
+-	if image, err = b.AssetBuilder.RemapImage(image); err != nil {
+-		return err
+-	}
+-	kubelet.PodInfraContainerImage = image
+-
+ 	if kubelet.FeatureGates == nil {
+ 		kubelet.FeatureGates = make(map[string]string)
+ 	}
+diff --git a/tests/integration/update_cluster/additionalobjects/data/aws_launch_template_master-us-test-1a.masters.additionalobjects.example.com_user_data b/tests/integration/update_cluster/additionalobjects/data/aws_launch_template_master-us-test-1a.masters.additionalobjects.example.com_user_data
+index 430ad8f7e4..e8d35f3221 100644
+--- a/tests/integration/update_cluster/additionalobjects/data/aws_launch_template_master-us-test-1a.masters.additionalobjects.example.com_user_data
++++ b/tests/integration/update_cluster/additionalobjects/data/aws_launch_template_master-us-test-1a.masters.additionalobjects.example.com_user_data
+@@ -130,7 +130,7 @@ ClusterName: additionalobjects.example.com
+ ConfigBase: memfs://tests/additionalobjects.example.com
+ InstanceGroupName: master-us-test-1a
+ InstanceGroupRole: ControlPlane
+-NodeupConfigHash: Fs2hbQ1UTITDVKZyfQgIjd55UiUucLBjwNrWgCrMXT8=
++NodeupConfigHash: qO8T/0CMlveCg74111HDV55wc6djXLZ3H5ufUCod814=
+ 
+ __EOF_KUBE_ENV
+ 
+diff --git a/tests/integration/update_cluster/additionalobjects/data/aws_launch_template_nodes.additionalobjects.example.com_user_data b/tests/integration/update_cluster/additionalobjects/data/aws_launch_template_nodes.additionalobjects.example.com_user_data
+index e3c1c1d845..66b62a234c 100644
+--- a/tests/integration/update_cluster/additionalobjects/data/aws_launch_template_nodes.additionalobjects.example.com_user_data
++++ b/tests/integration/update_cluster/additionalobjects/data/aws_launch_template_nodes.additionalobjects.example.com_user_data
+@@ -153,7 +153,7 @@ ConfigServer:
+   - https://kops-controller.internal.additionalobjects.example.com:3988/
+ InstanceGroupName: nodes
+ InstanceGroupRole: Node
+-NodeupConfigHash: v5boyYo0oAxJY5j5GrrkpKGSWQszupLx/Uxr5mjqtPY=
++NodeupConfigHash: frzkIIzqS2PcpaWfYzaoJxHGCavEgihuJrcd95nJTTM=
+ 
+ __EOF_KUBE_ENV
+ 
+diff --git a/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_cluster-completed.spec_content b/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_cluster-completed.spec_content
+index 0657c051e1..f959b9822f 100644
+--- a/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_cluster-completed.spec_content
++++ b/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_cluster-completed.spec_content
+@@ -28,6 +28,7 @@ spec:
+     logLevel: info
+     runc:
+       version: 1.2.4
++    sandboxImage: registry.k8s.io/pause:3.10.1
+     version: 1.7.25
+   dnsZone: Z1AFAKE1ZON3YO
+   etcdClusters:
+@@ -158,7 +159,6 @@ spec:
+       InTreePluginAWSUnregister: "true"
+     kubeconfigPath: /var/lib/kubelet/kubeconfig
+     logLevel: 2
+-    podInfraContainerImage: registry.k8s.io/pause:3.9
+     podManifestPath: /etc/kubernetes/manifests
+     protectKernelDefaults: true
+     registerSchedulable: true
+@@ -181,7 +181,6 @@ spec:
+       InTreePluginAWSUnregister: "true"
+     kubeconfigPath: /var/lib/kubelet/kubeconfig
+     logLevel: 2
+-    podInfraContainerImage: registry.k8s.io/pause:3.9
+     podManifestPath: /etc/kubernetes/manifests
+     protectKernelDefaults: true
+     registerSchedulable: true
+diff --git a/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_nodeupconfig-master-us-test-1a_content b/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+index 3d8d57ea00..c73c3ef1b0 100644
+--- a/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
++++ b/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+@@ -303,7 +303,6 @@ KubeletConfig:
+     kops.k8s.io/kops-controller-pki: ""
+     node-role.kubernetes.io/control-plane: ""
+     node.kubernetes.io/exclude-from-external-load-balancers: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -325,6 +324,7 @@ containerdConfig:
+   logLevel: info
+   runc:
+     version: 1.2.4
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.7.25
+ etcdManifests:
+ - memfs://tests/additionalobjects.example.com/manifests/etcd/main-master-us-test-1a.yaml
+diff --git a/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_nodeupconfig-nodes_content b/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_nodeupconfig-nodes_content
+index c72d791b65..3b2cc6fe02 100644
+--- a/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_nodeupconfig-nodes_content
++++ b/tests/integration/update_cluster/additionalobjects/data/aws_s3_object_nodeupconfig-nodes_content
+@@ -46,7 +46,6 @@ KubeletConfig:
+   nodeLabels:
+     kops.k8s.io/instancegroup: nodes-us-test-1a
+     node-role.kubernetes.io/node: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -61,6 +60,7 @@ containerdConfig:
+   logLevel: info
+   runc:
+     version: 1.2.4
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.7.25
+ usesLegacyGossip: false
+ usesNoneDNS: false
+diff --git a/tests/integration/update_cluster/apiservernodes/data/aws_launch_template_apiserver.apiservers.minimal.example.com_user_data b/tests/integration/update_cluster/apiservernodes/data/aws_launch_template_apiserver.apiservers.minimal.example.com_user_data
+index 395694b127..4df807c613 100644
+--- a/tests/integration/update_cluster/apiservernodes/data/aws_launch_template_apiserver.apiservers.minimal.example.com_user_data
++++ b/tests/integration/update_cluster/apiservernodes/data/aws_launch_template_apiserver.apiservers.minimal.example.com_user_data
+@@ -130,7 +130,7 @@ ClusterName: minimal.example.com
+ ConfigBase: memfs://clusters.example.com/minimal.example.com
+ InstanceGroupName: apiserver
+ InstanceGroupRole: APIServer
+-NodeupConfigHash: DGxbW0XRm7D5zB9YwjGlYU7alrRcRG85ySGSp39Mk1E=
++NodeupConfigHash: /oOLCfzBYPA93MykbkH21yfK0QxPEhnM7Vb3R2fhSiM=
+ 
+ __EOF_KUBE_ENV
+ 
+diff --git a/tests/integration/update_cluster/apiservernodes/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data b/tests/integration/update_cluster/apiservernodes/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
+index 1a13a8f0ec..a22f1e3fde 100644
+--- a/tests/integration/update_cluster/apiservernodes/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
++++ b/tests/integration/update_cluster/apiservernodes/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
+@@ -130,7 +130,7 @@ ClusterName: minimal.example.com
+ ConfigBase: memfs://clusters.example.com/minimal.example.com
+ InstanceGroupName: master-us-test-1a
+ InstanceGroupRole: ControlPlane
+-NodeupConfigHash: oat4TLWZZOwj65R6CKin5eR7GMvLjjtMZK541q480iE=
++NodeupConfigHash: W70yGWkJWTZP/vC2HkyagctTicWnHuyjH0/7LzHLyFU=
+ 
+ __EOF_KUBE_ENV
+ 
+diff --git a/tests/integration/update_cluster/apiservernodes/data/aws_launch_template_nodes.minimal.example.com_user_data b/tests/integration/update_cluster/apiservernodes/data/aws_launch_template_nodes.minimal.example.com_user_data
+index d546e3e81c..836b447e1e 100644
+--- a/tests/integration/update_cluster/apiservernodes/data/aws_launch_template_nodes.minimal.example.com_user_data
++++ b/tests/integration/update_cluster/apiservernodes/data/aws_launch_template_nodes.minimal.example.com_user_data
+@@ -153,7 +153,7 @@ ConfigServer:
+   - https://kops-controller.internal.minimal.example.com:3988/
+ InstanceGroupName: nodes
+ InstanceGroupRole: Node
+-NodeupConfigHash: 2qas7IWBw7bXrVthbyjE5kxmfKcL2NufTUVsZzWlfsY=
++NodeupConfigHash: 7S7zs81zX9f9Xz0jSiwfImOwBCezGrBAjDMPtbko6DA=
+ 
+ __EOF_KUBE_ENV
+ 
+diff --git a/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_cluster-completed.spec_content b/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_cluster-completed.spec_content
+index 17cb6a32d6..8001ebed16 100644
+--- a/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_cluster-completed.spec_content
++++ b/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_cluster-completed.spec_content
+@@ -28,6 +28,7 @@ spec:
+     logLevel: info
+     runc:
+       version: 1.1.5
++    sandboxImage: registry.k8s.io/pause:3.10.1
+     version: 1.6.20
+   dnsZone: Z1AFAKE1ZON3YO
+   etcdClusters:
+@@ -151,7 +152,6 @@ spec:
+       InTreePluginAWSUnregister: "true"
+     kubeconfigPath: /var/lib/kubelet/kubeconfig
+     logLevel: 2
+-    podInfraContainerImage: registry.k8s.io/pause:3.9
+     podManifestPath: /etc/kubernetes/manifests
+     protectKernelDefaults: true
+     registerSchedulable: true
+@@ -173,7 +173,6 @@ spec:
+       InTreePluginAWSUnregister: "true"
+     kubeconfigPath: /var/lib/kubelet/kubeconfig
+     logLevel: 2
+-    podInfraContainerImage: registry.k8s.io/pause:3.9
+     podManifestPath: /etc/kubernetes/manifests
+     protectKernelDefaults: true
+     registerSchedulable: true
+diff --git a/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_nodeupconfig-apiserver_content b/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_nodeupconfig-apiserver_content
+index b7c0026441..fa7780f53f 100644
+--- a/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_nodeupconfig-apiserver_content
++++ b/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_nodeupconfig-apiserver_content
+@@ -178,7 +178,6 @@ KubeletConfig:
+   logLevel: 2
+   nodeLabels:
+     node-role.kubernetes.io/api-server: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -198,6 +197,7 @@ containerdConfig:
+   logLevel: info
+   runc:
+     version: 1.1.5
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.6.20
+ staticManifests:
+ - key: kube-apiserver-healthcheck
+diff --git a/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_nodeupconfig-master-us-test-1a_content b/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+index 7551c2ee69..addf328f89 100644
+--- a/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
++++ b/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+@@ -301,7 +301,6 @@ KubeletConfig:
+     node-role.kubernetes.io/api-server: ""
+     node-role.kubernetes.io/control-plane: ""
+     node.kubernetes.io/exclude-from-external-load-balancers: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -323,6 +322,7 @@ containerdConfig:
+   logLevel: info
+   runc:
+     version: 1.1.5
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.6.20
+ etcdManifests:
+ - memfs://clusters.example.com/minimal.example.com/manifests/etcd/main-master-us-test-1a.yaml
+diff --git a/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_nodeupconfig-nodes_content b/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_nodeupconfig-nodes_content
+index 1053c7df23..ad1f70912c 100644
+--- a/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_nodeupconfig-nodes_content
++++ b/tests/integration/update_cluster/apiservernodes/data/aws_s3_object_nodeupconfig-nodes_content
+@@ -45,7 +45,6 @@ KubeletConfig:
+   logLevel: 2
+   nodeLabels:
+     node-role.kubernetes.io/node: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -60,6 +59,7 @@ containerdConfig:
+   logLevel: info
+   runc:
+     version: 1.1.5
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.6.20
+ usesLegacyGossip: false
+ usesNoneDNS: false
+diff --git a/tests/integration/update_cluster/aws-lb-controller/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data b/tests/integration/update_cluster/aws-lb-controller/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
+index f9e9d03953..cfb61715a4 100644
+--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
++++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
+@@ -130,7 +130,7 @@ ClusterName: minimal.example.com
+ ConfigBase: memfs://clusters.example.com/minimal.example.com
+ InstanceGroupName: master-us-test-1a
+ InstanceGroupRole: ControlPlane
+-NodeupConfigHash: hwe4qrB8lrpQUByJDxUeDm6WzYWNuE7nQHAfP5g5nQo=
++NodeupConfigHash: v1G8dUnySTcFSgsLymYfHH8ceR3deEJ+CDyFZklRX5g=
+ 
+ __EOF_KUBE_ENV
+ 
+diff --git a/tests/integration/update_cluster/aws-lb-controller/data/aws_launch_template_nodes.minimal.example.com_user_data b/tests/integration/update_cluster/aws-lb-controller/data/aws_launch_template_nodes.minimal.example.com_user_data
+index 4b6fe88318..13b9b6d58a 100644
+--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_launch_template_nodes.minimal.example.com_user_data
++++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_launch_template_nodes.minimal.example.com_user_data
+@@ -153,7 +153,7 @@ ConfigServer:
+   - https://kops-controller.internal.minimal.example.com:3988/
+ InstanceGroupName: nodes
+ InstanceGroupRole: Node
+-NodeupConfigHash: RwbCzWuKwqBp91KWu4IEZpgBJ0UVI0mpR+lv9mY5/nQ=
++NodeupConfigHash: MBILso1750yJWFfuk5/KINzohd8nOsHTvT6sHBIZjgU=
+ 
+ __EOF_KUBE_ENV
+ 
+diff --git a/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_cluster-completed.spec_content b/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_cluster-completed.spec_content
+index 1524d80898..3194bf7fad 100644
+--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_cluster-completed.spec_content
++++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_cluster-completed.spec_content
+@@ -32,6 +32,7 @@ spec:
+     logLevel: info
+     runc:
+       version: 1.2.4
++    sandboxImage: registry.k8s.io/pause:3.10.1
+     version: 1.7.25
+   dnsZone: Z1AFAKE1ZON3YO
+   etcdClusters:
+@@ -148,7 +149,6 @@ spec:
+     evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
+     kubeconfigPath: /var/lib/kubelet/kubeconfig
+     logLevel: 2
+-    podInfraContainerImage: registry.k8s.io/pause:3.9
+     podManifestPath: /etc/kubernetes/manifests
+     protectKernelDefaults: true
+     registerSchedulable: true
+@@ -168,7 +168,6 @@ spec:
+     evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
+     kubeconfigPath: /var/lib/kubelet/kubeconfig
+     logLevel: 2
+-    podInfraContainerImage: registry.k8s.io/pause:3.9
+     podManifestPath: /etc/kubernetes/manifests
+     protectKernelDefaults: true
+     registerSchedulable: true
+diff --git a/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_nodeupconfig-master-us-test-1a_content b/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+index 2bda32e2dd..03972c8795 100644
+--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
++++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+@@ -292,7 +292,6 @@ KubeletConfig:
+     kops.k8s.io/kops-controller-pki: ""
+     node-role.kubernetes.io/control-plane: ""
+     node.kubernetes.io/exclude-from-external-load-balancers: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -314,6 +313,7 @@ containerdConfig:
+   logLevel: info
+   runc:
+     version: 1.2.4
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.7.25
+ etcdManifests:
+ - memfs://clusters.example.com/minimal.example.com/manifests/etcd/main-master-us-test-1a.yaml
+diff --git a/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_nodeupconfig-nodes_content b/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_nodeupconfig-nodes_content
+index 2d88fa5a47..fe36f97d54 100644
+--- a/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_nodeupconfig-nodes_content
++++ b/tests/integration/update_cluster/aws-lb-controller/data/aws_s3_object_nodeupconfig-nodes_content
+@@ -43,7 +43,6 @@ KubeletConfig:
+   logLevel: 2
+   nodeLabels:
+     node-role.kubernetes.io/node: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -58,6 +57,7 @@ containerdConfig:
+   logLevel: info
+   runc:
+     version: 1.2.4
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.7.25
+ usesLegacyGossip: false
+ usesNoneDNS: false
+diff --git a/tests/integration/update_cluster/bastionadditional_user-data/data/aws_launch_template_master-us-test-1a.masters.bastionuserdata.example.com_user_data b/tests/integration/update_cluster/bastionadditional_user-data/data/aws_launch_template_master-us-test-1a.masters.bastionuserdata.example.com_user_data
+index 5ec907a0f1..3b36b5963c 100644
+--- a/tests/integration/update_cluster/bastionadditional_user-data/data/aws_launch_template_master-us-test-1a.masters.bastionuserdata.example.com_user_data
++++ b/tests/integration/update_cluster/bastionadditional_user-data/data/aws_launch_template_master-us-test-1a.masters.bastionuserdata.example.com_user_data
+@@ -130,7 +130,7 @@ ClusterName: bastionuserdata.example.com
+ ConfigBase: memfs://clusters.example.com/bastionuserdata.example.com
+ InstanceGroupName: master-us-test-1a
+ InstanceGroupRole: ControlPlane
+-NodeupConfigHash: /CMrJEa3vry2ndHUBbapU9y1w15UKdldYMHe4/Il0ic=
++NodeupConfigHash: 7+wnybDW4oYJgpgNVAtLKQVWAQmp0fEb9Xov93eS82A=
+ 
+ __EOF_KUBE_ENV
+ 
+diff --git a/tests/integration/update_cluster/bastionadditional_user-data/data/aws_launch_template_nodes.bastionuserdata.example.com_user_data b/tests/integration/update_cluster/bastionadditional_user-data/data/aws_launch_template_nodes.bastionuserdata.example.com_user_data
+index 183b7ceced..fa8e8a06bd 100644
+--- a/tests/integration/update_cluster/bastionadditional_user-data/data/aws_launch_template_nodes.bastionuserdata.example.com_user_data
++++ b/tests/integration/update_cluster/bastionadditional_user-data/data/aws_launch_template_nodes.bastionuserdata.example.com_user_data
+@@ -162,7 +162,7 @@ ConfigServer:
+   - https://kops-controller.internal.bastionuserdata.example.com:3988/
+ InstanceGroupName: nodes
+ InstanceGroupRole: Node
+-NodeupConfigHash: fD3w4saO4iXTeYYkOX3q2b0Qi3pubGTopGIRAv6CzFI=
++NodeupConfigHash: FANkux+rK1aiybnVp/ZO1MBvskIh+blzH1/4K/cgkug=
+ 
+ __EOF_KUBE_ENV
+ 
+diff --git a/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_cluster-completed.spec_content b/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_cluster-completed.spec_content
+index 50fb5ff3b7..6080bea380 100644
+--- a/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_cluster-completed.spec_content
++++ b/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_cluster-completed.spec_content
+@@ -30,6 +30,7 @@ spec:
+     logLevel: info
+     runc:
+       version: 1.2.4
++    sandboxImage: registry.k8s.io/pause:3.10.1
+     version: 1.7.25
+   dnsZone: Z1AFAKE1ZON3YO
+   etcdClusters:
+@@ -145,7 +146,6 @@ spec:
+     evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
+     kubeconfigPath: /var/lib/kubelet/kubeconfig
+     logLevel: 2
+-    podInfraContainerImage: registry.k8s.io/pause:3.9
+     podManifestPath: /etc/kubernetes/manifests
+     protectKernelDefaults: true
+     registerSchedulable: true
+@@ -165,7 +165,6 @@ spec:
+     evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
+     kubeconfigPath: /var/lib/kubelet/kubeconfig
+     logLevel: 2
+-    podInfraContainerImage: registry.k8s.io/pause:3.9
+     podManifestPath: /etc/kubernetes/manifests
+     protectKernelDefaults: true
+     registerSchedulable: true
+diff --git a/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_nodeupconfig-bastion_content b/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_nodeupconfig-bastion_content
+index 68f85e3471..7b20f37efc 100644
+--- a/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_nodeupconfig-bastion_content
++++ b/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_nodeupconfig-bastion_content
+@@ -40,7 +40,6 @@ KubeletConfig:
+   evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
+   kubeconfigPath: /var/lib/kubelet/kubeconfig
+   logLevel: 2
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -55,6 +54,7 @@ containerdConfig:
+   logLevel: info
+   runc:
+     version: 1.2.4
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.7.25
+ usesLegacyGossip: false
+ usesNoneDNS: false
+diff --git a/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_nodeupconfig-master-us-test-1a_content b/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+index d95c2319ec..020d914795 100644
+--- a/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
++++ b/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+@@ -291,7 +291,6 @@ KubeletConfig:
+     kops.k8s.io/kops-controller-pki: ""
+     node-role.kubernetes.io/control-plane: ""
+     node.kubernetes.io/exclude-from-external-load-balancers: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -313,6 +312,7 @@ containerdConfig:
+   logLevel: info
+   runc:
+     version: 1.2.4
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.7.25
+ etcdManifests:
+ - memfs://clusters.example.com/bastionuserdata.example.com/manifests/etcd/main-master-us-test-1a.yaml
+diff --git a/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_nodeupconfig-nodes_content b/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_nodeupconfig-nodes_content
+index 6f53c48006..adb7ef6c94 100644
+--- a/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_nodeupconfig-nodes_content
++++ b/tests/integration/update_cluster/bastionadditional_user-data/data/aws_s3_object_nodeupconfig-nodes_content
+@@ -43,7 +43,6 @@ KubeletConfig:
+   logLevel: 2
+   nodeLabels:
+     node-role.kubernetes.io/node: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -58,6 +57,7 @@ containerdConfig:
+   logLevel: info
+   runc:
+     version: 1.2.4
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.7.25
+ usesLegacyGossip: false
+ usesNoneDNS: false
+diff --git a/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_launch_template_master-us-test-1a.masters.cas-priority-expander-custom.example.com_user_data b/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_launch_template_master-us-test-1a.masters.cas-priority-expander-custom.example.com_user_data
+index bc10a7fe32..15d64faaff 100644
+--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_launch_template_master-us-test-1a.masters.cas-priority-expander-custom.example.com_user_data
++++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_launch_template_master-us-test-1a.masters.cas-priority-expander-custom.example.com_user_data
+@@ -130,7 +130,7 @@ ClusterName: cas-priority-expander-custom.example.com
+ ConfigBase: memfs://clusters.example.com/cas-priority-expander-custom.example.com
+ InstanceGroupName: master-us-test-1a
+ InstanceGroupRole: ControlPlane
+-NodeupConfigHash: lqrSzC/HkARFePSIR7bgPBUBlM3HsZGxpFrTx66sn1k=
++NodeupConfigHash: E7oj2P6stXKMm/3jdm28b8Oovh7fmYYczO53w4SKFkg=
+ 
+ __EOF_KUBE_ENV
+ 
+diff --git a/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_launch_template_nodes-high-priority.cas-priority-expander-custom.example.com_user_data b/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_launch_template_nodes-high-priority.cas-priority-expander-custom.example.com_user_data
+index 0f70c18462..98dc9333ca 100644
+--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_launch_template_nodes-high-priority.cas-priority-expander-custom.example.com_user_data
++++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_launch_template_nodes-high-priority.cas-priority-expander-custom.example.com_user_data
+@@ -153,7 +153,7 @@ ConfigServer:
+   - https://kops-controller.internal.cas-priority-expander-custom.example.com:3988/
+ InstanceGroupName: nodes-high-priority
+ InstanceGroupRole: Node
+-NodeupConfigHash: s7e/ie5rEtrvcwoIPO6aickeH0UWDhyHqsdN1htSrqo=
++NodeupConfigHash: bgtvwzvZ8Ho4vI773GwFqkmDdmk/CdrLlAggjW7xpdI=
+ 
+ __EOF_KUBE_ENV
+ 
+diff --git a/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_launch_template_nodes-low-priority.cas-priority-expander-custom.example.com_user_data b/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_launch_template_nodes-low-priority.cas-priority-expander-custom.example.com_user_data
+index fb21308eb9..0a87896b4f 100644
+--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_launch_template_nodes-low-priority.cas-priority-expander-custom.example.com_user_data
++++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_launch_template_nodes-low-priority.cas-priority-expander-custom.example.com_user_data
+@@ -153,7 +153,7 @@ ConfigServer:
+   - https://kops-controller.internal.cas-priority-expander-custom.example.com:3988/
+ InstanceGroupName: nodes-low-priority
+ InstanceGroupRole: Node
+-NodeupConfigHash: s7e/ie5rEtrvcwoIPO6aickeH0UWDhyHqsdN1htSrqo=
++NodeupConfigHash: bgtvwzvZ8Ho4vI773GwFqkmDdmk/CdrLlAggjW7xpdI=
+ 
+ __EOF_KUBE_ENV
+ 
+diff --git a/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_launch_template_nodes.cas-priority-expander-custom.example.com_user_data b/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_launch_template_nodes.cas-priority-expander-custom.example.com_user_data
+index 75692803c4..bad63ab291 100644
+--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_launch_template_nodes.cas-priority-expander-custom.example.com_user_data
++++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_launch_template_nodes.cas-priority-expander-custom.example.com_user_data
+@@ -153,7 +153,7 @@ ConfigServer:
+   - https://kops-controller.internal.cas-priority-expander-custom.example.com:3988/
+ InstanceGroupName: nodes
+ InstanceGroupRole: Node
+-NodeupConfigHash: s7e/ie5rEtrvcwoIPO6aickeH0UWDhyHqsdN1htSrqo=
++NodeupConfigHash: bgtvwzvZ8Ho4vI773GwFqkmDdmk/CdrLlAggjW7xpdI=
+ 
+ __EOF_KUBE_ENV
+ 
+diff --git a/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_cluster-completed.spec_content b/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_cluster-completed.spec_content
+index 2d66e418bf..e2fab14f6b 100644
+--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_cluster-completed.spec_content
++++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_cluster-completed.spec_content
+@@ -54,6 +54,7 @@ spec:
+     logLevel: info
+     runc:
+       version: 1.2.4
++    sandboxImage: registry.k8s.io/pause:3.10.1
+     version: 1.7.25
+   dnsZone: Z1AFAKE1ZON3YO
+   etcdClusters:
+@@ -166,7 +167,6 @@ spec:
+     evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
+     kubeconfigPath: /var/lib/kubelet/kubeconfig
+     logLevel: 2
+-    podInfraContainerImage: registry.k8s.io/pause:3.9
+     podManifestPath: /etc/kubernetes/manifests
+     protectKernelDefaults: true
+     registerSchedulable: true
+@@ -185,7 +185,6 @@ spec:
+     evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
+     kubeconfigPath: /var/lib/kubelet/kubeconfig
+     logLevel: 2
+-    podInfraContainerImage: registry.k8s.io/pause:3.9
+     podManifestPath: /etc/kubernetes/manifests
+     protectKernelDefaults: true
+     registerSchedulable: true
+diff --git a/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_nodeupconfig-master-us-test-1a_content b/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+index e9d2f28fdd..3b9d3b7100 100644
+--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
++++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+@@ -291,7 +291,6 @@ KubeletConfig:
+     kops.k8s.io/kops-controller-pki: ""
+     node-role.kubernetes.io/control-plane: ""
+     node.kubernetes.io/exclude-from-external-load-balancers: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -313,6 +312,7 @@ containerdConfig:
+   logLevel: info
+   runc:
+     version: 1.2.4
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.7.25
+ etcdManifests:
+ - memfs://clusters.example.com/cas-priority-expander-custom.example.com/manifests/etcd/main-master-us-test-1a.yaml
+diff --git a/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_nodeupconfig-nodes-high-priority_content b/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_nodeupconfig-nodes-high-priority_content
+index e1baca9d79..d3e89b57a3 100644
+--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_nodeupconfig-nodes-high-priority_content
++++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_nodeupconfig-nodes-high-priority_content
+@@ -42,7 +42,6 @@ KubeletConfig:
+   logLevel: 2
+   nodeLabels:
+     node-role.kubernetes.io/node: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -57,6 +56,7 @@ containerdConfig:
+   logLevel: info
+   runc:
+     version: 1.2.4
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.7.25
+ usesLegacyGossip: false
+ usesNoneDNS: false
+diff --git a/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_nodeupconfig-nodes-low-priority_content b/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_nodeupconfig-nodes-low-priority_content
+index e1baca9d79..d3e89b57a3 100644
+--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_nodeupconfig-nodes-low-priority_content
++++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_nodeupconfig-nodes-low-priority_content
+@@ -42,7 +42,6 @@ KubeletConfig:
+   logLevel: 2
+   nodeLabels:
+     node-role.kubernetes.io/node: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -57,6 +56,7 @@ containerdConfig:
+   logLevel: info
+   runc:
+     version: 1.2.4
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.7.25
+ usesLegacyGossip: false
+ usesNoneDNS: false
+diff --git a/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_nodeupconfig-nodes_content b/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_nodeupconfig-nodes_content
+index e1baca9d79..d3e89b57a3 100644
+--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_nodeupconfig-nodes_content
++++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander-custom/data/aws_s3_object_nodeupconfig-nodes_content
+@@ -42,7 +42,6 @@ KubeletConfig:
+   logLevel: 2
+   nodeLabels:
+     node-role.kubernetes.io/node: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -57,6 +56,7 @@ containerdConfig:
+   logLevel: info
+   runc:
+     version: 1.2.4
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.7.25
+ usesLegacyGossip: false
+ usesNoneDNS: false
+diff --git a/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_launch_template_master-us-test-1a.masters.cas-priority-expander.example.com_user_data b/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_launch_template_master-us-test-1a.masters.cas-priority-expander.example.com_user_data
+index b9028b1c6c..c33a7a8600 100644
+--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_launch_template_master-us-test-1a.masters.cas-priority-expander.example.com_user_data
++++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_launch_template_master-us-test-1a.masters.cas-priority-expander.example.com_user_data
+@@ -130,7 +130,7 @@ ClusterName: cas-priority-expander.example.com
+ ConfigBase: memfs://clusters.example.com/cas-priority-expander.example.com
+ InstanceGroupName: master-us-test-1a
+ InstanceGroupRole: ControlPlane
+-NodeupConfigHash: enuVLbFsywKaNY0DSUNgNQ9IQvTDd5e5YlxQOOzrnVg=
++NodeupConfigHash: uC/xrSgoOnRXtZJ7uidh8ZKap7j7k/X7gfOz2pr6x1s=
+ 
+ __EOF_KUBE_ENV
+ 
+diff --git a/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_launch_template_nodes-high-priority.cas-priority-expander.example.com_user_data b/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_launch_template_nodes-high-priority.cas-priority-expander.example.com_user_data
+index 37452df17b..141b199c16 100644
+--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_launch_template_nodes-high-priority.cas-priority-expander.example.com_user_data
++++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_launch_template_nodes-high-priority.cas-priority-expander.example.com_user_data
+@@ -153,7 +153,7 @@ ConfigServer:
+   - https://kops-controller.internal.cas-priority-expander.example.com:3988/
+ InstanceGroupName: nodes-high-priority
+ InstanceGroupRole: Node
+-NodeupConfigHash: cl9BRWMvX037nLwq94mFZFJBD6XTLFdsre5jxU+QHwU=
++NodeupConfigHash: yg08yRDOQAblfHEXm91YvV/ZZ2K9xOmbo5gwLR+A30E=
+ 
+ __EOF_KUBE_ENV
+ 
+diff --git a/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_launch_template_nodes-low-priority.cas-priority-expander.example.com_user_data b/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_launch_template_nodes-low-priority.cas-priority-expander.example.com_user_data
+index 9eebae7261..ce229fc1da 100644
+--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_launch_template_nodes-low-priority.cas-priority-expander.example.com_user_data
++++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_launch_template_nodes-low-priority.cas-priority-expander.example.com_user_data
+@@ -153,7 +153,7 @@ ConfigServer:
+   - https://kops-controller.internal.cas-priority-expander.example.com:3988/
+ InstanceGroupName: nodes-low-priority
+ InstanceGroupRole: Node
+-NodeupConfigHash: cl9BRWMvX037nLwq94mFZFJBD6XTLFdsre5jxU+QHwU=
++NodeupConfigHash: yg08yRDOQAblfHEXm91YvV/ZZ2K9xOmbo5gwLR+A30E=
+ 
+ __EOF_KUBE_ENV
+ 
+diff --git a/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_launch_template_nodes.cas-priority-expander.example.com_user_data b/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_launch_template_nodes.cas-priority-expander.example.com_user_data
+index 1273e5351b..1bd38f3b18 100644
+--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_launch_template_nodes.cas-priority-expander.example.com_user_data
++++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_launch_template_nodes.cas-priority-expander.example.com_user_data
+@@ -153,7 +153,7 @@ ConfigServer:
+   - https://kops-controller.internal.cas-priority-expander.example.com:3988/
+ InstanceGroupName: nodes
+ InstanceGroupRole: Node
+-NodeupConfigHash: cl9BRWMvX037nLwq94mFZFJBD6XTLFdsre5jxU+QHwU=
++NodeupConfigHash: yg08yRDOQAblfHEXm91YvV/ZZ2K9xOmbo5gwLR+A30E=
+ 
+ __EOF_KUBE_ENV
+ 
+diff --git a/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_cluster-completed.spec_content b/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_cluster-completed.spec_content
+index 8a91f090d8..a27e9c7f3b 100644
+--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_cluster-completed.spec_content
++++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_cluster-completed.spec_content
+@@ -47,6 +47,7 @@ spec:
+     logLevel: info
+     runc:
+       version: 1.2.4
++    sandboxImage: registry.k8s.io/pause:3.10.1
+     version: 1.7.25
+   dnsZone: Z1AFAKE1ZON3YO
+   etcdClusters:
+@@ -159,7 +160,6 @@ spec:
+     evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
+     kubeconfigPath: /var/lib/kubelet/kubeconfig
+     logLevel: 2
+-    podInfraContainerImage: registry.k8s.io/pause:3.9
+     podManifestPath: /etc/kubernetes/manifests
+     protectKernelDefaults: true
+     registerSchedulable: true
+@@ -178,7 +178,6 @@ spec:
+     evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
+     kubeconfigPath: /var/lib/kubelet/kubeconfig
+     logLevel: 2
+-    podInfraContainerImage: registry.k8s.io/pause:3.9
+     podManifestPath: /etc/kubernetes/manifests
+     protectKernelDefaults: true
+     registerSchedulable: true
+diff --git a/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_nodeupconfig-master-us-test-1a_content b/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+index 497c94219b..d754f281ab 100644
+--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
++++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+@@ -291,7 +291,6 @@ KubeletConfig:
+     kops.k8s.io/kops-controller-pki: ""
+     node-role.kubernetes.io/control-plane: ""
+     node.kubernetes.io/exclude-from-external-load-balancers: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -313,6 +312,7 @@ containerdConfig:
+   logLevel: info
+   runc:
+     version: 1.2.4
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.7.25
+ etcdManifests:
+ - memfs://clusters.example.com/cas-priority-expander.example.com/manifests/etcd/main-master-us-test-1a.yaml
+diff --git a/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_nodeupconfig-nodes-high-priority_content b/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_nodeupconfig-nodes-high-priority_content
+index f258bed47d..b164bc356d 100644
+--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_nodeupconfig-nodes-high-priority_content
++++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_nodeupconfig-nodes-high-priority_content
+@@ -42,7 +42,6 @@ KubeletConfig:
+   logLevel: 2
+   nodeLabels:
+     node-role.kubernetes.io/node: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -57,6 +56,7 @@ containerdConfig:
+   logLevel: info
+   runc:
+     version: 1.2.4
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.7.25
+ usesLegacyGossip: false
+ usesNoneDNS: false
+diff --git a/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_nodeupconfig-nodes-low-priority_content b/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_nodeupconfig-nodes-low-priority_content
+index f258bed47d..b164bc356d 100644
+--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_nodeupconfig-nodes-low-priority_content
++++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_nodeupconfig-nodes-low-priority_content
+@@ -42,7 +42,6 @@ KubeletConfig:
+   logLevel: 2
+   nodeLabels:
+     node-role.kubernetes.io/node: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -57,6 +56,7 @@ containerdConfig:
+   logLevel: info
+   runc:
+     version: 1.2.4
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.7.25
+ usesLegacyGossip: false
+ usesNoneDNS: false
+diff --git a/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_nodeupconfig-nodes_content b/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_nodeupconfig-nodes_content
+index f258bed47d..b164bc356d 100644
+--- a/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_nodeupconfig-nodes_content
++++ b/tests/integration/update_cluster/cluster-autoscaler-priority-expander/data/aws_s3_object_nodeupconfig-nodes_content
+@@ -42,7 +42,6 @@ KubeletConfig:
+   logLevel: 2
+   nodeLabels:
+     node-role.kubernetes.io/node: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -57,6 +56,7 @@ containerdConfig:
+   logLevel: info
+   runc:
+     version: 1.2.4
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.7.25
+ usesLegacyGossip: false
+ usesNoneDNS: false
+diff --git a/tests/integration/update_cluster/complex/data/aws_launch_template_master-us-test-1a.masters.complex.example.com_user_data b/tests/integration/update_cluster/complex/data/aws_launch_template_master-us-test-1a.masters.complex.example.com_user_data
+index 1b1f07cc86..1662d87fe3 100644
+--- a/tests/integration/update_cluster/complex/data/aws_launch_template_master-us-test-1a.masters.complex.example.com_user_data
++++ b/tests/integration/update_cluster/complex/data/aws_launch_template_master-us-test-1a.masters.complex.example.com_user_data
+@@ -139,7 +139,7 @@ ClusterName: complex.example.com
+ ConfigBase: memfs://clusters.example.com/complex.example.com
+ InstanceGroupName: master-us-test-1a
+ InstanceGroupRole: ControlPlane
+-NodeupConfigHash: Bs0VktUnEG71qqsma591CR4EQOBN57RHWCW7CLaVHas=
++NodeupConfigHash: rQ0+K8Ip2huuYvf/nD1SN0Zbs19z9ceQ6VUV1AAwFWw=
+ 
+ __EOF_KUBE_ENV
+ 
+diff --git a/tests/integration/update_cluster/complex/data/aws_launch_template_nodes.complex.example.com_user_data b/tests/integration/update_cluster/complex/data/aws_launch_template_nodes.complex.example.com_user_data
+index dfb40289e2..0f8841104d 100644
+--- a/tests/integration/update_cluster/complex/data/aws_launch_template_nodes.complex.example.com_user_data
++++ b/tests/integration/update_cluster/complex/data/aws_launch_template_nodes.complex.example.com_user_data
+@@ -162,7 +162,7 @@ ConfigServer:
+   - https://kops-controller.internal.complex.example.com:3988/
+ InstanceGroupName: nodes
+ InstanceGroupRole: Node
+-NodeupConfigHash: mjCSijO9Bnj00rvOTIhxruxOltFwyA4pYOuisbP+4R4=
++NodeupConfigHash: d7f5JgGA8pDYehV9Zls/CFhWyaHeXp3qATReDuDQQYM=
+ 
+ __EOF_KUBE_ENV
+ 
+diff --git a/tests/integration/update_cluster/complex/data/aws_s3_object_cluster-completed.spec_content b/tests/integration/update_cluster/complex/data/aws_s3_object_cluster-completed.spec_content
+index 0ddfeaf5af..2fc1142067 100644
+--- a/tests/integration/update_cluster/complex/data/aws_s3_object_cluster-completed.spec_content
++++ b/tests/integration/update_cluster/complex/data/aws_s3_object_cluster-completed.spec_content
+@@ -50,6 +50,7 @@ spec:
+     logLevel: info
+     runc:
+       version: 1.2.4
++    sandboxImage: registry.k8s.io/pause:3.10.1
+     version: 1.7.25
+   dnsZone: Z1AFAKE1ZON3YO
+   etcdClusters:
+@@ -190,7 +191,6 @@ spec:
+       InTreePluginAWSUnregister: "true"
+     kubeconfigPath: /var/lib/kubelet/kubeconfig
+     logLevel: 2
+-    podInfraContainerImage: registry.k8s.io/pause:3.9
+     podManifestPath: /etc/kubernetes/manifests
+     protectKernelDefaults: true
+     registerSchedulable: true
+@@ -213,7 +213,6 @@ spec:
+       InTreePluginAWSUnregister: "true"
+     kubeconfigPath: /var/lib/kubelet/kubeconfig
+     logLevel: 2
+-    podInfraContainerImage: registry.k8s.io/pause:3.9
+     podManifestPath: /etc/kubernetes/manifests
+     protectKernelDefaults: true
+     registerSchedulable: true
+diff --git a/tests/integration/update_cluster/complex/data/aws_s3_object_nodeupconfig-master-us-test-1a_content b/tests/integration/update_cluster/complex/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+index 450ca69287..5f17fdb44c 100644
+--- a/tests/integration/update_cluster/complex/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
++++ b/tests/integration/update_cluster/complex/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+@@ -317,7 +317,6 @@ KubeletConfig:
+     kops.k8s.io/kops-controller-pki: ""
+     node-role.kubernetes.io/control-plane: ""
+     node.kubernetes.io/exclude-from-external-load-balancers: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -340,6 +339,7 @@ containerdConfig:
+   logLevel: info
+   runc:
+     version: 1.2.4
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.7.25
+ etcdManifests:
+ - memfs://clusters.example.com/complex.example.com/manifests/etcd/main-master-us-test-1a.yaml
+diff --git a/tests/integration/update_cluster/complex/data/aws_s3_object_nodeupconfig-nodes_content b/tests/integration/update_cluster/complex/data/aws_s3_object_nodeupconfig-nodes_content
+index 1e059130ea..4406b2a0c3 100644
+--- a/tests/integration/update_cluster/complex/data/aws_s3_object_nodeupconfig-nodes_content
++++ b/tests/integration/update_cluster/complex/data/aws_s3_object_nodeupconfig-nodes_content
+@@ -45,7 +45,6 @@ KubeletConfig:
+   logLevel: 2
+   nodeLabels:
+     node-role.kubernetes.io/node: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -61,6 +60,7 @@ containerdConfig:
+   logLevel: info
+   runc:
+     version: 1.2.4
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.7.25
+ packages:
+ - nfs-common
+diff --git a/tests/integration/update_cluster/compress/data/aws_s3_object_cluster-completed.spec_content b/tests/integration/update_cluster/compress/data/aws_s3_object_cluster-completed.spec_content
+index 8f63b79525..f9e8a44314 100644
+--- a/tests/integration/update_cluster/compress/data/aws_s3_object_cluster-completed.spec_content
++++ b/tests/integration/update_cluster/compress/data/aws_s3_object_cluster-completed.spec_content
+@@ -28,6 +28,7 @@ spec:
+     logLevel: info
+     runc:
+       version: 1.2.4
++    sandboxImage: registry.k8s.io/pause:3.10.1
+     version: 1.7.25
+   dnsZone: Z1AFAKE1ZON3YO
+   etcdClusters:
+@@ -143,7 +144,6 @@ spec:
+     evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
+     kubeconfigPath: /var/lib/kubelet/kubeconfig
+     logLevel: 2
+-    podInfraContainerImage: registry.k8s.io/pause:3.9
+     podManifestPath: /etc/kubernetes/manifests
+     protectKernelDefaults: true
+     registerSchedulable: true
+@@ -163,7 +163,6 @@ spec:
+     evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
+     kubeconfigPath: /var/lib/kubelet/kubeconfig
+     logLevel: 2
+-    podInfraContainerImage: registry.k8s.io/pause:3.9
+     podManifestPath: /etc/kubernetes/manifests
+     protectKernelDefaults: true
+     registerSchedulable: true
+diff --git a/tests/integration/update_cluster/compress/data/aws_s3_object_nodeupconfig-master-us-test-1a_content b/tests/integration/update_cluster/compress/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+index 9bdfeda827..c45d60e030 100644
+--- a/tests/integration/update_cluster/compress/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
++++ b/tests/integration/update_cluster/compress/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+@@ -292,7 +292,6 @@ KubeletConfig:
+     kops.k8s.io/kops-controller-pki: ""
+     node-role.kubernetes.io/control-plane: ""
+     node.kubernetes.io/exclude-from-external-load-balancers: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -314,6 +313,7 @@ containerdConfig:
+   logLevel: info
+   runc:
+     version: 1.2.4
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.7.25
+ etcdManifests:
+ - memfs://clusters.example.com/compress.example.com/manifests/etcd/main-master-us-test-1a.yaml
+diff --git a/tests/integration/update_cluster/compress/data/aws_s3_object_nodeupconfig-nodes_content b/tests/integration/update_cluster/compress/data/aws_s3_object_nodeupconfig-nodes_content
+index 7f99f2bab3..5820af03d3 100644
+--- a/tests/integration/update_cluster/compress/data/aws_s3_object_nodeupconfig-nodes_content
++++ b/tests/integration/update_cluster/compress/data/aws_s3_object_nodeupconfig-nodes_content
+@@ -43,7 +43,6 @@ KubeletConfig:
+   logLevel: 2
+   nodeLabels:
+     node-role.kubernetes.io/node: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -58,6 +57,7 @@ containerdConfig:
+   logLevel: info
+   runc:
+     version: 1.2.4
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.7.25
+ usesLegacyGossip: false
+ usesNoneDNS: false
+diff --git a/tests/integration/update_cluster/containerd-custom/data/aws_launch_template_master-us-test-1a.masters.containerd.example.com_user_data b/tests/integration/update_cluster/containerd-custom/data/aws_launch_template_master-us-test-1a.masters.containerd.example.com_user_data
+index 92aca5a9fe..8c34893309 100644
+--- a/tests/integration/update_cluster/containerd-custom/data/aws_launch_template_master-us-test-1a.masters.containerd.example.com_user_data
++++ b/tests/integration/update_cluster/containerd-custom/data/aws_launch_template_master-us-test-1a.masters.containerd.example.com_user_data
+@@ -130,7 +130,7 @@ ClusterName: containerd.example.com
+ ConfigBase: memfs://clusters.example.com/containerd.example.com
+ InstanceGroupName: master-us-test-1a
+ InstanceGroupRole: ControlPlane
+-NodeupConfigHash: kurdQDak4IW5y5zXemSZTL1bmivMlFyqkktNHV6KDQ0=
++NodeupConfigHash: xdxKtRHnz+Ci6z2ODFm/4CQEIXHQf6+7uZn4h2AMEU8=
+ 
+ __EOF_KUBE_ENV
+ 
+diff --git a/tests/integration/update_cluster/containerd-custom/data/aws_launch_template_nodes.containerd.example.com_user_data b/tests/integration/update_cluster/containerd-custom/data/aws_launch_template_nodes.containerd.example.com_user_data
+index 03c1b37c95..a24cfc60a0 100644
+--- a/tests/integration/update_cluster/containerd-custom/data/aws_launch_template_nodes.containerd.example.com_user_data
++++ b/tests/integration/update_cluster/containerd-custom/data/aws_launch_template_nodes.containerd.example.com_user_data
+@@ -153,7 +153,7 @@ ConfigServer:
+   - https://kops-controller.internal.containerd.example.com:3988/
+ InstanceGroupName: nodes
+ InstanceGroupRole: Node
+-NodeupConfigHash: NOUriyVTYriIh98hMxHIzamDyuX6usLFjqInEcv0mgE=
++NodeupConfigHash: v7zox3OZqvXUzcvqKEo/XGvoiK9Q5YU+0XMWqnO35z4=
+ 
+ __EOF_KUBE_ENV
+ 
+diff --git a/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_cluster-completed.spec_content b/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_cluster-completed.spec_content
+index 543bcc1820..1e161641ec 100644
+--- a/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_cluster-completed.spec_content
++++ b/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_cluster-completed.spec_content
+@@ -36,6 +36,7 @@ spec:
+       - https://registry-1.docker.io
+     runc:
+       version: 1.2.4
++    sandboxImage: registry.k8s.io/pause:3.10.1
+     skipInstall: true
+     version: 1.7.25
+   dnsZone: Z1AFAKE1ZON3YO
+@@ -152,7 +153,6 @@ spec:
+     evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
+     kubeconfigPath: /var/lib/kubelet/kubeconfig
+     logLevel: 2
+-    podInfraContainerImage: registry.k8s.io/pause:3.9
+     podManifestPath: /etc/kubernetes/manifests
+     protectKernelDefaults: true
+     registerSchedulable: true
+@@ -172,7 +172,6 @@ spec:
+     evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
+     kubeconfigPath: /var/lib/kubelet/kubeconfig
+     logLevel: 2
+-    podInfraContainerImage: registry.k8s.io/pause:3.9
+     podManifestPath: /etc/kubernetes/manifests
+     protectKernelDefaults: true
+     registerSchedulable: true
+diff --git a/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_nodeupconfig-master-us-test-1a_content b/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+index bca4f17399..d6a66aa011 100644
+--- a/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
++++ b/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+@@ -286,7 +286,6 @@ KubeletConfig:
+     kops.k8s.io/kops-controller-pki: ""
+     node-role.kubernetes.io/control-plane: ""
+     node.kubernetes.io/exclude-from-external-load-balancers: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -316,6 +315,7 @@ containerdConfig:
+     - https://registry-1.docker.io
+   runc:
+     version: 1.2.4
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   skipInstall: true
+   version: 1.7.25
+ etcdManifests:
+diff --git a/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_nodeupconfig-nodes_content b/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_nodeupconfig-nodes_content
+index 7c12451d0c..5a3c27d01e 100644
+--- a/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_nodeupconfig-nodes_content
++++ b/tests/integration/update_cluster/containerd-custom/data/aws_s3_object_nodeupconfig-nodes_content
+@@ -37,7 +37,6 @@ KubeletConfig:
+   logLevel: 2
+   nodeLabels:
+     node-role.kubernetes.io/node: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -60,6 +59,7 @@ containerdConfig:
+     - https://registry-1.docker.io
+   runc:
+     version: 1.2.4
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   skipInstall: true
+   version: 1.7.25
+ usesLegacyGossip: false
+diff --git a/tests/integration/update_cluster/containerd/assets.yaml b/tests/integration/update_cluster/containerd/assets.yaml
+index 9af1912b0b..ff6b6b9458 100644
+--- a/tests/integration/update_cluster/containerd/assets.yaml
++++ b/tests/integration/update_cluster/containerd/assets.yaml
+@@ -50,8 +50,8 @@ files:
+ images:
+ - canonical: registry.k8s.io/kube-apiserver:v1.32.0
+   download: registry.k8s.io/kube-apiserver:v1.32.0
+-- canonical: registry.k8s.io/pause:3.9
+-  download: registry.k8s.io/pause:3.9
++- canonical: registry.k8s.io/pause:3.10.1
++  download: registry.k8s.io/pause:3.10.1
+ - canonical: registry.k8s.io/kube-controller-manager:v1.32.0
+   download: registry.k8s.io/kube-controller-manager:v1.32.0
+ - canonical: registry.k8s.io/kube-scheduler:v1.32.0
+diff --git a/tests/integration/update_cluster/containerd/data/aws_launch_template_master-us-test-1a.masters.containerd.example.com_user_data b/tests/integration/update_cluster/containerd/data/aws_launch_template_master-us-test-1a.masters.containerd.example.com_user_data
+index 8287fa35bf..6e850b8484 100644
+--- a/tests/integration/update_cluster/containerd/data/aws_launch_template_master-us-test-1a.masters.containerd.example.com_user_data
++++ b/tests/integration/update_cluster/containerd/data/aws_launch_template_master-us-test-1a.masters.containerd.example.com_user_data
+@@ -130,7 +130,7 @@ ClusterName: containerd.example.com
+ ConfigBase: memfs://clusters.example.com/containerd.example.com
+ InstanceGroupName: master-us-test-1a
+ InstanceGroupRole: ControlPlane
+-NodeupConfigHash: UnhfYjHKvEKf6uGyuZeQE8nWhiKde88/ev/Ltw9rBEA=
++NodeupConfigHash: xSNEfoTa7Lyppsii+dNdJmymZPCCW6BoAIjG0nDCJgk=
+ 
+ __EOF_KUBE_ENV
+ 
+diff --git a/tests/integration/update_cluster/containerd/data/aws_launch_template_nodes.containerd.example.com_user_data b/tests/integration/update_cluster/containerd/data/aws_launch_template_nodes.containerd.example.com_user_data
+index c3733b49e8..af80562d86 100644
+--- a/tests/integration/update_cluster/containerd/data/aws_launch_template_nodes.containerd.example.com_user_data
++++ b/tests/integration/update_cluster/containerd/data/aws_launch_template_nodes.containerd.example.com_user_data
+@@ -153,7 +153,7 @@ ConfigServer:
+   - https://kops-controller.internal.containerd.example.com:3988/
+ InstanceGroupName: nodes
+ InstanceGroupRole: Node
+-NodeupConfigHash: VuOK8MsJ71UZZk4essJX08TFa25DfeUuNwkue3YdxHk=
++NodeupConfigHash: 2S9KpwpLeiAIuj0m0hquFkQbCaGplzcR3Ijq02AoTYU=
+ 
+ __EOF_KUBE_ENV
+ 
+diff --git a/tests/integration/update_cluster/containerd/data/aws_s3_object_cluster-completed.spec_content b/tests/integration/update_cluster/containerd/data/aws_s3_object_cluster-completed.spec_content
+index 9c34d64811..d379dc3b9a 100644
+--- a/tests/integration/update_cluster/containerd/data/aws_s3_object_cluster-completed.spec_content
++++ b/tests/integration/update_cluster/containerd/data/aws_s3_object_cluster-completed.spec_content
+@@ -28,6 +28,7 @@ spec:
+     logLevel: info
+     runc:
+       version: 1.2.4
++    sandboxImage: registry.k8s.io/pause:3.10.1
+     version: 1.7.25
+   dnsZone: Z1AFAKE1ZON3YO
+   etcdClusters:
+@@ -143,7 +144,6 @@ spec:
+     evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
+     kubeconfigPath: /var/lib/kubelet/kubeconfig
+     logLevel: 2
+-    podInfraContainerImage: registry.k8s.io/pause:3.9
+     podManifestPath: /etc/kubernetes/manifests
+     protectKernelDefaults: true
+     registerSchedulable: true
+@@ -163,7 +163,6 @@ spec:
+     evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
+     kubeconfigPath: /var/lib/kubelet/kubeconfig
+     logLevel: 2
+-    podInfraContainerImage: registry.k8s.io/pause:3.9
+     podManifestPath: /etc/kubernetes/manifests
+     protectKernelDefaults: true
+     registerSchedulable: true
+diff --git a/tests/integration/update_cluster/containerd/data/aws_s3_object_nodeupconfig-master-us-test-1a_content b/tests/integration/update_cluster/containerd/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+index f885aea634..4be3bca166 100644
+--- a/tests/integration/update_cluster/containerd/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
++++ b/tests/integration/update_cluster/containerd/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+@@ -292,7 +292,6 @@ KubeletConfig:
+     kops.k8s.io/kops-controller-pki: ""
+     node-role.kubernetes.io/control-plane: ""
+     node.kubernetes.io/exclude-from-external-load-balancers: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -314,6 +313,7 @@ containerdConfig:
+   logLevel: info
+   runc:
+     version: 1.2.4
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.7.25
+ etcdManifests:
+ - memfs://clusters.example.com/containerd.example.com/manifests/etcd/main-master-us-test-1a.yaml
+diff --git a/tests/integration/update_cluster/containerd/data/aws_s3_object_nodeupconfig-nodes_content b/tests/integration/update_cluster/containerd/data/aws_s3_object_nodeupconfig-nodes_content
+index f6f706522f..50d4e00912 100644
+--- a/tests/integration/update_cluster/containerd/data/aws_s3_object_nodeupconfig-nodes_content
++++ b/tests/integration/update_cluster/containerd/data/aws_s3_object_nodeupconfig-nodes_content
+@@ -43,7 +43,6 @@ KubeletConfig:
+   logLevel: 2
+   nodeLabels:
+     node-role.kubernetes.io/node: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -58,6 +57,7 @@ containerdConfig:
+   logLevel: info
+   runc:
+     version: 1.2.4
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.7.25
+ usesLegacyGossip: false
+ usesNoneDNS: false
+diff --git a/tests/integration/update_cluster/digit/data/aws_launch_template_master-us-test-1a.masters.123.example.com_user_data b/tests/integration/update_cluster/digit/data/aws_launch_template_master-us-test-1a.masters.123.example.com_user_data
+index ec5651cc84..860f4c96a0 100644
+--- a/tests/integration/update_cluster/digit/data/aws_launch_template_master-us-test-1a.masters.123.example.com_user_data
++++ b/tests/integration/update_cluster/digit/data/aws_launch_template_master-us-test-1a.masters.123.example.com_user_data
+@@ -130,7 +130,7 @@ ClusterName: 123.example.com
+ ConfigBase: memfs://clusters.example.com/123.example.com
+ InstanceGroupName: master-us-test-1a
+ InstanceGroupRole: ControlPlane
+-NodeupConfigHash: iQRW/DgDicPYkFuudMAT10xGylfYtQsdIv4aLr3iPz0=
++NodeupConfigHash: Zd9rMyomlqoIJZ9YBihe3bp/FfQkO0WP57W4GZ+pxiA=
+ 
+ __EOF_KUBE_ENV
+ 
+diff --git a/tests/integration/update_cluster/digit/data/aws_launch_template_nodes.123.example.com_user_data b/tests/integration/update_cluster/digit/data/aws_launch_template_nodes.123.example.com_user_data
+index ed57834e00..a914a07b28 100644
+--- a/tests/integration/update_cluster/digit/data/aws_launch_template_nodes.123.example.com_user_data
++++ b/tests/integration/update_cluster/digit/data/aws_launch_template_nodes.123.example.com_user_data
+@@ -153,7 +153,7 @@ ConfigServer:
+   - https://kops-controller.internal.123.example.com:3988/
+ InstanceGroupName: nodes
+ InstanceGroupRole: Node
+-NodeupConfigHash: WM7Lpy+J9LY1SwjxOGhTHwmfrBGtQSNSB5GuXDRuS8Q=
++NodeupConfigHash: H0m/XqYjYVL3+SXg1CeX9PjLvvHskVxE+XBNWJt3IUw=
+ 
+ __EOF_KUBE_ENV
+ 
+diff --git a/tests/integration/update_cluster/digit/data/aws_s3_object_cluster-completed.spec_content b/tests/integration/update_cluster/digit/data/aws_s3_object_cluster-completed.spec_content
+index 91be8f2338..c77525b9ac 100644
+--- a/tests/integration/update_cluster/digit/data/aws_s3_object_cluster-completed.spec_content
++++ b/tests/integration/update_cluster/digit/data/aws_s3_object_cluster-completed.spec_content
+@@ -28,6 +28,7 @@ spec:
+     logLevel: info
+     runc:
+       version: 1.2.4
++    sandboxImage: registry.k8s.io/pause:3.10.1
+     version: 1.7.25
+   dnsZone: Z1AFAKE1ZON3YO
+   etcdClusters:
+@@ -165,7 +166,6 @@ spec:
+     evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
+     kubeconfigPath: /var/lib/kubelet/kubeconfig
+     logLevel: 2
+-    podInfraContainerImage: registry.k8s.io/pause:3.9
+     podManifestPath: /etc/kubernetes/manifests
+     protectKernelDefaults: true
+     registerSchedulable: true
+@@ -185,7 +185,6 @@ spec:
+     evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
+     kubeconfigPath: /var/lib/kubelet/kubeconfig
+     logLevel: 2
+-    podInfraContainerImage: registry.k8s.io/pause:3.9
+     podManifestPath: /etc/kubernetes/manifests
+     protectKernelDefaults: true
+     registerSchedulable: true
+diff --git a/tests/integration/update_cluster/digit/data/aws_s3_object_nodeupconfig-master-us-test-1a_content b/tests/integration/update_cluster/digit/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+index 8af979e622..8c8e01dbe1 100644
+--- a/tests/integration/update_cluster/digit/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
++++ b/tests/integration/update_cluster/digit/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+@@ -292,7 +292,6 @@ KubeletConfig:
+     kops.k8s.io/kops-controller-pki: ""
+     node-role.kubernetes.io/control-plane: ""
+     node.kubernetes.io/exclude-from-external-load-balancers: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -314,6 +313,7 @@ containerdConfig:
+   logLevel: info
+   runc:
+     version: 1.2.4
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.7.25
+ etcdManifests:
+ - memfs://clusters.example.com/123.example.com/manifests/etcd/main-master-us-test-1a.yaml
+diff --git a/tests/integration/update_cluster/digit/data/aws_s3_object_nodeupconfig-nodes_content b/tests/integration/update_cluster/digit/data/aws_s3_object_nodeupconfig-nodes_content
+index ba038acbf1..9546952541 100644
+--- a/tests/integration/update_cluster/digit/data/aws_s3_object_nodeupconfig-nodes_content
++++ b/tests/integration/update_cluster/digit/data/aws_s3_object_nodeupconfig-nodes_content
+@@ -43,7 +43,6 @@ KubeletConfig:
+   logLevel: 2
+   nodeLabels:
+     node-role.kubernetes.io/node: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -58,6 +57,7 @@ containerdConfig:
+   logLevel: info
+   runc:
+     version: 1.2.4
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.7.25
+ usesLegacyGossip: false
+ usesNoneDNS: false
+diff --git a/tests/integration/update_cluster/existing_iam/data/aws_launch_template_master-us-test-1a.masters.existing-iam.example.com_user_data b/tests/integration/update_cluster/existing_iam/data/aws_launch_template_master-us-test-1a.masters.existing-iam.example.com_user_data
+index 2a1c8b28d1..593a10b72f 100644
+--- a/tests/integration/update_cluster/existing_iam/data/aws_launch_template_master-us-test-1a.masters.existing-iam.example.com_user_data
++++ b/tests/integration/update_cluster/existing_iam/data/aws_launch_template_master-us-test-1a.masters.existing-iam.example.com_user_data
+@@ -130,7 +130,7 @@ ClusterName: existing-iam.example.com
+ ConfigBase: memfs://tests/existing-iam.example.com
+ InstanceGroupName: master-us-test-1a
+ InstanceGroupRole: ControlPlane
+-NodeupConfigHash: V0NfQj8EcqRFMs4Je3swie/YA7E/vgVhFO3QEENWWWg=
++NodeupConfigHash: jYL2wP8ksx7JQFbnF/91k1X3BR+tW1SRICgC3oboTGo=
+ 
+ __EOF_KUBE_ENV
+ 
+diff --git a/tests/integration/update_cluster/existing_iam/data/aws_launch_template_master-us-test-1b.masters.existing-iam.example.com_user_data b/tests/integration/update_cluster/existing_iam/data/aws_launch_template_master-us-test-1b.masters.existing-iam.example.com_user_data
+index f8e8fe67de..b001281801 100644
+--- a/tests/integration/update_cluster/existing_iam/data/aws_launch_template_master-us-test-1b.masters.existing-iam.example.com_user_data
++++ b/tests/integration/update_cluster/existing_iam/data/aws_launch_template_master-us-test-1b.masters.existing-iam.example.com_user_data
+@@ -130,7 +130,7 @@ ClusterName: existing-iam.example.com
+ ConfigBase: memfs://tests/existing-iam.example.com
+ InstanceGroupName: master-us-test-1b
+ InstanceGroupRole: ControlPlane
+-NodeupConfigHash: SHk/FaVBp+1YnzcMsqJX3BEA0+AjrBZaUCLH9+lNmhI=
++NodeupConfigHash: qC7DHrLLmR5HkhuHEoSQF+JwMvItMZhAiUI8Wrikx6s=
+ 
+ __EOF_KUBE_ENV
+ 
+diff --git a/tests/integration/update_cluster/existing_iam/data/aws_launch_template_master-us-test-1c.masters.existing-iam.example.com_user_data b/tests/integration/update_cluster/existing_iam/data/aws_launch_template_master-us-test-1c.masters.existing-iam.example.com_user_data
+index 998482c6e9..a72dbb9106 100644
+--- a/tests/integration/update_cluster/existing_iam/data/aws_launch_template_master-us-test-1c.masters.existing-iam.example.com_user_data
++++ b/tests/integration/update_cluster/existing_iam/data/aws_launch_template_master-us-test-1c.masters.existing-iam.example.com_user_data
+@@ -130,7 +130,7 @@ ClusterName: existing-iam.example.com
+ ConfigBase: memfs://tests/existing-iam.example.com
+ InstanceGroupName: master-us-test-1c
+ InstanceGroupRole: ControlPlane
+-NodeupConfigHash: UqiUW2RwXvibbcikamT1FcWcg+L/wSrFAwrvo2F403g=
++NodeupConfigHash: 3P+ep5MoPQN4xBkxcZyQNJNPQEaUA6K0zGwHlqL5/G4=
+ 
+ __EOF_KUBE_ENV
+ 
+diff --git a/tests/integration/update_cluster/existing_iam/data/aws_launch_template_nodes.existing-iam.example.com_user_data b/tests/integration/update_cluster/existing_iam/data/aws_launch_template_nodes.existing-iam.example.com_user_data
+index 98a513fa33..dac4049c0e 100644
+--- a/tests/integration/update_cluster/existing_iam/data/aws_launch_template_nodes.existing-iam.example.com_user_data
++++ b/tests/integration/update_cluster/existing_iam/data/aws_launch_template_nodes.existing-iam.example.com_user_data
+@@ -153,7 +153,7 @@ ConfigServer:
+   - https://kops-controller.internal.existing-iam.example.com:3988/
+ InstanceGroupName: nodes
+ InstanceGroupRole: Node
+-NodeupConfigHash: DL+w+Z8W+20KtT2bg72UOiN2zf7B4pRmbByFgUxIos0=
++NodeupConfigHash: GYpsfSkSx9elcMyAvr28gcQZFA127adNspdamWywNOU=
+ 
+ __EOF_KUBE_ENV
+ 
+diff --git a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_cluster-completed.spec_content b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_cluster-completed.spec_content
+index 01d65b1bb5..07f96fa77d 100644
+--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_cluster-completed.spec_content
++++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_cluster-completed.spec_content
+@@ -28,6 +28,7 @@ spec:
+     logLevel: info
+     runc:
+       version: 1.2.4
++    sandboxImage: registry.k8s.io/pause:3.10.1
+     version: 1.7.25
+   dnsZone: Z1AFAKE1ZON3YO
+   etcdClusters:
+@@ -151,7 +152,6 @@ spec:
+     evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
+     kubeconfigPath: /var/lib/kubelet/kubeconfig
+     logLevel: 2
+-    podInfraContainerImage: registry.k8s.io/pause:3.9
+     podManifestPath: /etc/kubernetes/manifests
+     protectKernelDefaults: true
+     registerSchedulable: true
+@@ -171,7 +171,6 @@ spec:
+     evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
+     kubeconfigPath: /var/lib/kubelet/kubeconfig
+     logLevel: 2
+-    podInfraContainerImage: registry.k8s.io/pause:3.9
+     podManifestPath: /etc/kubernetes/manifests
+     protectKernelDefaults: true
+     registerSchedulable: true
+diff --git a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_nodeupconfig-master-us-test-1a_content b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+index 4c94e32891..84d2c114e1 100644
+--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
++++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+@@ -292,7 +292,6 @@ KubeletConfig:
+     kops.k8s.io/kops-controller-pki: ""
+     node-role.kubernetes.io/control-plane: ""
+     node.kubernetes.io/exclude-from-external-load-balancers: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -314,6 +313,7 @@ containerdConfig:
+   logLevel: info
+   runc:
+     version: 1.2.4
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.7.25
+ etcdManifests:
+ - memfs://tests/existing-iam.example.com/manifests/etcd/main-master-us-test-1a.yaml
+diff --git a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_nodeupconfig-master-us-test-1b_content b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_nodeupconfig-master-us-test-1b_content
+index 2b8e9a14a4..317267eba3 100644
+--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_nodeupconfig-master-us-test-1b_content
++++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_nodeupconfig-master-us-test-1b_content
+@@ -292,7 +292,6 @@ KubeletConfig:
+     kops.k8s.io/kops-controller-pki: ""
+     node-role.kubernetes.io/control-plane: ""
+     node.kubernetes.io/exclude-from-external-load-balancers: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -314,6 +313,7 @@ containerdConfig:
+   logLevel: info
+   runc:
+     version: 1.2.4
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.7.25
+ etcdManifests:
+ - memfs://tests/existing-iam.example.com/manifests/etcd/main-master-us-test-1b.yaml
+diff --git a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_nodeupconfig-master-us-test-1c_content b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_nodeupconfig-master-us-test-1c_content
+index 77a7a1fa74..815453200a 100644
+--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_nodeupconfig-master-us-test-1c_content
++++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_nodeupconfig-master-us-test-1c_content
+@@ -292,7 +292,6 @@ KubeletConfig:
+     kops.k8s.io/kops-controller-pki: ""
+     node-role.kubernetes.io/control-plane: ""
+     node.kubernetes.io/exclude-from-external-load-balancers: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -314,6 +313,7 @@ containerdConfig:
+   logLevel: info
+   runc:
+     version: 1.2.4
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.7.25
+ etcdManifests:
+ - memfs://tests/existing-iam.example.com/manifests/etcd/main-master-us-test-1c.yaml
+diff --git a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_nodeupconfig-nodes_content b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_nodeupconfig-nodes_content
+index 090e888f5b..b612797eed 100644
+--- a/tests/integration/update_cluster/existing_iam/data/aws_s3_object_nodeupconfig-nodes_content
++++ b/tests/integration/update_cluster/existing_iam/data/aws_s3_object_nodeupconfig-nodes_content
+@@ -43,7 +43,6 @@ KubeletConfig:
+   logLevel: 2
+   nodeLabels:
+     node-role.kubernetes.io/node: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -58,6 +57,7 @@ containerdConfig:
+   logLevel: info
+   runc:
+     version: 1.2.4
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.7.25
+ usesLegacyGossip: false
+ usesNoneDNS: false
+diff --git a/tests/integration/update_cluster/existing_sg/data/aws_launch_template_master-us-test-1a.masters.existingsg.example.com_user_data b/tests/integration/update_cluster/existing_sg/data/aws_launch_template_master-us-test-1a.masters.existingsg.example.com_user_data
+index c6b05a9f84..78e4ec9377 100644
+--- a/tests/integration/update_cluster/existing_sg/data/aws_launch_template_master-us-test-1a.masters.existingsg.example.com_user_data
++++ b/tests/integration/update_cluster/existing_sg/data/aws_launch_template_master-us-test-1a.masters.existingsg.example.com_user_data
+@@ -130,7 +130,7 @@ ClusterName: existingsg.example.com
+ ConfigBase: memfs://clusters.example.com/existingsg.example.com
+ InstanceGroupName: master-us-test-1a
+ InstanceGroupRole: ControlPlane
+-NodeupConfigHash: VI6i3YAOECBj4LkUcJtNGoDVp52/JsIVMCK+oQ0Sric=
++NodeupConfigHash: B5btjvmw0eccyDlgpyxq7ykKz5pD9K0Zkurq/GcXwAA=
+ 
+ __EOF_KUBE_ENV
+ 
+diff --git a/tests/integration/update_cluster/existing_sg/data/aws_launch_template_master-us-test-1b.masters.existingsg.example.com_user_data b/tests/integration/update_cluster/existing_sg/data/aws_launch_template_master-us-test-1b.masters.existingsg.example.com_user_data
+index 218167f120..c6c32ac266 100644
+--- a/tests/integration/update_cluster/existing_sg/data/aws_launch_template_master-us-test-1b.masters.existingsg.example.com_user_data
++++ b/tests/integration/update_cluster/existing_sg/data/aws_launch_template_master-us-test-1b.masters.existingsg.example.com_user_data
+@@ -130,7 +130,7 @@ ClusterName: existingsg.example.com
+ ConfigBase: memfs://clusters.example.com/existingsg.example.com
+ InstanceGroupName: master-us-test-1b
+ InstanceGroupRole: ControlPlane
+-NodeupConfigHash: neEB5h7tN2cE8xQlxqVl3MGPIBHpD5ULBK0+rgHiuR0=
++NodeupConfigHash: wDRGVkE3hOITT1szLDiKT2ZBcCuyzxY7b7zaMssK3zo=
+ 
+ __EOF_KUBE_ENV
+ 
+diff --git a/tests/integration/update_cluster/existing_sg/data/aws_launch_template_master-us-test-1c.masters.existingsg.example.com_user_data b/tests/integration/update_cluster/existing_sg/data/aws_launch_template_master-us-test-1c.masters.existingsg.example.com_user_data
+index cec4869d3d..cdb073c360 100644
+--- a/tests/integration/update_cluster/existing_sg/data/aws_launch_template_master-us-test-1c.masters.existingsg.example.com_user_data
++++ b/tests/integration/update_cluster/existing_sg/data/aws_launch_template_master-us-test-1c.masters.existingsg.example.com_user_data
+@@ -130,7 +130,7 @@ ClusterName: existingsg.example.com
+ ConfigBase: memfs://clusters.example.com/existingsg.example.com
+ InstanceGroupName: master-us-test-1c
+ InstanceGroupRole: ControlPlane
+-NodeupConfigHash: LqFXUhl09XzKG70qa0SxoaM69H3eOQ2LuHNKKKTeNBQ=
++NodeupConfigHash: Q8HQw5h73wjoqFY/GTMclRt76OUOp5AwT20OVY/jji4=
+ 
+ __EOF_KUBE_ENV
+ 
+diff --git a/tests/integration/update_cluster/existing_sg/data/aws_launch_template_nodes.existingsg.example.com_user_data b/tests/integration/update_cluster/existing_sg/data/aws_launch_template_nodes.existingsg.example.com_user_data
+index 4e0d7596a3..5a34d473db 100644
+--- a/tests/integration/update_cluster/existing_sg/data/aws_launch_template_nodes.existingsg.example.com_user_data
++++ b/tests/integration/update_cluster/existing_sg/data/aws_launch_template_nodes.existingsg.example.com_user_data
+@@ -153,7 +153,7 @@ ConfigServer:
+   - https://kops-controller.internal.existingsg.example.com:3988/
+ InstanceGroupName: nodes
+ InstanceGroupRole: Node
+-NodeupConfigHash: +EKPmtaPFf7/97Ih9ebY1kLHeb2fyNpu5W0b3bCVVe0=
++NodeupConfigHash: CIpXXgxJ59QjZhrdZD7UHgO6rxl3LoAEtpOMcJj3XqQ=
+ 
+ __EOF_KUBE_ENV
+ 
+diff --git a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_cluster-completed.spec_content b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_cluster-completed.spec_content
+index cff21f4276..a17ae34981 100644
+--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_cluster-completed.spec_content
++++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_cluster-completed.spec_content
+@@ -31,6 +31,7 @@ spec:
+     logLevel: info
+     runc:
+       version: 1.2.4
++    sandboxImage: registry.k8s.io/pause:3.10.1
+     version: 1.7.25
+   dnsZone: Z1AFAKE1ZON3YO
+   etcdClusters:
+@@ -154,7 +155,6 @@ spec:
+     evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
+     kubeconfigPath: /var/lib/kubelet/kubeconfig
+     logLevel: 2
+-    podInfraContainerImage: registry.k8s.io/pause:3.9
+     podManifestPath: /etc/kubernetes/manifests
+     protectKernelDefaults: true
+     registerSchedulable: true
+@@ -174,7 +174,6 @@ spec:
+     evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
+     kubeconfigPath: /var/lib/kubelet/kubeconfig
+     logLevel: 2
+-    podInfraContainerImage: registry.k8s.io/pause:3.9
+     podManifestPath: /etc/kubernetes/manifests
+     protectKernelDefaults: true
+     registerSchedulable: true
+diff --git a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_nodeupconfig-master-us-test-1a_content b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+index fb36a4c924..1153eae7da 100644
+--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
++++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+@@ -291,7 +291,6 @@ KubeletConfig:
+     kops.k8s.io/kops-controller-pki: ""
+     node-role.kubernetes.io/control-plane: ""
+     node.kubernetes.io/exclude-from-external-load-balancers: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -313,6 +312,7 @@ containerdConfig:
+   logLevel: info
+   runc:
+     version: 1.2.4
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.7.25
+ etcdManifests:
+ - memfs://clusters.example.com/existingsg.example.com/manifests/etcd/main-master-us-test-1a.yaml
+diff --git a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_nodeupconfig-master-us-test-1b_content b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_nodeupconfig-master-us-test-1b_content
+index 102bbb6bd0..8b868c1fef 100644
+--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_nodeupconfig-master-us-test-1b_content
++++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_nodeupconfig-master-us-test-1b_content
+@@ -291,7 +291,6 @@ KubeletConfig:
+     kops.k8s.io/kops-controller-pki: ""
+     node-role.kubernetes.io/control-plane: ""
+     node.kubernetes.io/exclude-from-external-load-balancers: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -313,6 +312,7 @@ containerdConfig:
+   logLevel: info
+   runc:
+     version: 1.2.4
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.7.25
+ etcdManifests:
+ - memfs://clusters.example.com/existingsg.example.com/manifests/etcd/main-master-us-test-1b.yaml
+diff --git a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_nodeupconfig-master-us-test-1c_content b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_nodeupconfig-master-us-test-1c_content
+index 07e8cfdec5..f959d99869 100644
+--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_nodeupconfig-master-us-test-1c_content
++++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_nodeupconfig-master-us-test-1c_content
+@@ -291,7 +291,6 @@ KubeletConfig:
+     kops.k8s.io/kops-controller-pki: ""
+     node-role.kubernetes.io/control-plane: ""
+     node.kubernetes.io/exclude-from-external-load-balancers: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -313,6 +312,7 @@ containerdConfig:
+   logLevel: info
+   runc:
+     version: 1.2.4
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.7.25
+ etcdManifests:
+ - memfs://clusters.example.com/existingsg.example.com/manifests/etcd/main-master-us-test-1c.yaml
+diff --git a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_nodeupconfig-nodes_content b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_nodeupconfig-nodes_content
+index 12b10a644f..0dbde9a68d 100644
+--- a/tests/integration/update_cluster/existing_sg/data/aws_s3_object_nodeupconfig-nodes_content
++++ b/tests/integration/update_cluster/existing_sg/data/aws_s3_object_nodeupconfig-nodes_content
+@@ -43,7 +43,6 @@ KubeletConfig:
+   logLevel: 2
+   nodeLabels:
+     node-role.kubernetes.io/node: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -58,6 +57,7 @@ containerdConfig:
+   logLevel: info
+   runc:
+     version: 1.2.4
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.7.25
+ usesLegacyGossip: false
+ usesNoneDNS: false
+diff --git a/tests/integration/update_cluster/external_dns/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data b/tests/integration/update_cluster/external_dns/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
+index 5477ff9838..7bc96dd065 100644
+--- a/tests/integration/update_cluster/external_dns/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
++++ b/tests/integration/update_cluster/external_dns/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
+@@ -130,7 +130,7 @@ ClusterName: minimal.example.com
+ ConfigBase: memfs://clusters.example.com/minimal.example.com
+ InstanceGroupName: master-us-test-1a
+ InstanceGroupRole: ControlPlane
+-NodeupConfigHash: ucsdJGKI6NlyxcMuxNbIl5QTQ9XH7jlClzx6w6ZSu+I=
++NodeupConfigHash: QgVGs/0YUwUnI6Kqga5EjoUYo40di+z7q9qJkhMgdO4=
+ 
+ __EOF_KUBE_ENV
+ 
+diff --git a/tests/integration/update_cluster/external_dns/data/aws_launch_template_nodes.minimal.example.com_user_data b/tests/integration/update_cluster/external_dns/data/aws_launch_template_nodes.minimal.example.com_user_data
+index 4b6fe88318..13b9b6d58a 100644
+--- a/tests/integration/update_cluster/external_dns/data/aws_launch_template_nodes.minimal.example.com_user_data
++++ b/tests/integration/update_cluster/external_dns/data/aws_launch_template_nodes.minimal.example.com_user_data
+@@ -153,7 +153,7 @@ ConfigServer:
+   - https://kops-controller.internal.minimal.example.com:3988/
+ InstanceGroupName: nodes
+ InstanceGroupRole: Node
+-NodeupConfigHash: RwbCzWuKwqBp91KWu4IEZpgBJ0UVI0mpR+lv9mY5/nQ=
++NodeupConfigHash: MBILso1750yJWFfuk5/KINzohd8nOsHTvT6sHBIZjgU=
+ 
+ __EOF_KUBE_ENV
+ 
+diff --git a/tests/integration/update_cluster/external_dns/data/aws_s3_object_cluster-completed.spec_content b/tests/integration/update_cluster/external_dns/data/aws_s3_object_cluster-completed.spec_content
+index 209e9ed31a..c389b9ba78 100644
+--- a/tests/integration/update_cluster/external_dns/data/aws_s3_object_cluster-completed.spec_content
++++ b/tests/integration/update_cluster/external_dns/data/aws_s3_object_cluster-completed.spec_content
+@@ -28,6 +28,7 @@ spec:
+     logLevel: info
+     runc:
+       version: 1.2.4
++    sandboxImage: registry.k8s.io/pause:3.10.1
+     version: 1.7.25
+   dnsZone: Z1AFAKE1ZON3YO
+   etcdClusters:
+@@ -143,7 +144,6 @@ spec:
+     evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
+     kubeconfigPath: /var/lib/kubelet/kubeconfig
+     logLevel: 2
+-    podInfraContainerImage: registry.k8s.io/pause:3.9
+     podManifestPath: /etc/kubernetes/manifests
+     protectKernelDefaults: true
+     registerSchedulable: true
+@@ -163,7 +163,6 @@ spec:
+     evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
+     kubeconfigPath: /var/lib/kubelet/kubeconfig
+     logLevel: 2
+-    podInfraContainerImage: registry.k8s.io/pause:3.9
+     podManifestPath: /etc/kubernetes/manifests
+     protectKernelDefaults: true
+     registerSchedulable: true
+diff --git a/tests/integration/update_cluster/external_dns/data/aws_s3_object_nodeupconfig-master-us-test-1a_content b/tests/integration/update_cluster/external_dns/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+index ebe132ffcb..11dbc89cf6 100644
+--- a/tests/integration/update_cluster/external_dns/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
++++ b/tests/integration/update_cluster/external_dns/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+@@ -292,7 +292,6 @@ KubeletConfig:
+     kops.k8s.io/kops-controller-pki: ""
+     node-role.kubernetes.io/control-plane: ""
+     node.kubernetes.io/exclude-from-external-load-balancers: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -314,6 +313,7 @@ containerdConfig:
+   logLevel: info
+   runc:
+     version: 1.2.4
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.7.25
+ etcdManifests:
+ - memfs://clusters.example.com/minimal.example.com/manifests/etcd/main-master-us-test-1a.yaml
+diff --git a/tests/integration/update_cluster/external_dns/data/aws_s3_object_nodeupconfig-nodes_content b/tests/integration/update_cluster/external_dns/data/aws_s3_object_nodeupconfig-nodes_content
+index 2d88fa5a47..fe36f97d54 100644
+--- a/tests/integration/update_cluster/external_dns/data/aws_s3_object_nodeupconfig-nodes_content
++++ b/tests/integration/update_cluster/external_dns/data/aws_s3_object_nodeupconfig-nodes_content
+@@ -43,7 +43,6 @@ KubeletConfig:
+   logLevel: 2
+   nodeLabels:
+     node-role.kubernetes.io/node: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -58,6 +57,7 @@ containerdConfig:
+   logLevel: info
+   runc:
+     version: 1.2.4
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.7.25
+ usesLegacyGossip: false
+ usesNoneDNS: false
+diff --git a/tests/integration/update_cluster/external_dns_irsa/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data b/tests/integration/update_cluster/external_dns_irsa/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
+index f9e9d03953..cfb61715a4 100644
+--- a/tests/integration/update_cluster/external_dns_irsa/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
++++ b/tests/integration/update_cluster/external_dns_irsa/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
+@@ -130,7 +130,7 @@ ClusterName: minimal.example.com
+ ConfigBase: memfs://clusters.example.com/minimal.example.com
+ InstanceGroupName: master-us-test-1a
+ InstanceGroupRole: ControlPlane
+-NodeupConfigHash: hwe4qrB8lrpQUByJDxUeDm6WzYWNuE7nQHAfP5g5nQo=
++NodeupConfigHash: v1G8dUnySTcFSgsLymYfHH8ceR3deEJ+CDyFZklRX5g=
+ 
+ __EOF_KUBE_ENV
+ 
+diff --git a/tests/integration/update_cluster/external_dns_irsa/data/aws_launch_template_nodes.minimal.example.com_user_data b/tests/integration/update_cluster/external_dns_irsa/data/aws_launch_template_nodes.minimal.example.com_user_data
+index 4b6fe88318..13b9b6d58a 100644
+--- a/tests/integration/update_cluster/external_dns_irsa/data/aws_launch_template_nodes.minimal.example.com_user_data
++++ b/tests/integration/update_cluster/external_dns_irsa/data/aws_launch_template_nodes.minimal.example.com_user_data
+@@ -153,7 +153,7 @@ ConfigServer:
+   - https://kops-controller.internal.minimal.example.com:3988/
+ InstanceGroupName: nodes
+ InstanceGroupRole: Node
+-NodeupConfigHash: RwbCzWuKwqBp91KWu4IEZpgBJ0UVI0mpR+lv9mY5/nQ=
++NodeupConfigHash: MBILso1750yJWFfuk5/KINzohd8nOsHTvT6sHBIZjgU=
+ 
+ __EOF_KUBE_ENV
+ 
+diff --git a/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_cluster-completed.spec_content b/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_cluster-completed.spec_content
+index 6afa42b69f..b53b9e7c9c 100644
+--- a/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_cluster-completed.spec_content
++++ b/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_cluster-completed.spec_content
+@@ -28,6 +28,7 @@ spec:
+     logLevel: info
+     runc:
+       version: 1.2.4
++    sandboxImage: registry.k8s.io/pause:3.10.1
+     version: 1.7.25
+   dnsZone: Z1AFAKE1ZON3YO
+   etcdClusters:
+@@ -144,7 +145,6 @@ spec:
+     evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
+     kubeconfigPath: /var/lib/kubelet/kubeconfig
+     logLevel: 2
+-    podInfraContainerImage: registry.k8s.io/pause:3.9
+     podManifestPath: /etc/kubernetes/manifests
+     protectKernelDefaults: true
+     registerSchedulable: true
+@@ -164,7 +164,6 @@ spec:
+     evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
+     kubeconfigPath: /var/lib/kubelet/kubeconfig
+     logLevel: 2
+-    podInfraContainerImage: registry.k8s.io/pause:3.9
+     podManifestPath: /etc/kubernetes/manifests
+     protectKernelDefaults: true
+     registerSchedulable: true
+diff --git a/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_nodeupconfig-master-us-test-1a_content b/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+index 2bda32e2dd..03972c8795 100644
+--- a/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
++++ b/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+@@ -292,7 +292,6 @@ KubeletConfig:
+     kops.k8s.io/kops-controller-pki: ""
+     node-role.kubernetes.io/control-plane: ""
+     node.kubernetes.io/exclude-from-external-load-balancers: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -314,6 +313,7 @@ containerdConfig:
+   logLevel: info
+   runc:
+     version: 1.2.4
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.7.25
+ etcdManifests:
+ - memfs://clusters.example.com/minimal.example.com/manifests/etcd/main-master-us-test-1a.yaml
+diff --git a/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_nodeupconfig-nodes_content b/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_nodeupconfig-nodes_content
+index 2d88fa5a47..fe36f97d54 100644
+--- a/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_nodeupconfig-nodes_content
++++ b/tests/integration/update_cluster/external_dns_irsa/data/aws_s3_object_nodeupconfig-nodes_content
+@@ -43,7 +43,6 @@ KubeletConfig:
+   logLevel: 2
+   nodeLabels:
+     node-role.kubernetes.io/node: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -58,6 +57,7 @@ containerdConfig:
+   logLevel: info
+   runc:
+     version: 1.2.4
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.7.25
+ usesLegacyGossip: false
+ usesNoneDNS: false
+diff --git a/tests/integration/update_cluster/externallb/data/aws_launch_template_master-us-test-1a.masters.externallb.example.com_user_data b/tests/integration/update_cluster/externallb/data/aws_launch_template_master-us-test-1a.masters.externallb.example.com_user_data
+index ce8845d2a7..f136f0a442 100644
+--- a/tests/integration/update_cluster/externallb/data/aws_launch_template_master-us-test-1a.masters.externallb.example.com_user_data
++++ b/tests/integration/update_cluster/externallb/data/aws_launch_template_master-us-test-1a.masters.externallb.example.com_user_data
+@@ -130,7 +130,7 @@ ClusterName: externallb.example.com
+ ConfigBase: memfs://clusters.example.com/externallb.example.com
+ InstanceGroupName: master-us-test-1a
+ InstanceGroupRole: ControlPlane
+-NodeupConfigHash: gkLlh0jvZvSPM1aU0VO84JoEWJV0KRUwlCOMkW5D7Fg=
++NodeupConfigHash: mcvwE2UkzK8FzHmZ/7sbIiLd3LpK/XqbJyZAimWaVCA=
+ 
+ __EOF_KUBE_ENV
+ 
+diff --git a/tests/integration/update_cluster/externallb/data/aws_launch_template_nodes.externallb.example.com_user_data b/tests/integration/update_cluster/externallb/data/aws_launch_template_nodes.externallb.example.com_user_data
+index f00ddc155d..7969d36d41 100644
+--- a/tests/integration/update_cluster/externallb/data/aws_launch_template_nodes.externallb.example.com_user_data
++++ b/tests/integration/update_cluster/externallb/data/aws_launch_template_nodes.externallb.example.com_user_data
+@@ -153,7 +153,7 @@ ConfigServer:
+   - https://kops-controller.internal.externallb.example.com:3988/
+ InstanceGroupName: nodes
+ InstanceGroupRole: Node
+-NodeupConfigHash: sEyuEd7V64MBYj0QsFdFYL7vXbirlplGXkDoX47Fzvc=
++NodeupConfigHash: m+1QFDB1xkmzPmLTxGlEC1uTEYINtu3XoxFD47FZAqk=
+ 
+ __EOF_KUBE_ENV
+ 
+diff --git a/tests/integration/update_cluster/externallb/data/aws_s3_object_cluster-completed.spec_content b/tests/integration/update_cluster/externallb/data/aws_s3_object_cluster-completed.spec_content
+index 6481f8875a..05fe463465 100644
+--- a/tests/integration/update_cluster/externallb/data/aws_s3_object_cluster-completed.spec_content
++++ b/tests/integration/update_cluster/externallb/data/aws_s3_object_cluster-completed.spec_content
+@@ -28,6 +28,7 @@ spec:
+     logLevel: info
+     runc:
+       version: 1.2.4
++    sandboxImage: registry.k8s.io/pause:3.10.1
+     version: 1.7.25
+   dnsZone: Z1AFAKE1ZON3YO
+   etcdClusters:
+@@ -143,7 +144,6 @@ spec:
+     evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
+     kubeconfigPath: /var/lib/kubelet/kubeconfig
+     logLevel: 2
+-    podInfraContainerImage: registry.k8s.io/pause:3.9
+     podManifestPath: /etc/kubernetes/manifests
+     protectKernelDefaults: true
+     registerSchedulable: true
+@@ -163,7 +163,6 @@ spec:
+     evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
+     kubeconfigPath: /var/lib/kubelet/kubeconfig
+     logLevel: 2
+-    podInfraContainerImage: registry.k8s.io/pause:3.9
+     podManifestPath: /etc/kubernetes/manifests
+     protectKernelDefaults: true
+     registerSchedulable: true
+diff --git a/tests/integration/update_cluster/externallb/data/aws_s3_object_nodeupconfig-master-us-test-1a_content b/tests/integration/update_cluster/externallb/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+index 85e142bf64..eb907c2a3f 100644
+--- a/tests/integration/update_cluster/externallb/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
++++ b/tests/integration/update_cluster/externallb/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+@@ -292,7 +292,6 @@ KubeletConfig:
+     kops.k8s.io/kops-controller-pki: ""
+     node-role.kubernetes.io/control-plane: ""
+     node.kubernetes.io/exclude-from-external-load-balancers: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -314,6 +313,7 @@ containerdConfig:
+   logLevel: info
+   runc:
+     version: 1.2.4
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.7.25
+ etcdManifests:
+ - memfs://clusters.example.com/externallb.example.com/manifests/etcd/main-master-us-test-1a.yaml
+diff --git a/tests/integration/update_cluster/externallb/data/aws_s3_object_nodeupconfig-nodes_content b/tests/integration/update_cluster/externallb/data/aws_s3_object_nodeupconfig-nodes_content
+index b911bc60f6..9597a78bb8 100644
+--- a/tests/integration/update_cluster/externallb/data/aws_s3_object_nodeupconfig-nodes_content
++++ b/tests/integration/update_cluster/externallb/data/aws_s3_object_nodeupconfig-nodes_content
+@@ -43,7 +43,6 @@ KubeletConfig:
+   logLevel: 2
+   nodeLabels:
+     node-role.kubernetes.io/node: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -58,6 +57,7 @@ containerdConfig:
+   logLevel: info
+   runc:
+     version: 1.2.4
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.7.25
+ usesLegacyGossip: false
+ usesNoneDNS: false
+diff --git a/tests/integration/update_cluster/externalpolicies/data/aws_launch_template_master-us-test-1a.masters.externalpolicies.example.com_user_data b/tests/integration/update_cluster/externalpolicies/data/aws_launch_template_master-us-test-1a.masters.externalpolicies.example.com_user_data
+index faafb3d728..ff031da68c 100644
+--- a/tests/integration/update_cluster/externalpolicies/data/aws_launch_template_master-us-test-1a.masters.externalpolicies.example.com_user_data
++++ b/tests/integration/update_cluster/externalpolicies/data/aws_launch_template_master-us-test-1a.masters.externalpolicies.example.com_user_data
+@@ -130,7 +130,7 @@ ClusterName: externalpolicies.example.com
+ ConfigBase: memfs://clusters.example.com/externalpolicies.example.com
+ InstanceGroupName: master-us-test-1a
+ InstanceGroupRole: ControlPlane
+-NodeupConfigHash: ANsW469TD3QuP8vNBr5lbhMpndW4BhzSuaDWDjr7ENw=
++NodeupConfigHash: 7WSdSxtDeTFIDAjLXw03Zej/JiSKhi5CEKvP0POdrkk=
+ 
+ __EOF_KUBE_ENV
+ 
+diff --git a/tests/integration/update_cluster/externalpolicies/data/aws_launch_template_nodes.externalpolicies.example.com_user_data b/tests/integration/update_cluster/externalpolicies/data/aws_launch_template_nodes.externalpolicies.example.com_user_data
+index 33b8ea567e..252b8febf9 100644
+--- a/tests/integration/update_cluster/externalpolicies/data/aws_launch_template_nodes.externalpolicies.example.com_user_data
++++ b/tests/integration/update_cluster/externalpolicies/data/aws_launch_template_nodes.externalpolicies.example.com_user_data
+@@ -153,7 +153,7 @@ ConfigServer:
+   - https://kops-controller.internal.externalpolicies.example.com:3988/
+ InstanceGroupName: nodes
+ InstanceGroupRole: Node
+-NodeupConfigHash: Zo0dFjE83JSBRaEsS1xaVnOCAQD8zmA71Ee/R3tWMKY=
++NodeupConfigHash: B/sA/bctGH8/gmqV5NgrsDDnfik9kCq97PkEO2posss=
+ 
+ __EOF_KUBE_ENV
+ 
+diff --git a/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_cluster-completed.spec_content b/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_cluster-completed.spec_content
+index fef00bf9ad..07bc144d3f 100644
+--- a/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_cluster-completed.spec_content
++++ b/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_cluster-completed.spec_content
+@@ -36,6 +36,7 @@ spec:
+     logLevel: info
+     runc:
+       version: 1.2.4
++    sandboxImage: registry.k8s.io/pause:3.10.1
+     version: 1.7.25
+   dnsZone: Z1AFAKE1ZON3YO
+   etcdClusters:
+@@ -160,7 +161,6 @@ spec:
+     evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
+     kubeconfigPath: /var/lib/kubelet/kubeconfig
+     logLevel: 2
+-    podInfraContainerImage: registry.k8s.io/pause:3.9
+     podManifestPath: /etc/kubernetes/manifests
+     protectKernelDefaults: true
+     registerSchedulable: true
+@@ -180,7 +180,6 @@ spec:
+     evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
+     kubeconfigPath: /var/lib/kubelet/kubeconfig
+     logLevel: 2
+-    podInfraContainerImage: registry.k8s.io/pause:3.9
+     podManifestPath: /etc/kubernetes/manifests
+     protectKernelDefaults: true
+     registerSchedulable: true
+diff --git a/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_nodeupconfig-master-us-test-1a_content b/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+index 46c0313c7a..1161983c3e 100644
+--- a/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
++++ b/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+@@ -293,7 +293,6 @@ KubeletConfig:
+     kops.k8s.io/kops-controller-pki: ""
+     node-role.kubernetes.io/control-plane: ""
+     node.kubernetes.io/exclude-from-external-load-balancers: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -316,6 +315,7 @@ containerdConfig:
+   logLevel: info
+   runc:
+     version: 1.2.4
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.7.25
+ etcdManifests:
+ - memfs://clusters.example.com/externalpolicies.example.com/manifests/etcd/main-master-us-test-1a.yaml
+diff --git a/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_nodeupconfig-nodes_content b/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_nodeupconfig-nodes_content
+index 5a910fea1a..7c6aa7d8e6 100644
+--- a/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_nodeupconfig-nodes_content
++++ b/tests/integration/update_cluster/externalpolicies/data/aws_s3_object_nodeupconfig-nodes_content
+@@ -43,7 +43,6 @@ KubeletConfig:
+   logLevel: 2
+   nodeLabels:
+     node-role.kubernetes.io/node: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -59,6 +58,7 @@ containerdConfig:
+   logLevel: info
+   runc:
+     version: 1.2.4
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.7.25
+ usesLegacyGossip: false
+ usesNoneDNS: false
+diff --git a/tests/integration/update_cluster/ha/data/aws_launch_template_master-us-test-1a.masters.ha.example.com_user_data b/tests/integration/update_cluster/ha/data/aws_launch_template_master-us-test-1a.masters.ha.example.com_user_data
+index 2f46100c54..2c59510d56 100644
+--- a/tests/integration/update_cluster/ha/data/aws_launch_template_master-us-test-1a.masters.ha.example.com_user_data
++++ b/tests/integration/update_cluster/ha/data/aws_launch_template_master-us-test-1a.masters.ha.example.com_user_data
+@@ -130,7 +130,7 @@ ClusterName: ha.example.com
+ ConfigBase: memfs://tests/ha.example.com
+ InstanceGroupName: master-us-test-1a
+ InstanceGroupRole: ControlPlane
+-NodeupConfigHash: a/cBjBH0b7oxj6wX4QTdtZBOXQMcZZ9xVo2GQaT/umM=
++NodeupConfigHash: PuZuOkIpd6ZOtIca0+18UQbQQxooJya1YEdKOWoWZDY=
+ 
+ __EOF_KUBE_ENV
+ 
+diff --git a/tests/integration/update_cluster/ha/data/aws_launch_template_master-us-test-1b.masters.ha.example.com_user_data b/tests/integration/update_cluster/ha/data/aws_launch_template_master-us-test-1b.masters.ha.example.com_user_data
+index 0703602fc1..59f5b03d89 100644
+--- a/tests/integration/update_cluster/ha/data/aws_launch_template_master-us-test-1b.masters.ha.example.com_user_data
++++ b/tests/integration/update_cluster/ha/data/aws_launch_template_master-us-test-1b.masters.ha.example.com_user_data
+@@ -130,7 +130,7 @@ ClusterName: ha.example.com
+ ConfigBase: memfs://tests/ha.example.com
+ InstanceGroupName: master-us-test-1b
+ InstanceGroupRole: ControlPlane
+-NodeupConfigHash: Lvs3mTw5mrCA507VeCAq850OsvZ3Un6D5iBJ8QyW2SQ=
++NodeupConfigHash: l5iDnIQGClmYZVVDg2xjQGpCQce4y5W/0bjlcX44STg=
+ 
+ __EOF_KUBE_ENV
+ 
+diff --git a/tests/integration/update_cluster/ha/data/aws_launch_template_master-us-test-1c.masters.ha.example.com_user_data b/tests/integration/update_cluster/ha/data/aws_launch_template_master-us-test-1c.masters.ha.example.com_user_data
+index fcd125f8fc..365eaa9707 100644
+--- a/tests/integration/update_cluster/ha/data/aws_launch_template_master-us-test-1c.masters.ha.example.com_user_data
++++ b/tests/integration/update_cluster/ha/data/aws_launch_template_master-us-test-1c.masters.ha.example.com_user_data
+@@ -130,7 +130,7 @@ ClusterName: ha.example.com
+ ConfigBase: memfs://tests/ha.example.com
+ InstanceGroupName: master-us-test-1c
+ InstanceGroupRole: ControlPlane
+-NodeupConfigHash: mSN0tX/kCbZQI7SaKc0py6rEo8Ddu8yB5VSgv4DInl4=
++NodeupConfigHash: jvnq4roy2bXyBcUFk18G5LP3KGEbOzK3xFJ47IMtI1o=
+ 
+ __EOF_KUBE_ENV
+ 
+diff --git a/tests/integration/update_cluster/ha/data/aws_launch_template_nodes.ha.example.com_user_data b/tests/integration/update_cluster/ha/data/aws_launch_template_nodes.ha.example.com_user_data
+index 3a85d9e5d2..51e02226d7 100644
+--- a/tests/integration/update_cluster/ha/data/aws_launch_template_nodes.ha.example.com_user_data
++++ b/tests/integration/update_cluster/ha/data/aws_launch_template_nodes.ha.example.com_user_data
+@@ -153,7 +153,7 @@ ConfigServer:
+   - https://kops-controller.internal.ha.example.com:3988/
+ InstanceGroupName: nodes
+ InstanceGroupRole: Node
+-NodeupConfigHash: f+POTTSE4RDluvyRHR+rPuK9t+QCXI/MkCDVHgp+64Y=
++NodeupConfigHash: E9t8VUSfZ4hmdrR0mXdgsQ/UDDYM0nkI62SeqEOdsRw=
+ 
+ __EOF_KUBE_ENV
+ 
+diff --git a/tests/integration/update_cluster/ha/data/aws_s3_object_cluster-completed.spec_content b/tests/integration/update_cluster/ha/data/aws_s3_object_cluster-completed.spec_content
+index eb38cf19d7..78fb132fee 100644
+--- a/tests/integration/update_cluster/ha/data/aws_s3_object_cluster-completed.spec_content
++++ b/tests/integration/update_cluster/ha/data/aws_s3_object_cluster-completed.spec_content
+@@ -28,6 +28,7 @@ spec:
+     logLevel: info
+     runc:
+       version: 1.2.4
++    sandboxImage: registry.k8s.io/pause:3.10.1
+     version: 1.7.25
+   dnsZone: Z1AFAKE1ZON3YO
+   etcdClusters:
+@@ -151,7 +152,6 @@ spec:
+     evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
+     kubeconfigPath: /var/lib/kubelet/kubeconfig
+     logLevel: 2
+-    podInfraContainerImage: registry.k8s.io/pause:3.9
+     podManifestPath: /etc/kubernetes/manifests
+     protectKernelDefaults: true
+     registerSchedulable: true
+@@ -171,7 +171,6 @@ spec:
+     evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
+     kubeconfigPath: /var/lib/kubelet/kubeconfig
+     logLevel: 2
+-    podInfraContainerImage: registry.k8s.io/pause:3.9
+     podManifestPath: /etc/kubernetes/manifests
+     protectKernelDefaults: true
+     registerSchedulable: true
+diff --git a/tests/integration/update_cluster/ha/data/aws_s3_object_nodeupconfig-master-us-test-1a_content b/tests/integration/update_cluster/ha/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+index ce5779f93f..6804c0b6cb 100644
+--- a/tests/integration/update_cluster/ha/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
++++ b/tests/integration/update_cluster/ha/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+@@ -292,7 +292,6 @@ KubeletConfig:
+     kops.k8s.io/kops-controller-pki: ""
+     node-role.kubernetes.io/control-plane: ""
+     node.kubernetes.io/exclude-from-external-load-balancers: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -314,6 +313,7 @@ containerdConfig:
+   logLevel: info
+   runc:
+     version: 1.2.4
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.7.25
+ etcdManifests:
+ - memfs://tests/ha.example.com/manifests/etcd/main-master-us-test-1a.yaml
+diff --git a/tests/integration/update_cluster/ha/data/aws_s3_object_nodeupconfig-master-us-test-1b_content b/tests/integration/update_cluster/ha/data/aws_s3_object_nodeupconfig-master-us-test-1b_content
+index 18102a9fad..e0561dddd7 100644
+--- a/tests/integration/update_cluster/ha/data/aws_s3_object_nodeupconfig-master-us-test-1b_content
++++ b/tests/integration/update_cluster/ha/data/aws_s3_object_nodeupconfig-master-us-test-1b_content
+@@ -292,7 +292,6 @@ KubeletConfig:
+     kops.k8s.io/kops-controller-pki: ""
+     node-role.kubernetes.io/control-plane: ""
+     node.kubernetes.io/exclude-from-external-load-balancers: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -314,6 +313,7 @@ containerdConfig:
+   logLevel: info
+   runc:
+     version: 1.2.4
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.7.25
+ etcdManifests:
+ - memfs://tests/ha.example.com/manifests/etcd/main-master-us-test-1b.yaml
+diff --git a/tests/integration/update_cluster/ha/data/aws_s3_object_nodeupconfig-master-us-test-1c_content b/tests/integration/update_cluster/ha/data/aws_s3_object_nodeupconfig-master-us-test-1c_content
+index ee61758475..f893c0fded 100644
+--- a/tests/integration/update_cluster/ha/data/aws_s3_object_nodeupconfig-master-us-test-1c_content
++++ b/tests/integration/update_cluster/ha/data/aws_s3_object_nodeupconfig-master-us-test-1c_content
+@@ -292,7 +292,6 @@ KubeletConfig:
+     kops.k8s.io/kops-controller-pki: ""
+     node-role.kubernetes.io/control-plane: ""
+     node.kubernetes.io/exclude-from-external-load-balancers: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -314,6 +313,7 @@ containerdConfig:
+   logLevel: info
+   runc:
+     version: 1.2.4
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.7.25
+ etcdManifests:
+ - memfs://tests/ha.example.com/manifests/etcd/main-master-us-test-1c.yaml
+diff --git a/tests/integration/update_cluster/ha/data/aws_s3_object_nodeupconfig-nodes_content b/tests/integration/update_cluster/ha/data/aws_s3_object_nodeupconfig-nodes_content
+index 5b76ca9427..5f7c2dc514 100644
+--- a/tests/integration/update_cluster/ha/data/aws_s3_object_nodeupconfig-nodes_content
++++ b/tests/integration/update_cluster/ha/data/aws_s3_object_nodeupconfig-nodes_content
+@@ -43,7 +43,6 @@ KubeletConfig:
+   logLevel: 2
+   nodeLabels:
+     node-role.kubernetes.io/node: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -58,6 +57,7 @@ containerdConfig:
+   logLevel: info
+   runc:
+     version: 1.2.4
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.7.25
+ usesLegacyGossip: false
+ usesNoneDNS: false
+diff --git a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_cluster-completed.spec_content b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_cluster-completed.spec_content
+index ba4ecd09e7..7bacecf4ee 100644
+--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_cluster-completed.spec_content
++++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_cluster-completed.spec_content
+@@ -33,6 +33,7 @@ spec:
+     logLevel: info
+     runc:
+       version: 1.2.4
++    sandboxImage: registry.k8s.io/pause:3.10.1
+     version: 1.7.25
+   dnsZone: "1"
+   etcdClusters:
+@@ -161,7 +162,6 @@ spec:
+     hairpinMode: promiscuous-bridge
+     kubeconfigPath: /var/lib/kubelet/kubeconfig
+     logLevel: 2
+-    podInfraContainerImage: registry.k8s.io/pause:3.9
+     podManifestPath: /etc/kubernetes/manifests
+     protectKernelDefaults: true
+     registerSchedulable: true
+@@ -183,7 +183,6 @@ spec:
+     hairpinMode: promiscuous-bridge
+     kubeconfigPath: /var/lib/kubelet/kubeconfig
+     logLevel: 2
+-    podInfraContainerImage: registry.k8s.io/pause:3.9
+     podManifestPath: /etc/kubernetes/manifests
+     protectKernelDefaults: true
+     registerSchedulable: true
+diff --git a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_nodeupconfig-master-us-test1-a_content b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_nodeupconfig-master-us-test1-a_content
+index e269793be0..478de6d3da 100644
+--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_nodeupconfig-master-us-test1-a_content
++++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_nodeupconfig-master-us-test1-a_content
+@@ -295,7 +295,6 @@ KubeletConfig:
+     kops.k8s.io/kops-controller-pki: ""
+     node-role.kubernetes.io/control-plane: ""
+     node.kubernetes.io/exclude-from-external-load-balancers: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -317,6 +316,7 @@ containerdConfig:
+   logLevel: info
+   runc:
+     version: 1.2.4
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.7.25
+ etcdManifests:
+ - memfs://tests/ha-gce.example.com/manifests/etcd/main-master-us-test1-a.yaml
+diff --git a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_nodeupconfig-master-us-test1-b_content b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_nodeupconfig-master-us-test1-b_content
+index ad630aee78..d1dd1f2c0a 100644
+--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_nodeupconfig-master-us-test1-b_content
++++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_nodeupconfig-master-us-test1-b_content
+@@ -295,7 +295,6 @@ KubeletConfig:
+     kops.k8s.io/kops-controller-pki: ""
+     node-role.kubernetes.io/control-plane: ""
+     node.kubernetes.io/exclude-from-external-load-balancers: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -317,6 +316,7 @@ containerdConfig:
+   logLevel: info
+   runc:
+     version: 1.2.4
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.7.25
+ etcdManifests:
+ - memfs://tests/ha-gce.example.com/manifests/etcd/main-master-us-test1-b.yaml
+diff --git a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_nodeupconfig-master-us-test1-c_content b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_nodeupconfig-master-us-test1-c_content
+index 9935f55c39..9cae596f44 100644
+--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_nodeupconfig-master-us-test1-c_content
++++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_nodeupconfig-master-us-test1-c_content
+@@ -295,7 +295,6 @@ KubeletConfig:
+     kops.k8s.io/kops-controller-pki: ""
+     node-role.kubernetes.io/control-plane: ""
+     node.kubernetes.io/exclude-from-external-load-balancers: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -317,6 +316,7 @@ containerdConfig:
+   logLevel: info
+   runc:
+     version: 1.2.4
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.7.25
+ etcdManifests:
+ - memfs://tests/ha-gce.example.com/manifests/etcd/main-master-us-test1-c.yaml
+diff --git a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_nodeupconfig-nodes_content b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_nodeupconfig-nodes_content
+index 06dd902350..e617afc285 100644
+--- a/tests/integration/update_cluster/ha_gce/data/aws_s3_object_nodeupconfig-nodes_content
++++ b/tests/integration/update_cluster/ha_gce/data/aws_s3_object_nodeupconfig-nodes_content
+@@ -46,7 +46,6 @@ KubeletConfig:
+   logLevel: 2
+   nodeLabels:
+     node-role.kubernetes.io/node: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -61,6 +60,7 @@ containerdConfig:
+   logLevel: info
+   runc:
+     version: 1.2.4
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.7.25
+ multizone: true
+ nodeTags: ha-gce-example-com-k8s-io-role-node
+diff --git a/tests/integration/update_cluster/ha_gce/data/google_compute_instance_template_master-us-test1-a-ha-gce-example-com_metadata_user-data b/tests/integration/update_cluster/ha_gce/data/google_compute_instance_template_master-us-test1-a-ha-gce-example-com_metadata_user-data
+index dd14c7c6b0..15228fcddf 100644
+--- a/tests/integration/update_cluster/ha_gce/data/google_compute_instance_template_master-us-test1-a-ha-gce-example-com_metadata_user-data
++++ b/tests/integration/update_cluster/ha_gce/data/google_compute_instance_template_master-us-test1-a-ha-gce-example-com_metadata_user-data
+@@ -129,7 +129,7 @@ ClusterName: ha-gce.example.com
+ ConfigBase: memfs://tests/ha-gce.example.com
+ InstanceGroupName: master-us-test1-a
+ InstanceGroupRole: ControlPlane
+-NodeupConfigHash: hPBJj8OJ89zFI0zUcvUOUAof/k5gmpOzhU0UTpf4Mm8=
++NodeupConfigHash: tKKRauNy3iEc6SJ2mzNB0ZjbANmMREg19a4QaEmG25Q=
+ 
+ __EOF_KUBE_ENV
+ 
+diff --git a/tests/integration/update_cluster/ha_gce/data/google_compute_instance_template_master-us-test1-b-ha-gce-example-com_metadata_user-data b/tests/integration/update_cluster/ha_gce/data/google_compute_instance_template_master-us-test1-b-ha-gce-example-com_metadata_user-data
+index 9c3470658d..c9fdd88636 100644
+--- a/tests/integration/update_cluster/ha_gce/data/google_compute_instance_template_master-us-test1-b-ha-gce-example-com_metadata_user-data
++++ b/tests/integration/update_cluster/ha_gce/data/google_compute_instance_template_master-us-test1-b-ha-gce-example-com_metadata_user-data
+@@ -129,7 +129,7 @@ ClusterName: ha-gce.example.com
+ ConfigBase: memfs://tests/ha-gce.example.com
+ InstanceGroupName: master-us-test1-b
+ InstanceGroupRole: ControlPlane
+-NodeupConfigHash: jJsUMHmDUBZHoOivF0vmpDefMalqnp5nkF4CnJo6Ous=
++NodeupConfigHash: 0CFMqf1BELHIdrOTrQiY6safbT+9J4cLxaflrKR+MQA=
+ 
+ __EOF_KUBE_ENV
+ 
+diff --git a/tests/integration/update_cluster/ha_gce/data/google_compute_instance_template_master-us-test1-c-ha-gce-example-com_metadata_user-data b/tests/integration/update_cluster/ha_gce/data/google_compute_instance_template_master-us-test1-c-ha-gce-example-com_metadata_user-data
+index 7e466cad54..a618e449ca 100644
+--- a/tests/integration/update_cluster/ha_gce/data/google_compute_instance_template_master-us-test1-c-ha-gce-example-com_metadata_user-data
++++ b/tests/integration/update_cluster/ha_gce/data/google_compute_instance_template_master-us-test1-c-ha-gce-example-com_metadata_user-data
+@@ -129,7 +129,7 @@ ClusterName: ha-gce.example.com
+ ConfigBase: memfs://tests/ha-gce.example.com
+ InstanceGroupName: master-us-test1-c
+ InstanceGroupRole: ControlPlane
+-NodeupConfigHash: BfZYIQ54OItxyMh2T5UTvm+6lFBDQYAcj4HYkHgzV6k=
++NodeupConfigHash: uxoZbjbKz7/m6YMAahA4GEeQs7SSkR2cZky0x55k3RI=
+ 
+ __EOF_KUBE_ENV
+ 
+diff --git a/tests/integration/update_cluster/ha_gce/data/google_compute_instance_template_nodes-ha-gce-example-com_metadata_user-data b/tests/integration/update_cluster/ha_gce/data/google_compute_instance_template_nodes-ha-gce-example-com_metadata_user-data
+index f560a83e0d..97d23dc073 100644
+--- a/tests/integration/update_cluster/ha_gce/data/google_compute_instance_template_nodes-ha-gce-example-com_metadata_user-data
++++ b/tests/integration/update_cluster/ha_gce/data/google_compute_instance_template_nodes-ha-gce-example-com_metadata_user-data
+@@ -152,7 +152,7 @@ ConfigServer:
+   - https://kops-controller.internal.ha-gce.example.com:3988/
+ InstanceGroupName: nodes
+ InstanceGroupRole: Node
+-NodeupConfigHash: yKU09Zx4MJaCy5r784FI8CXqrVXqnDp7nZdOuzohYlU=
++NodeupConfigHash: njmFjTLxw8aleNipGsErGYesGTTX92Sfb8RMmitcycw=
+ 
+ __EOF_KUBE_ENV
+ 
+diff --git a/tests/integration/update_cluster/irsa/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data b/tests/integration/update_cluster/irsa/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
+index f9e9d03953..cfb61715a4 100644
+--- a/tests/integration/update_cluster/irsa/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
++++ b/tests/integration/update_cluster/irsa/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
+@@ -130,7 +130,7 @@ ClusterName: minimal.example.com
+ ConfigBase: memfs://clusters.example.com/minimal.example.com
+ InstanceGroupName: master-us-test-1a
+ InstanceGroupRole: ControlPlane
+-NodeupConfigHash: hwe4qrB8lrpQUByJDxUeDm6WzYWNuE7nQHAfP5g5nQo=
++NodeupConfigHash: v1G8dUnySTcFSgsLymYfHH8ceR3deEJ+CDyFZklRX5g=
+ 
+ __EOF_KUBE_ENV
+ 
+diff --git a/tests/integration/update_cluster/irsa/data/aws_launch_template_nodes.minimal.example.com_user_data b/tests/integration/update_cluster/irsa/data/aws_launch_template_nodes.minimal.example.com_user_data
+index 4b6fe88318..13b9b6d58a 100644
+--- a/tests/integration/update_cluster/irsa/data/aws_launch_template_nodes.minimal.example.com_user_data
++++ b/tests/integration/update_cluster/irsa/data/aws_launch_template_nodes.minimal.example.com_user_data
+@@ -153,7 +153,7 @@ ConfigServer:
+   - https://kops-controller.internal.minimal.example.com:3988/
+ InstanceGroupName: nodes
+ InstanceGroupRole: Node
+-NodeupConfigHash: RwbCzWuKwqBp91KWu4IEZpgBJ0UVI0mpR+lv9mY5/nQ=
++NodeupConfigHash: MBILso1750yJWFfuk5/KINzohd8nOsHTvT6sHBIZjgU=
+ 
+ __EOF_KUBE_ENV
+ 
+diff --git a/tests/integration/update_cluster/irsa/data/aws_s3_object_cluster-completed.spec_content b/tests/integration/update_cluster/irsa/data/aws_s3_object_cluster-completed.spec_content
+index b2bdfb9080..f8d8a8e06d 100644
+--- a/tests/integration/update_cluster/irsa/data/aws_s3_object_cluster-completed.spec_content
++++ b/tests/integration/update_cluster/irsa/data/aws_s3_object_cluster-completed.spec_content
+@@ -30,6 +30,7 @@ spec:
+     logLevel: info
+     runc:
+       version: 1.2.4
++    sandboxImage: registry.k8s.io/pause:3.10.1
+     version: 1.7.25
+   dnsZone: Z1AFAKE1ZON3YO
+   etcdClusters:
+@@ -172,7 +173,6 @@ spec:
+     evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
+     kubeconfigPath: /var/lib/kubelet/kubeconfig
+     logLevel: 2
+-    podInfraContainerImage: registry.k8s.io/pause:3.9
+     podManifestPath: /etc/kubernetes/manifests
+     protectKernelDefaults: true
+     registerSchedulable: true
+@@ -192,7 +192,6 @@ spec:
+     evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
+     kubeconfigPath: /var/lib/kubelet/kubeconfig
+     logLevel: 2
+-    podInfraContainerImage: registry.k8s.io/pause:3.9
+     podManifestPath: /etc/kubernetes/manifests
+     protectKernelDefaults: true
+     registerSchedulable: true
+diff --git a/tests/integration/update_cluster/irsa/data/aws_s3_object_nodeupconfig-master-us-test-1a_content b/tests/integration/update_cluster/irsa/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+index 2bda32e2dd..03972c8795 100644
+--- a/tests/integration/update_cluster/irsa/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
++++ b/tests/integration/update_cluster/irsa/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+@@ -292,7 +292,6 @@ KubeletConfig:
+     kops.k8s.io/kops-controller-pki: ""
+     node-role.kubernetes.io/control-plane: ""
+     node.kubernetes.io/exclude-from-external-load-balancers: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -314,6 +313,7 @@ containerdConfig:
+   logLevel: info
+   runc:
+     version: 1.2.4
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.7.25
+ etcdManifests:
+ - memfs://clusters.example.com/minimal.example.com/manifests/etcd/main-master-us-test-1a.yaml
+diff --git a/tests/integration/update_cluster/irsa/data/aws_s3_object_nodeupconfig-nodes_content b/tests/integration/update_cluster/irsa/data/aws_s3_object_nodeupconfig-nodes_content
+index 2d88fa5a47..fe36f97d54 100644
+--- a/tests/integration/update_cluster/irsa/data/aws_s3_object_nodeupconfig-nodes_content
++++ b/tests/integration/update_cluster/irsa/data/aws_s3_object_nodeupconfig-nodes_content
+@@ -43,7 +43,6 @@ KubeletConfig:
+   logLevel: 2
+   nodeLabels:
+     node-role.kubernetes.io/node: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -58,6 +57,7 @@ containerdConfig:
+   logLevel: info
+   runc:
+     version: 1.2.4
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.7.25
+ usesLegacyGossip: false
+ usesNoneDNS: false
+diff --git a/tests/integration/update_cluster/karpenter/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data b/tests/integration/update_cluster/karpenter/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
+index f9e9d03953..cfb61715a4 100644
+--- a/tests/integration/update_cluster/karpenter/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
++++ b/tests/integration/update_cluster/karpenter/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
+@@ -130,7 +130,7 @@ ClusterName: minimal.example.com
+ ConfigBase: memfs://clusters.example.com/minimal.example.com
+ InstanceGroupName: master-us-test-1a
+ InstanceGroupRole: ControlPlane
+-NodeupConfigHash: hwe4qrB8lrpQUByJDxUeDm6WzYWNuE7nQHAfP5g5nQo=
++NodeupConfigHash: v1G8dUnySTcFSgsLymYfHH8ceR3deEJ+CDyFZklRX5g=
+ 
+ __EOF_KUBE_ENV
+ 
+diff --git a/tests/integration/update_cluster/karpenter/data/aws_launch_template_nodes.minimal.example.com_user_data b/tests/integration/update_cluster/karpenter/data/aws_launch_template_nodes.minimal.example.com_user_data
+index 4b6fe88318..13b9b6d58a 100644
+--- a/tests/integration/update_cluster/karpenter/data/aws_launch_template_nodes.minimal.example.com_user_data
++++ b/tests/integration/update_cluster/karpenter/data/aws_launch_template_nodes.minimal.example.com_user_data
+@@ -153,7 +153,7 @@ ConfigServer:
+   - https://kops-controller.internal.minimal.example.com:3988/
+ InstanceGroupName: nodes
+ InstanceGroupRole: Node
+-NodeupConfigHash: RwbCzWuKwqBp91KWu4IEZpgBJ0UVI0mpR+lv9mY5/nQ=
++NodeupConfigHash: MBILso1750yJWFfuk5/KINzohd8nOsHTvT6sHBIZjgU=
+ 
+ __EOF_KUBE_ENV
+ 
+diff --git a/tests/integration/update_cluster/karpenter/data/aws_s3_object_cluster-completed.spec_content b/tests/integration/update_cluster/karpenter/data/aws_s3_object_cluster-completed.spec_content
+index ba4e7b051f..dbda1f20a4 100644
+--- a/tests/integration/update_cluster/karpenter/data/aws_s3_object_cluster-completed.spec_content
++++ b/tests/integration/update_cluster/karpenter/data/aws_s3_object_cluster-completed.spec_content
+@@ -28,6 +28,7 @@ spec:
+     logLevel: info
+     runc:
+       version: 1.2.4
++    sandboxImage: registry.k8s.io/pause:3.10.1
+     version: 1.7.25
+   dnsZone: Z1AFAKE1ZON3YO
+   etcdClusters:
+@@ -152,7 +153,6 @@ spec:
+     evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
+     kubeconfigPath: /var/lib/kubelet/kubeconfig
+     logLevel: 2
+-    podInfraContainerImage: registry.k8s.io/pause:3.9
+     podManifestPath: /etc/kubernetes/manifests
+     protectKernelDefaults: true
+     registerSchedulable: true
+@@ -172,7 +172,6 @@ spec:
+     evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
+     kubeconfigPath: /var/lib/kubelet/kubeconfig
+     logLevel: 2
+-    podInfraContainerImage: registry.k8s.io/pause:3.9
+     podManifestPath: /etc/kubernetes/manifests
+     protectKernelDefaults: true
+     registerSchedulable: true
+diff --git a/tests/integration/update_cluster/karpenter/data/aws_s3_object_nodeupconfig-karpenter-nodes-default_content b/tests/integration/update_cluster/karpenter/data/aws_s3_object_nodeupconfig-karpenter-nodes-default_content
+index 89e45e4c13..081168fec9 100644
+--- a/tests/integration/update_cluster/karpenter/data/aws_s3_object_nodeupconfig-karpenter-nodes-default_content
++++ b/tests/integration/update_cluster/karpenter/data/aws_s3_object_nodeupconfig-karpenter-nodes-default_content
+@@ -48,7 +48,6 @@ KubeletConfig:
+   nodeLabels:
+     karpenter.sh/provisioner-name: karpenter-nodes-default
+     node-role.kubernetes.io/node: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -66,6 +65,7 @@ containerdConfig:
+   logLevel: info
+   runc:
+     version: 1.2.4
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.7.25
+ usesLegacyGossip: false
+ usesNoneDNS: false
+diff --git a/tests/integration/update_cluster/karpenter/data/aws_s3_object_nodeupconfig-karpenter-nodes-single-machinetype_content b/tests/integration/update_cluster/karpenter/data/aws_s3_object_nodeupconfig-karpenter-nodes-single-machinetype_content
+index 35fa968413..3d4fb910b0 100644
+--- a/tests/integration/update_cluster/karpenter/data/aws_s3_object_nodeupconfig-karpenter-nodes-single-machinetype_content
++++ b/tests/integration/update_cluster/karpenter/data/aws_s3_object_nodeupconfig-karpenter-nodes-single-machinetype_content
+@@ -44,7 +44,6 @@ KubeletConfig:
+   nodeLabels:
+     karpenter.sh/provisioner-name: karpenter-nodes-single-machinetype
+     node-role.kubernetes.io/node: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -59,6 +58,7 @@ containerdConfig:
+   logLevel: info
+   runc:
+     version: 1.2.4
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.7.25
+ usesLegacyGossip: false
+ usesNoneDNS: false
+diff --git a/tests/integration/update_cluster/karpenter/data/aws_s3_object_nodeupconfig-master-us-test-1a_content b/tests/integration/update_cluster/karpenter/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+index 2bda32e2dd..03972c8795 100644
+--- a/tests/integration/update_cluster/karpenter/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
++++ b/tests/integration/update_cluster/karpenter/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+@@ -292,7 +292,6 @@ KubeletConfig:
+     kops.k8s.io/kops-controller-pki: ""
+     node-role.kubernetes.io/control-plane: ""
+     node.kubernetes.io/exclude-from-external-load-balancers: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -314,6 +313,7 @@ containerdConfig:
+   logLevel: info
+   runc:
+     version: 1.2.4
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.7.25
+ etcdManifests:
+ - memfs://clusters.example.com/minimal.example.com/manifests/etcd/main-master-us-test-1a.yaml
+diff --git a/tests/integration/update_cluster/karpenter/data/aws_s3_object_nodeupconfig-nodes_content b/tests/integration/update_cluster/karpenter/data/aws_s3_object_nodeupconfig-nodes_content
+index 2d88fa5a47..fe36f97d54 100644
+--- a/tests/integration/update_cluster/karpenter/data/aws_s3_object_nodeupconfig-nodes_content
++++ b/tests/integration/update_cluster/karpenter/data/aws_s3_object_nodeupconfig-nodes_content
+@@ -43,7 +43,6 @@ KubeletConfig:
+   logLevel: 2
+   nodeLabels:
+     node-role.kubernetes.io/node: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -58,6 +57,7 @@ containerdConfig:
+   logLevel: info
+   runc:
+     version: 1.2.4
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.7.25
+ usesLegacyGossip: false
+ usesNoneDNS: false
+diff --git a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
+index a34b35151e..48de19a27d 100644
+--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
++++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
+@@ -130,7 +130,7 @@ ClusterName: minimal.example.com
+ ConfigBase: memfs://clusters.example.com/minimal.example.com
+ InstanceGroupName: master-us-test-1a
+ InstanceGroupRole: ControlPlane
+-NodeupConfigHash: h2ZfkvYU0XfqQoOk13x7b6kBn24WLViQW8xThQg90JU=
++NodeupConfigHash: ZtpZuFdOM5Km/mSXm6VA9p6Dj0KQFT0vol/YjHkjSZc=
+ 
+ __EOF_KUBE_ENV
+ 
+diff --git a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_launch_template_nodes.minimal.example.com_user_data b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_launch_template_nodes.minimal.example.com_user_data
+index f44c422086..8a110b802a 100644
+--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_launch_template_nodes.minimal.example.com_user_data
++++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_launch_template_nodes.minimal.example.com_user_data
+@@ -153,7 +153,7 @@ ConfigServer:
+   - https://kops-controller.internal.minimal.example.com:3988/
+ InstanceGroupName: nodes
+ InstanceGroupRole: Node
+-NodeupConfigHash: EquZRIcPeQR6CdGKbUGzn4SOU3VhQGvKvMkgZN2BFb4=
++NodeupConfigHash: 4qNATCPuxJHW27zTy58uOwnUXGJRT828WuvNQDLYd1Y=
+ 
+ __EOF_KUBE_ENV
+ 
+diff --git a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_cluster-completed.spec_content b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_cluster-completed.spec_content
+index 33c1b5694e..1a9ae7ca05 100644
+--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_cluster-completed.spec_content
++++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_cluster-completed.spec_content
+@@ -50,6 +50,7 @@ spec:
+     logLevel: info
+     runc:
+       version: 1.2.4
++    sandboxImage: registry.k8s.io/pause:3.10.1
+     version: 1.7.25
+   dnsZone: Z1AFAKE1ZON3YO
+   etcdClusters:
+@@ -166,7 +167,6 @@ spec:
+     evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
+     kubeconfigPath: /var/lib/kubelet/kubeconfig
+     logLevel: 2
+-    podInfraContainerImage: registry.k8s.io/pause:3.9
+     podManifestPath: /etc/kubernetes/manifests
+     protectKernelDefaults: true
+     registerSchedulable: true
+@@ -186,7 +186,6 @@ spec:
+     evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
+     kubeconfigPath: /var/lib/kubelet/kubeconfig
+     logLevel: 2
+-    podInfraContainerImage: registry.k8s.io/pause:3.9
+     podManifestPath: /etc/kubernetes/manifests
+     protectKernelDefaults: true
+     registerSchedulable: true
+diff --git a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_nodeupconfig-master-us-test-1a_content b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+index 1a26a808fe..23bc50d0e8 100644
+--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
++++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+@@ -290,7 +290,6 @@ KubeletConfig:
+     kops.k8s.io/kops-controller-pki: ""
+     node-role.kubernetes.io/control-plane: ""
+     node.kubernetes.io/exclude-from-external-load-balancers: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -313,6 +312,7 @@ containerdConfig:
+   logLevel: info
+   runc:
+     version: 1.2.4
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.7.25
+ etcdManifests:
+ - memfs://clusters.example.com/minimal.example.com/manifests/etcd/main-master-us-test-1a.yaml
+diff --git a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_nodeupconfig-nodes_content b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_nodeupconfig-nodes_content
+index 7108a862fa..4e6a7bb38f 100644
+--- a/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_nodeupconfig-nodes_content
++++ b/tests/integration/update_cluster/many-addons-ccm-irsa/data/aws_s3_object_nodeupconfig-nodes_content
+@@ -40,7 +40,6 @@ KubeletConfig:
+   logLevel: 2
+   nodeLabels:
+     node-role.kubernetes.io/node: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -56,6 +55,7 @@ containerdConfig:
+   logLevel: info
+   runc:
+     version: 1.2.4
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.7.25
+ usesLegacyGossip: false
+ usesNoneDNS: false
+diff --git a/tests/integration/update_cluster/many-addons-ccm/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data b/tests/integration/update_cluster/many-addons-ccm/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
+index af0fb164f3..982e15721b 100644
+--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
++++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
+@@ -130,7 +130,7 @@ ClusterName: minimal.example.com
+ ConfigBase: memfs://clusters.example.com/minimal.example.com
+ InstanceGroupName: master-us-test-1a
+ InstanceGroupRole: ControlPlane
+-NodeupConfigHash: vBJW2myrUYHT/tNqWkomaMQ63E4WdoHXq0dklO9BilQ=
++NodeupConfigHash: YVbzPIWoFrGehxWAM8jk6aWX8FrA0iR+ik3ovcuEg7c=
+ 
+ __EOF_KUBE_ENV
+ 
+diff --git a/tests/integration/update_cluster/many-addons-ccm/data/aws_launch_template_nodes.minimal.example.com_user_data b/tests/integration/update_cluster/many-addons-ccm/data/aws_launch_template_nodes.minimal.example.com_user_data
+index f44c422086..8a110b802a 100644
+--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_launch_template_nodes.minimal.example.com_user_data
++++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_launch_template_nodes.minimal.example.com_user_data
+@@ -153,7 +153,7 @@ ConfigServer:
+   - https://kops-controller.internal.minimal.example.com:3988/
+ InstanceGroupName: nodes
+ InstanceGroupRole: Node
+-NodeupConfigHash: EquZRIcPeQR6CdGKbUGzn4SOU3VhQGvKvMkgZN2BFb4=
++NodeupConfigHash: 4qNATCPuxJHW27zTy58uOwnUXGJRT828WuvNQDLYd1Y=
+ 
+ __EOF_KUBE_ENV
+ 
+diff --git a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_cluster-completed.spec_content b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_cluster-completed.spec_content
+index 9039dcda66..e72426cceb 100644
+--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_cluster-completed.spec_content
++++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_cluster-completed.spec_content
+@@ -51,6 +51,7 @@ spec:
+     logLevel: info
+     runc:
+       version: 1.2.4
++    sandboxImage: registry.k8s.io/pause:3.10.1
+     version: 1.7.25
+   dnsZone: Z1AFAKE1ZON3YO
+   etcdClusters:
+@@ -166,7 +167,6 @@ spec:
+     evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
+     kubeconfigPath: /var/lib/kubelet/kubeconfig
+     logLevel: 2
+-    podInfraContainerImage: registry.k8s.io/pause:3.9
+     podManifestPath: /etc/kubernetes/manifests
+     protectKernelDefaults: true
+     registerSchedulable: true
+@@ -186,7 +186,6 @@ spec:
+     evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
+     kubeconfigPath: /var/lib/kubelet/kubeconfig
+     logLevel: 2
+-    podInfraContainerImage: registry.k8s.io/pause:3.9
+     podManifestPath: /etc/kubernetes/manifests
+     protectKernelDefaults: true
+     registerSchedulable: true
+diff --git a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_nodeupconfig-master-us-test-1a_content b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+index fb86505c74..099ff7fa58 100644
+--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
++++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+@@ -290,7 +290,6 @@ KubeletConfig:
+     kops.k8s.io/kops-controller-pki: ""
+     node-role.kubernetes.io/control-plane: ""
+     node.kubernetes.io/exclude-from-external-load-balancers: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -313,6 +312,7 @@ containerdConfig:
+   logLevel: info
+   runc:
+     version: 1.2.4
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.7.25
+ etcdManifests:
+ - memfs://clusters.example.com/minimal.example.com/manifests/etcd/main-master-us-test-1a.yaml
+diff --git a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_nodeupconfig-nodes_content b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_nodeupconfig-nodes_content
+index 7108a862fa..4e6a7bb38f 100644
+--- a/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_nodeupconfig-nodes_content
++++ b/tests/integration/update_cluster/many-addons-ccm/data/aws_s3_object_nodeupconfig-nodes_content
+@@ -40,7 +40,6 @@ KubeletConfig:
+   logLevel: 2
+   nodeLabels:
+     node-role.kubernetes.io/node: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -56,6 +55,7 @@ containerdConfig:
+   logLevel: info
+   runc:
+     version: 1.2.4
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.7.25
+ usesLegacyGossip: false
+ usesNoneDNS: false
+diff --git a/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_cluster-completed.spec_content b/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_cluster-completed.spec_content
+index 5029363482..4bfc53abfe 100644
+--- a/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_cluster-completed.spec_content
++++ b/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_cluster-completed.spec_content
+@@ -51,6 +51,7 @@ spec:
+     logLevel: info
+     runc:
+       version: 1.2.4
++    sandboxImage: registry.k8s.io/pause:3.10.1
+     version: 1.7.25
+   dnsZone: "1"
+   etcdClusters:
+@@ -173,7 +174,6 @@ spec:
+     hairpinMode: promiscuous-bridge
+     kubeconfigPath: /var/lib/kubelet/kubeconfig
+     logLevel: 2
+-    podInfraContainerImage: registry.k8s.io/pause:3.9
+     podManifestPath: /etc/kubernetes/manifests
+     protectKernelDefaults: true
+     registerSchedulable: true
+@@ -195,7 +195,6 @@ spec:
+     hairpinMode: promiscuous-bridge
+     kubeconfigPath: /var/lib/kubelet/kubeconfig
+     logLevel: 2
+-    podInfraContainerImage: registry.k8s.io/pause:3.9
+     podManifestPath: /etc/kubernetes/manifests
+     protectKernelDefaults: true
+     registerSchedulable: true
+diff --git a/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_nodeupconfig-master-us-test1-a_content b/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_nodeupconfig-master-us-test1-a_content
+index 17f8a41e71..e565b7cc04 100644
+--- a/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_nodeupconfig-master-us-test1-a_content
++++ b/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_nodeupconfig-master-us-test1-a_content
+@@ -296,7 +296,6 @@ KubeletConfig:
+     kops.k8s.io/kops-controller-pki: ""
+     node-role.kubernetes.io/control-plane: ""
+     node.kubernetes.io/exclude-from-external-load-balancers: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -318,6 +317,7 @@ containerdConfig:
+   logLevel: info
+   runc:
+     version: 1.2.4
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.7.25
+ etcdManifests:
+ - memfs://tests/minimal.example.com/manifests/etcd/main-master-us-test1-a.yaml
+diff --git a/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_nodeupconfig-nodes_content b/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_nodeupconfig-nodes_content
+index 58846a0936..f3530f7de6 100644
+--- a/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_nodeupconfig-nodes_content
++++ b/tests/integration/update_cluster/many-addons-gce/data/aws_s3_object_nodeupconfig-nodes_content
+@@ -46,7 +46,6 @@ KubeletConfig:
+   logLevel: 2
+   nodeLabels:
+     node-role.kubernetes.io/node: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -61,6 +60,7 @@ containerdConfig:
+   logLevel: info
+   runc:
+     version: 1.2.4
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.7.25
+ multizone: true
+ nodeTags: minimal-example-com-k8s-io-role-node
+diff --git a/tests/integration/update_cluster/many-addons-gce/data/google_compute_instance_template_master-us-test1-a-minimal-example-com_metadata_user-data b/tests/integration/update_cluster/many-addons-gce/data/google_compute_instance_template_master-us-test1-a-minimal-example-com_metadata_user-data
+index 2d4c7f2d1e..09bf6b151f 100644
+--- a/tests/integration/update_cluster/many-addons-gce/data/google_compute_instance_template_master-us-test1-a-minimal-example-com_metadata_user-data
++++ b/tests/integration/update_cluster/many-addons-gce/data/google_compute_instance_template_master-us-test1-a-minimal-example-com_metadata_user-data
+@@ -129,7 +129,7 @@ ClusterName: minimal.example.com
+ ConfigBase: memfs://tests/minimal.example.com
+ InstanceGroupName: master-us-test1-a
+ InstanceGroupRole: ControlPlane
+-NodeupConfigHash: ew4dXhZ2kDAuzCCZHPkkeCXTWUB9NQGXJ93u8wx3q1o=
++NodeupConfigHash: MWRiMwV5iZckCVstS9E0jzC2OM5YUkHXoJ1tZqbQtX0=
+ 
+ __EOF_KUBE_ENV
+ 
+diff --git a/tests/integration/update_cluster/many-addons-gce/data/google_compute_instance_template_nodes-minimal-example-com_metadata_user-data b/tests/integration/update_cluster/many-addons-gce/data/google_compute_instance_template_nodes-minimal-example-com_metadata_user-data
+index 6d7c04af7f..21baa4d538 100644
+--- a/tests/integration/update_cluster/many-addons-gce/data/google_compute_instance_template_nodes-minimal-example-com_metadata_user-data
++++ b/tests/integration/update_cluster/many-addons-gce/data/google_compute_instance_template_nodes-minimal-example-com_metadata_user-data
+@@ -152,7 +152,7 @@ ConfigServer:
+   - https://kops-controller.internal.minimal.example.com:3988/
+ InstanceGroupName: nodes
+ InstanceGroupRole: Node
+-NodeupConfigHash: ylKFUEn9952DZnwj6n+dW4B2BFHOZTKmlnEA3gnaboM=
++NodeupConfigHash: q09HOOYJsE7TBJmfcBcxwCXHgSPx1ORekWCbWjAS0So=
+ 
+ __EOF_KUBE_ENV
+ 
+diff --git a/tests/integration/update_cluster/many-addons/data/aws_launch_template_master-us-test-1a.masters.many-addons.example.com_user_data b/tests/integration/update_cluster/many-addons/data/aws_launch_template_master-us-test-1a.masters.many-addons.example.com_user_data
+index 7bf825929c..97a7c5bb72 100644
+--- a/tests/integration/update_cluster/many-addons/data/aws_launch_template_master-us-test-1a.masters.many-addons.example.com_user_data
++++ b/tests/integration/update_cluster/many-addons/data/aws_launch_template_master-us-test-1a.masters.many-addons.example.com_user_data
+@@ -130,7 +130,7 @@ ClusterName: many-addons.example.com
+ ConfigBase: memfs://tests/many-addons.example.com
+ InstanceGroupName: master-us-test-1a
+ InstanceGroupRole: ControlPlane
+-NodeupConfigHash: A+I9325Mdqo1Uh6uqXwhMC1iYv+p2l6COqbF6VUNg04=
++NodeupConfigHash: V9s/0JZJcLWEdZYKDX9/zwynSIwq4fsENd3v/enXhCE=
+ 
+ __EOF_KUBE_ENV
+ 
+diff --git a/tests/integration/update_cluster/many-addons/data/aws_launch_template_nodes.many-addons.example.com_user_data b/tests/integration/update_cluster/many-addons/data/aws_launch_template_nodes.many-addons.example.com_user_data
+index ecc196a305..906f7725da 100644
+--- a/tests/integration/update_cluster/many-addons/data/aws_launch_template_nodes.many-addons.example.com_user_data
++++ b/tests/integration/update_cluster/many-addons/data/aws_launch_template_nodes.many-addons.example.com_user_data
+@@ -153,7 +153,7 @@ ConfigServer:
+   - https://kops-controller.internal.many-addons.example.com:3988/
+ InstanceGroupName: nodes
+ InstanceGroupRole: Node
+-NodeupConfigHash: VkNxoepqsYY8SO6Cp0QvFLXaG2En7OHRH0icP9aA2s8=
++NodeupConfigHash: 1hQ8fhwv1GZti4rHld/uXyshKy/CGSp1hGaBT3EUMcM=
+ 
+ __EOF_KUBE_ENV
+ 
+diff --git a/tests/integration/update_cluster/many-addons/data/aws_s3_object_cluster-completed.spec_content b/tests/integration/update_cluster/many-addons/data/aws_s3_object_cluster-completed.spec_content
+index 8662b589e0..eea8bed316 100644
+--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_cluster-completed.spec_content
++++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_cluster-completed.spec_content
+@@ -53,6 +53,7 @@ spec:
+     logLevel: info
+     runc:
+       version: 1.2.4
++    sandboxImage: registry.k8s.io/pause:3.10.1
+     version: 1.7.25
+   dnsZone: Z1AFAKE1ZON3YO
+   etcdClusters:
+@@ -168,7 +169,6 @@ spec:
+     evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
+     kubeconfigPath: /var/lib/kubelet/kubeconfig
+     logLevel: 2
+-    podInfraContainerImage: registry.k8s.io/pause:3.9
+     podManifestPath: /etc/kubernetes/manifests
+     protectKernelDefaults: true
+     registerSchedulable: true
+@@ -188,7 +188,6 @@ spec:
+     evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
+     kubeconfigPath: /var/lib/kubelet/kubeconfig
+     logLevel: 2
+-    podInfraContainerImage: registry.k8s.io/pause:3.9
+     podManifestPath: /etc/kubernetes/manifests
+     protectKernelDefaults: true
+     registerSchedulable: true
+diff --git a/tests/integration/update_cluster/many-addons/data/aws_s3_object_nodeupconfig-master-us-test-1a_content b/tests/integration/update_cluster/many-addons/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+index 3ead51b8ec..ad563ae693 100644
+--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
++++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+@@ -290,7 +290,6 @@ KubeletConfig:
+     kops.k8s.io/kops-controller-pki: ""
+     node-role.kubernetes.io/control-plane: ""
+     node.kubernetes.io/exclude-from-external-load-balancers: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -313,6 +312,7 @@ containerdConfig:
+   logLevel: info
+   runc:
+     version: 1.2.4
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.7.25
+ etcdManifests:
+ - memfs://tests/many-addons.example.com/manifests/etcd/main-master-us-test-1a.yaml
+diff --git a/tests/integration/update_cluster/many-addons/data/aws_s3_object_nodeupconfig-nodes_content b/tests/integration/update_cluster/many-addons/data/aws_s3_object_nodeupconfig-nodes_content
+index 0f5d1b0cfb..a761becfe2 100644
+--- a/tests/integration/update_cluster/many-addons/data/aws_s3_object_nodeupconfig-nodes_content
++++ b/tests/integration/update_cluster/many-addons/data/aws_s3_object_nodeupconfig-nodes_content
+@@ -40,7 +40,6 @@ KubeletConfig:
+   logLevel: 2
+   nodeLabels:
+     node-role.kubernetes.io/node: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -56,6 +55,7 @@ containerdConfig:
+   logLevel: info
+   runc:
+     version: 1.2.4
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.7.25
+ usesLegacyGossip: false
+ usesNoneDNS: false
+diff --git a/tests/integration/update_cluster/minimal-1.29/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data b/tests/integration/update_cluster/minimal-1.29/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
+index 569bb3ad90..2ab2a4b100 100644
+--- a/tests/integration/update_cluster/minimal-1.29/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
++++ b/tests/integration/update_cluster/minimal-1.29/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
+@@ -130,7 +130,7 @@ ClusterName: minimal.example.com
+ ConfigBase: memfs://tests/minimal.example.com
+ InstanceGroupName: master-us-test-1a
+ InstanceGroupRole: ControlPlane
+-NodeupConfigHash: Y0SPPeEmREia9y9pJHjBwD3hBXse+vT8Ft7d55TDvhQ=
++NodeupConfigHash: qQG4zDw1KfQm7lNitwZ67CSdD6+EM+87+SydB8kQJ/E=
+ 
+ __EOF_KUBE_ENV
+ 
+diff --git a/tests/integration/update_cluster/minimal-1.29/data/aws_launch_template_nodes.minimal.example.com_user_data b/tests/integration/update_cluster/minimal-1.29/data/aws_launch_template_nodes.minimal.example.com_user_data
+index d0a3431864..e16fe2e721 100644
+--- a/tests/integration/update_cluster/minimal-1.29/data/aws_launch_template_nodes.minimal.example.com_user_data
++++ b/tests/integration/update_cluster/minimal-1.29/data/aws_launch_template_nodes.minimal.example.com_user_data
+@@ -153,7 +153,7 @@ ConfigServer:
+   - https://kops-controller.internal.minimal.example.com:3988/
+ InstanceGroupName: nodes
+ InstanceGroupRole: Node
+-NodeupConfigHash: wSvNsAJnU2WyDBvoSO/WVPG1toZqlKaAdafrXBd21nY=
++NodeupConfigHash: 4zlUOstWPtVj5AyI8jQIovQfqFkvBt9AycQiApuqa5E=
+ 
+ __EOF_KUBE_ENV
+ 
+diff --git a/tests/integration/update_cluster/minimal-1.29/data/aws_s3_object_cluster-completed.spec_content b/tests/integration/update_cluster/minimal-1.29/data/aws_s3_object_cluster-completed.spec_content
+index ca5997a618..575a092e35 100644
+--- a/tests/integration/update_cluster/minimal-1.29/data/aws_s3_object_cluster-completed.spec_content
++++ b/tests/integration/update_cluster/minimal-1.29/data/aws_s3_object_cluster-completed.spec_content
+@@ -28,6 +28,7 @@ spec:
+     logLevel: info
+     runc:
+       version: 1.2.4
++    sandboxImage: registry.k8s.io/pause:3.10.1
+     version: 1.7.25
+   dnsZone: Z1AFAKE1ZON3YO
+   etcdClusters:
+@@ -158,7 +159,6 @@ spec:
+       InTreePluginAWSUnregister: "true"
+     kubeconfigPath: /var/lib/kubelet/kubeconfig
+     logLevel: 2
+-    podInfraContainerImage: registry.k8s.io/pause:3.9
+     podManifestPath: /etc/kubernetes/manifests
+     protectKernelDefaults: true
+     registerSchedulable: true
+@@ -181,7 +181,6 @@ spec:
+       InTreePluginAWSUnregister: "true"
+     kubeconfigPath: /var/lib/kubelet/kubeconfig
+     logLevel: 2
+-    podInfraContainerImage: registry.k8s.io/pause:3.9
+     podManifestPath: /etc/kubernetes/manifests
+     protectKernelDefaults: true
+     registerSchedulable: true
+diff --git a/tests/integration/update_cluster/minimal-1.29/data/aws_s3_object_nodeupconfig-master-us-test-1a_content b/tests/integration/update_cluster/minimal-1.29/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+index fbf3821b4c..a51c490837 100644
+--- a/tests/integration/update_cluster/minimal-1.29/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
++++ b/tests/integration/update_cluster/minimal-1.29/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+@@ -301,7 +301,6 @@ KubeletConfig:
+     kops.k8s.io/kops-controller-pki: ""
+     node-role.kubernetes.io/control-plane: ""
+     node.kubernetes.io/exclude-from-external-load-balancers: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -323,6 +322,7 @@ containerdConfig:
+   logLevel: info
+   runc:
+     version: 1.2.4
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.7.25
+ etcdManifests:
+ - memfs://tests/minimal.example.com/manifests/etcd/main-master-us-test-1a.yaml
+diff --git a/tests/integration/update_cluster/minimal-1.29/data/aws_s3_object_nodeupconfig-nodes_content b/tests/integration/update_cluster/minimal-1.29/data/aws_s3_object_nodeupconfig-nodes_content
+index c5408604df..5dafdd2def 100644
+--- a/tests/integration/update_cluster/minimal-1.29/data/aws_s3_object_nodeupconfig-nodes_content
++++ b/tests/integration/update_cluster/minimal-1.29/data/aws_s3_object_nodeupconfig-nodes_content
+@@ -46,7 +46,6 @@ KubeletConfig:
+   nodeLabels:
+     kops.k8s.io/instancegroup: nodes-us-test-1a
+     node-role.kubernetes.io/node: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -61,6 +60,7 @@ containerdConfig:
+   logLevel: info
+   runc:
+     version: 1.2.4
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.7.25
+ usesLegacyGossip: false
+ usesNoneDNS: false
+diff --git a/tests/integration/update_cluster/minimal-1.30/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data b/tests/integration/update_cluster/minimal-1.30/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
+index a92016f0f3..1cb3f34dba 100644
+--- a/tests/integration/update_cluster/minimal-1.30/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
++++ b/tests/integration/update_cluster/minimal-1.30/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
+@@ -130,7 +130,7 @@ ClusterName: minimal.example.com
+ ConfigBase: memfs://tests/minimal.example.com
+ InstanceGroupName: master-us-test-1a
+ InstanceGroupRole: ControlPlane
+-NodeupConfigHash: PzSXSAmmLiTOVLRZfayWsRtE0gxKXJWNXsj0A265GPE=
++NodeupConfigHash: keCO4KpprCHSbOhoyzTlZztQug9qRxPOBgW4ZhBRNhs=
+ 
+ __EOF_KUBE_ENV
+ 
+diff --git a/tests/integration/update_cluster/minimal-1.30/data/aws_launch_template_nodes.minimal.example.com_user_data b/tests/integration/update_cluster/minimal-1.30/data/aws_launch_template_nodes.minimal.example.com_user_data
+index 5946c265b9..8dba75423b 100644
+--- a/tests/integration/update_cluster/minimal-1.30/data/aws_launch_template_nodes.minimal.example.com_user_data
++++ b/tests/integration/update_cluster/minimal-1.30/data/aws_launch_template_nodes.minimal.example.com_user_data
+@@ -153,7 +153,7 @@ ConfigServer:
+   - https://kops-controller.internal.minimal.example.com:3988/
+ InstanceGroupName: nodes
+ InstanceGroupRole: Node
+-NodeupConfigHash: mtjLgy/dmUHnEOPpJwSsPiVwloRLbxW10E03B5mrqCw=
++NodeupConfigHash: kCwMl2XQzJN5ucyacq9uITXuYPQcyAI9ea6w4oaHQUI=
+ 
+ __EOF_KUBE_ENV
+ 
+diff --git a/tests/integration/update_cluster/minimal-1.30/data/aws_s3_object_cluster-completed.spec_content b/tests/integration/update_cluster/minimal-1.30/data/aws_s3_object_cluster-completed.spec_content
+index e12b899274..9dc99a4775 100644
+--- a/tests/integration/update_cluster/minimal-1.30/data/aws_s3_object_cluster-completed.spec_content
++++ b/tests/integration/update_cluster/minimal-1.30/data/aws_s3_object_cluster-completed.spec_content
+@@ -28,6 +28,7 @@ spec:
+     logLevel: info
+     runc:
+       version: 1.2.4
++    sandboxImage: registry.k8s.io/pause:3.10.1
+     version: 1.7.25
+   dnsZone: Z1AFAKE1ZON3YO
+   etcdClusters:
+@@ -158,7 +159,6 @@ spec:
+       InTreePluginAWSUnregister: "true"
+     kubeconfigPath: /var/lib/kubelet/kubeconfig
+     logLevel: 2
+-    podInfraContainerImage: registry.k8s.io/pause:3.9
+     podManifestPath: /etc/kubernetes/manifests
+     protectKernelDefaults: true
+     registerSchedulable: true
+@@ -181,7 +181,6 @@ spec:
+       InTreePluginAWSUnregister: "true"
+     kubeconfigPath: /var/lib/kubelet/kubeconfig
+     logLevel: 2
+-    podInfraContainerImage: registry.k8s.io/pause:3.9
+     podManifestPath: /etc/kubernetes/manifests
+     protectKernelDefaults: true
+     registerSchedulable: true
+diff --git a/tests/integration/update_cluster/minimal-1.30/data/aws_s3_object_nodeupconfig-master-us-test-1a_content b/tests/integration/update_cluster/minimal-1.30/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+index df36e2bd89..6235979ec8 100644
+--- a/tests/integration/update_cluster/minimal-1.30/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
++++ b/tests/integration/update_cluster/minimal-1.30/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+@@ -301,7 +301,6 @@ KubeletConfig:
+     kops.k8s.io/kops-controller-pki: ""
+     node-role.kubernetes.io/control-plane: ""
+     node.kubernetes.io/exclude-from-external-load-balancers: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -323,6 +322,7 @@ containerdConfig:
+   logLevel: info
+   runc:
+     version: 1.2.4
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.7.25
+ etcdManifests:
+ - memfs://tests/minimal.example.com/manifests/etcd/main-master-us-test-1a.yaml
+diff --git a/tests/integration/update_cluster/minimal-1.30/data/aws_s3_object_nodeupconfig-nodes_content b/tests/integration/update_cluster/minimal-1.30/data/aws_s3_object_nodeupconfig-nodes_content
+index 2b359a650c..6aad398870 100644
+--- a/tests/integration/update_cluster/minimal-1.30/data/aws_s3_object_nodeupconfig-nodes_content
++++ b/tests/integration/update_cluster/minimal-1.30/data/aws_s3_object_nodeupconfig-nodes_content
+@@ -46,7 +46,6 @@ KubeletConfig:
+   nodeLabels:
+     kops.k8s.io/instancegroup: nodes-us-test-1a
+     node-role.kubernetes.io/node: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -61,6 +60,7 @@ containerdConfig:
+   logLevel: info
+   runc:
+     version: 1.2.4
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.7.25
+ usesLegacyGossip: false
+ usesNoneDNS: false
+diff --git a/tests/integration/update_cluster/minimal-1.31/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data b/tests/integration/update_cluster/minimal-1.31/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
+index 7bc927699b..33b1c31118 100644
+--- a/tests/integration/update_cluster/minimal-1.31/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
++++ b/tests/integration/update_cluster/minimal-1.31/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
+@@ -130,7 +130,7 @@ ClusterName: minimal.example.com
+ ConfigBase: memfs://tests/minimal.example.com
+ InstanceGroupName: master-us-test-1a
+ InstanceGroupRole: ControlPlane
+-NodeupConfigHash: 4anatDD/dG4gJSLVmkEn4jBFGpIRK1DduOSuoCM8mSo=
++NodeupConfigHash: eduvyNARbkRjlhkOIw0v5A5AHqocXbMlqnucKNZgato=
+ 
+ __EOF_KUBE_ENV
+ 
+diff --git a/tests/integration/update_cluster/minimal-1.31/data/aws_launch_template_nodes.minimal.example.com_user_data b/tests/integration/update_cluster/minimal-1.31/data/aws_launch_template_nodes.minimal.example.com_user_data
+index 85914c24aa..ecd702c970 100644
+--- a/tests/integration/update_cluster/minimal-1.31/data/aws_launch_template_nodes.minimal.example.com_user_data
++++ b/tests/integration/update_cluster/minimal-1.31/data/aws_launch_template_nodes.minimal.example.com_user_data
+@@ -153,7 +153,7 @@ ConfigServer:
+   - https://kops-controller.internal.minimal.example.com:3988/
+ InstanceGroupName: nodes
+ InstanceGroupRole: Node
+-NodeupConfigHash: zG1NsitJnKztYFL57zm7MHbQz2CByl8gEQB0JCEKTfI=
++NodeupConfigHash: iFQvQ49NCeF5HCyi5tzoxV+8HrmYVn5HA0YD9M9A7YA=
+ 
+ __EOF_KUBE_ENV
+ 
+diff --git a/tests/integration/update_cluster/minimal-1.31/data/aws_s3_object_cluster-completed.spec_content b/tests/integration/update_cluster/minimal-1.31/data/aws_s3_object_cluster-completed.spec_content
+index 14615c2e1a..f6f32fb590 100644
+--- a/tests/integration/update_cluster/minimal-1.31/data/aws_s3_object_cluster-completed.spec_content
++++ b/tests/integration/update_cluster/minimal-1.31/data/aws_s3_object_cluster-completed.spec_content
+@@ -28,6 +28,7 @@ spec:
+     logLevel: info
+     runc:
+       version: 1.2.4
++    sandboxImage: registry.k8s.io/pause:3.10.1
+     version: 1.7.25
+   dnsZone: Z1AFAKE1ZON3YO
+   etcdClusters:
+@@ -150,7 +151,6 @@ spec:
+     evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
+     kubeconfigPath: /var/lib/kubelet/kubeconfig
+     logLevel: 2
+-    podInfraContainerImage: registry.k8s.io/pause:3.9
+     podManifestPath: /etc/kubernetes/manifests
+     protectKernelDefaults: true
+     registerSchedulable: true
+@@ -171,7 +171,6 @@ spec:
+     evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
+     kubeconfigPath: /var/lib/kubelet/kubeconfig
+     logLevel: 2
+-    podInfraContainerImage: registry.k8s.io/pause:3.9
+     podManifestPath: /etc/kubernetes/manifests
+     protectKernelDefaults: true
+     registerSchedulable: true
+diff --git a/tests/integration/update_cluster/minimal-1.31/data/aws_s3_object_nodeupconfig-master-us-test-1a_content b/tests/integration/update_cluster/minimal-1.31/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+index a1a5778cac..ed7e701d33 100644
+--- a/tests/integration/update_cluster/minimal-1.31/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
++++ b/tests/integration/update_cluster/minimal-1.31/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+@@ -293,7 +293,6 @@ KubeletConfig:
+     kops.k8s.io/kops-controller-pki: ""
+     node-role.kubernetes.io/control-plane: ""
+     node.kubernetes.io/exclude-from-external-load-balancers: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -315,6 +314,7 @@ containerdConfig:
+   logLevel: info
+   runc:
+     version: 1.2.4
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.7.25
+ etcdManifests:
+ - memfs://tests/minimal.example.com/manifests/etcd/main-master-us-test-1a.yaml
+diff --git a/tests/integration/update_cluster/minimal-1.31/data/aws_s3_object_nodeupconfig-nodes_content b/tests/integration/update_cluster/minimal-1.31/data/aws_s3_object_nodeupconfig-nodes_content
+index d679fc06ca..a0c26ebc36 100644
+--- a/tests/integration/update_cluster/minimal-1.31/data/aws_s3_object_nodeupconfig-nodes_content
++++ b/tests/integration/update_cluster/minimal-1.31/data/aws_s3_object_nodeupconfig-nodes_content
+@@ -44,7 +44,6 @@ KubeletConfig:
+   nodeLabels:
+     kops.k8s.io/instancegroup: nodes-us-test-1a
+     node-role.kubernetes.io/node: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -59,6 +58,7 @@ containerdConfig:
+   logLevel: info
+   runc:
+     version: 1.2.4
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.7.25
+ usesLegacyGossip: false
+ usesNoneDNS: false
+diff --git a/tests/integration/update_cluster/minimal-1.32/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data b/tests/integration/update_cluster/minimal-1.32/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
+index b5e36593e1..13e5bb749c 100644
+--- a/tests/integration/update_cluster/minimal-1.32/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
++++ b/tests/integration/update_cluster/minimal-1.32/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
+@@ -130,7 +130,7 @@ ClusterName: minimal.example.com
+ ConfigBase: memfs://tests/minimal.example.com
+ InstanceGroupName: master-us-test-1a
+ InstanceGroupRole: ControlPlane
+-NodeupConfigHash: FLgMik7c2ZGPsRNCfgD9XyJk9kLzg/oD46UD38bTt5w=
++NodeupConfigHash: mCWF2NcccGG23q/eNhcz/S1V9uk6740j63tWqmfTJ+A=
+ 
+ __EOF_KUBE_ENV
+ 
+diff --git a/tests/integration/update_cluster/minimal-1.32/data/aws_launch_template_nodes.minimal.example.com_user_data b/tests/integration/update_cluster/minimal-1.32/data/aws_launch_template_nodes.minimal.example.com_user_data
+index 86cf4257a1..392c8b077b 100644
+--- a/tests/integration/update_cluster/minimal-1.32/data/aws_launch_template_nodes.minimal.example.com_user_data
++++ b/tests/integration/update_cluster/minimal-1.32/data/aws_launch_template_nodes.minimal.example.com_user_data
+@@ -153,7 +153,7 @@ ConfigServer:
+   - https://kops-controller.internal.minimal.example.com:3988/
+ InstanceGroupName: nodes
+ InstanceGroupRole: Node
+-NodeupConfigHash: G6gfLNMd0m0T80ntKqmyda7IWUp3+KLrGjcpDSuF8qk=
++NodeupConfigHash: epGhOHBjAkOqYy8FdXx1iQ51Z3K5RcLsCSAlXxUczvA=
+ 
+ __EOF_KUBE_ENV
+ 
+diff --git a/tests/integration/update_cluster/minimal-1.32/data/aws_s3_object_cluster-completed.spec_content b/tests/integration/update_cluster/minimal-1.32/data/aws_s3_object_cluster-completed.spec_content
+index 422ba2de3e..10c8d59030 100644
+--- a/tests/integration/update_cluster/minimal-1.32/data/aws_s3_object_cluster-completed.spec_content
++++ b/tests/integration/update_cluster/minimal-1.32/data/aws_s3_object_cluster-completed.spec_content
+@@ -28,6 +28,7 @@ spec:
+     logLevel: info
+     runc:
+       version: 1.2.4
++    sandboxImage: registry.k8s.io/pause:3.10.1
+     version: 1.7.25
+   dnsZone: Z1AFAKE1ZON3YO
+   etcdClusters:
+@@ -150,7 +151,6 @@ spec:
+     evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
+     kubeconfigPath: /var/lib/kubelet/kubeconfig
+     logLevel: 2
+-    podInfraContainerImage: registry.k8s.io/pause:3.9
+     podManifestPath: /etc/kubernetes/manifests
+     protectKernelDefaults: true
+     registerSchedulable: true
+@@ -171,7 +171,6 @@ spec:
+     evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
+     kubeconfigPath: /var/lib/kubelet/kubeconfig
+     logLevel: 2
+-    podInfraContainerImage: registry.k8s.io/pause:3.9
+     podManifestPath: /etc/kubernetes/manifests
+     protectKernelDefaults: true
+     registerSchedulable: true
+diff --git a/tests/integration/update_cluster/minimal-1.32/data/aws_s3_object_nodeupconfig-master-us-test-1a_content b/tests/integration/update_cluster/minimal-1.32/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+index 65729790d9..3cffae29a4 100644
+--- a/tests/integration/update_cluster/minimal-1.32/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
++++ b/tests/integration/update_cluster/minimal-1.32/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+@@ -293,7 +293,6 @@ KubeletConfig:
+     kops.k8s.io/kops-controller-pki: ""
+     node-role.kubernetes.io/control-plane: ""
+     node.kubernetes.io/exclude-from-external-load-balancers: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -315,6 +314,7 @@ containerdConfig:
+   logLevel: info
+   runc:
+     version: 1.2.4
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.7.25
+ etcdManifests:
+ - memfs://tests/minimal.example.com/manifests/etcd/main-master-us-test-1a.yaml
+diff --git a/tests/integration/update_cluster/minimal-1.32/data/aws_s3_object_nodeupconfig-nodes_content b/tests/integration/update_cluster/minimal-1.32/data/aws_s3_object_nodeupconfig-nodes_content
+index 5af3183fe2..4cb343d408 100644
+--- a/tests/integration/update_cluster/minimal-1.32/data/aws_s3_object_nodeupconfig-nodes_content
++++ b/tests/integration/update_cluster/minimal-1.32/data/aws_s3_object_nodeupconfig-nodes_content
+@@ -44,7 +44,6 @@ KubeletConfig:
+   nodeLabels:
+     kops.k8s.io/instancegroup: nodes-us-test-1a
+     node-role.kubernetes.io/node: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -59,6 +58,7 @@ containerdConfig:
+   logLevel: info
+   runc:
+     version: 1.2.4
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.7.25
+ usesLegacyGossip: false
+ usesNoneDNS: false
+diff --git a/tests/integration/update_cluster/minimal-aws/data/aws_launch_template_master-us-test-1a.masters.minimal-aws.example.com_user_data b/tests/integration/update_cluster/minimal-aws/data/aws_launch_template_master-us-test-1a.masters.minimal-aws.example.com_user_data
+index 4b9ed4cb2f..c94084e421 100644
+--- a/tests/integration/update_cluster/minimal-aws/data/aws_launch_template_master-us-test-1a.masters.minimal-aws.example.com_user_data
++++ b/tests/integration/update_cluster/minimal-aws/data/aws_launch_template_master-us-test-1a.masters.minimal-aws.example.com_user_data
+@@ -130,7 +130,7 @@ ClusterName: minimal-aws.example.com
+ ConfigBase: memfs://clusters.example.com/minimal-aws.example.com
+ InstanceGroupName: master-us-test-1a
+ InstanceGroupRole: ControlPlane
+-NodeupConfigHash: UefPbjbiXca1aLfAZ1BrhkiiVmHP/vWp3YiYAxejcUg=
++NodeupConfigHash: eIY1wUhxsfruyOV92scODtpwLYRkLc4dGwTDg2MKyvY=
+ 
+ __EOF_KUBE_ENV
+ 
+diff --git a/tests/integration/update_cluster/minimal-aws/data/aws_launch_template_nodes.minimal-aws.example.com_user_data b/tests/integration/update_cluster/minimal-aws/data/aws_launch_template_nodes.minimal-aws.example.com_user_data
+index e0706492aa..a6a9cfd503 100644
+--- a/tests/integration/update_cluster/minimal-aws/data/aws_launch_template_nodes.minimal-aws.example.com_user_data
++++ b/tests/integration/update_cluster/minimal-aws/data/aws_launch_template_nodes.minimal-aws.example.com_user_data
+@@ -153,7 +153,7 @@ ConfigServer:
+   - https://kops-controller.internal.minimal-aws.example.com:3988/
+ InstanceGroupName: nodes
+ InstanceGroupRole: Node
+-NodeupConfigHash: 4Ri7AqtZ/z9waxTvCFNS/G/Dc/pGuIRpuDB6qc5TG00=
++NodeupConfigHash: vGTaHak7ayFNPPPMCF3s1W3KHINuXHBmixOnyZLD1FI=
+ 
+ __EOF_KUBE_ENV
+ 
+diff --git a/tests/integration/update_cluster/minimal-aws/data/aws_s3_object_cluster-completed.spec_content b/tests/integration/update_cluster/minimal-aws/data/aws_s3_object_cluster-completed.spec_content
+index 5368c51664..cbdb97c944 100644
+--- a/tests/integration/update_cluster/minimal-aws/data/aws_s3_object_cluster-completed.spec_content
++++ b/tests/integration/update_cluster/minimal-aws/data/aws_s3_object_cluster-completed.spec_content
+@@ -28,6 +28,7 @@ spec:
+     logLevel: info
+     runc:
+       version: 1.1.5
++    sandboxImage: registry.k8s.io/pause:3.10.1
+     version: 1.6.20
+   dnsZone: Z1AFAKE1ZON3YO
+   etcdClusters:
+@@ -148,7 +149,6 @@ spec:
+       InTreePluginAWSUnregister: "true"
+     kubeconfigPath: /var/lib/kubelet/kubeconfig
+     logLevel: 2
+-    podInfraContainerImage: registry.k8s.io/pause:3.9
+     podManifestPath: /etc/kubernetes/manifests
+     protectKernelDefaults: true
+     registerSchedulable: true
+@@ -169,7 +169,6 @@ spec:
+       InTreePluginAWSUnregister: "true"
+     kubeconfigPath: /var/lib/kubelet/kubeconfig
+     logLevel: 2
+-    podInfraContainerImage: registry.k8s.io/pause:3.9
+     podManifestPath: /etc/kubernetes/manifests
+     protectKernelDefaults: true
+     registerSchedulable: true
+diff --git a/tests/integration/update_cluster/minimal-aws/data/aws_s3_object_nodeupconfig-master-us-test-1a_content b/tests/integration/update_cluster/minimal-aws/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+index 73b461e8a9..34412ebe47 100644
+--- a/tests/integration/update_cluster/minimal-aws/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
++++ b/tests/integration/update_cluster/minimal-aws/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+@@ -299,7 +299,6 @@ KubeletConfig:
+     kops.k8s.io/kops-controller-pki: ""
+     node-role.kubernetes.io/control-plane: ""
+     node.kubernetes.io/exclude-from-external-load-balancers: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -321,6 +320,7 @@ containerdConfig:
+   logLevel: info
+   runc:
+     version: 1.1.5
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.6.20
+ etcdManifests:
+ - memfs://clusters.example.com/minimal-aws.example.com/manifests/etcd/main-master-us-test-1a.yaml
+diff --git a/tests/integration/update_cluster/minimal-aws/data/aws_s3_object_nodeupconfig-nodes_content b/tests/integration/update_cluster/minimal-aws/data/aws_s3_object_nodeupconfig-nodes_content
+index ea2e930ea2..43ca4cdc0b 100644
+--- a/tests/integration/update_cluster/minimal-aws/data/aws_s3_object_nodeupconfig-nodes_content
++++ b/tests/integration/update_cluster/minimal-aws/data/aws_s3_object_nodeupconfig-nodes_content
+@@ -44,7 +44,6 @@ KubeletConfig:
+   logLevel: 2
+   nodeLabels:
+     node-role.kubernetes.io/node: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -59,6 +58,7 @@ containerdConfig:
+   logLevel: info
+   runc:
+     version: 1.1.5
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.6.20
+ usesLegacyGossip: false
+ usesNoneDNS: false
+diff --git a/tests/integration/update_cluster/minimal-dns-none/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data b/tests/integration/update_cluster/minimal-dns-none/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
+index 027166ec2e..854be87d6e 100644
+--- a/tests/integration/update_cluster/minimal-dns-none/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
++++ b/tests/integration/update_cluster/minimal-dns-none/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
+@@ -130,7 +130,7 @@ ClusterName: minimal.example.com
+ ConfigBase: memfs://tests/minimal.example.com
+ InstanceGroupName: master-us-test-1a
+ InstanceGroupRole: ControlPlane
+-NodeupConfigHash: CMWhGZbDrTRR+1n43OGdQf1kZSPSvPHf1XXiCAHhYDY=
++NodeupConfigHash: Np+VVLwQjiqW5pbkvj1wpdLJersHAmrUQEz99zePcHM=
+ 
+ __EOF_KUBE_ENV
+ 
+diff --git a/tests/integration/update_cluster/minimal-dns-none/data/aws_launch_template_nodes.minimal.example.com_user_data b/tests/integration/update_cluster/minimal-dns-none/data/aws_launch_template_nodes.minimal.example.com_user_data
+index c5de2a363c..5ff745eab5 100644
+--- a/tests/integration/update_cluster/minimal-dns-none/data/aws_launch_template_nodes.minimal.example.com_user_data
++++ b/tests/integration/update_cluster/minimal-dns-none/data/aws_launch_template_nodes.minimal.example.com_user_data
+@@ -153,7 +153,7 @@ ConfigServer:
+   - https://kops-controller.internal.minimal.example.com:3988/
+ InstanceGroupName: nodes
+ InstanceGroupRole: Node
+-NodeupConfigHash: G6azeYR+gcwUUaRfChEa58aij/r8HvI88Y0SsEG6WAU=
++NodeupConfigHash: 5rVr+FD+s32qb65qzBJcGwUxCKRRTV+9vmno1sKW7+g=
+ 
+ __EOF_KUBE_ENV
+ 
+diff --git a/tests/integration/update_cluster/minimal-dns-none/data/aws_s3_object_cluster-completed.spec_content b/tests/integration/update_cluster/minimal-dns-none/data/aws_s3_object_cluster-completed.spec_content
+index e53135ade2..b48ba7abf8 100644
+--- a/tests/integration/update_cluster/minimal-dns-none/data/aws_s3_object_cluster-completed.spec_content
++++ b/tests/integration/update_cluster/minimal-dns-none/data/aws_s3_object_cluster-completed.spec_content
+@@ -30,6 +30,7 @@ spec:
+     logLevel: info
+     runc:
+       version: 1.2.4
++    sandboxImage: registry.k8s.io/pause:3.10.1
+     version: 1.7.25
+   etcdClusters:
+   - backups:
+@@ -149,7 +150,6 @@ spec:
+     evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
+     kubeconfigPath: /var/lib/kubelet/kubeconfig
+     logLevel: 2
+-    podInfraContainerImage: registry.k8s.io/pause:3.9
+     podManifestPath: /etc/kubernetes/manifests
+     protectKernelDefaults: true
+     registerSchedulable: true
+@@ -170,7 +170,6 @@ spec:
+     evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
+     kubeconfigPath: /var/lib/kubelet/kubeconfig
+     logLevel: 2
+-    podInfraContainerImage: registry.k8s.io/pause:3.9
+     podManifestPath: /etc/kubernetes/manifests
+     protectKernelDefaults: true
+     registerSchedulable: true
+diff --git a/tests/integration/update_cluster/minimal-dns-none/data/aws_s3_object_nodeupconfig-master-us-test-1a_content b/tests/integration/update_cluster/minimal-dns-none/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+index 457daabeb1..f68f965e48 100644
+--- a/tests/integration/update_cluster/minimal-dns-none/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
++++ b/tests/integration/update_cluster/minimal-dns-none/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+@@ -291,7 +291,6 @@ KubeletConfig:
+     kops.k8s.io/kops-controller-pki: ""
+     node-role.kubernetes.io/control-plane: ""
+     node.kubernetes.io/exclude-from-external-load-balancers: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -313,6 +312,7 @@ containerdConfig:
+   logLevel: info
+   runc:
+     version: 1.2.4
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.7.25
+ etcdManifests:
+ - memfs://tests/minimal.example.com/manifests/etcd/main-master-us-test-1a.yaml
+diff --git a/tests/integration/update_cluster/minimal-dns-none/data/aws_s3_object_nodeupconfig-nodes_content b/tests/integration/update_cluster/minimal-dns-none/data/aws_s3_object_nodeupconfig-nodes_content
+index 52d03ae35c..3b68a1ee5d 100644
+--- a/tests/integration/update_cluster/minimal-dns-none/data/aws_s3_object_nodeupconfig-nodes_content
++++ b/tests/integration/update_cluster/minimal-dns-none/data/aws_s3_object_nodeupconfig-nodes_content
+@@ -44,7 +44,6 @@ KubeletConfig:
+   nodeLabels:
+     kops.k8s.io/instancegroup: nodes-us-test-1a
+     node-role.kubernetes.io/node: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -59,6 +58,7 @@ containerdConfig:
+   logLevel: info
+   runc:
+     version: 1.2.4
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.7.25
+ usesLegacyGossip: false
+ usesNoneDNS: true
+diff --git a/tests/integration/update_cluster/minimal-etcd/data/aws_launch_template_master-us-test-1a.masters.minimal-etcd.example.com_user_data b/tests/integration/update_cluster/minimal-etcd/data/aws_launch_template_master-us-test-1a.masters.minimal-etcd.example.com_user_data
+index e7d4d6a5fe..27634517f8 100644
+--- a/tests/integration/update_cluster/minimal-etcd/data/aws_launch_template_master-us-test-1a.masters.minimal-etcd.example.com_user_data
++++ b/tests/integration/update_cluster/minimal-etcd/data/aws_launch_template_master-us-test-1a.masters.minimal-etcd.example.com_user_data
+@@ -130,7 +130,7 @@ ClusterName: minimal-etcd.example.com
+ ConfigBase: memfs://clusters.example.com/minimal-etcd.example.com
+ InstanceGroupName: master-us-test-1a
+ InstanceGroupRole: ControlPlane
+-NodeupConfigHash: zAs+qTIvofwL1p/lIx4qRKA4E31I8lO8967H3NNygeA=
++NodeupConfigHash: Du85g1ZvHbFUcx/7o01KVHBuGqZFHGjfnsJOPY9itSs=
+ 
+ __EOF_KUBE_ENV
+ 
+diff --git a/tests/integration/update_cluster/minimal-etcd/data/aws_launch_template_nodes.minimal-etcd.example.com_user_data b/tests/integration/update_cluster/minimal-etcd/data/aws_launch_template_nodes.minimal-etcd.example.com_user_data
+index f087c2ef9d..bb706bdda2 100644
+--- a/tests/integration/update_cluster/minimal-etcd/data/aws_launch_template_nodes.minimal-etcd.example.com_user_data
++++ b/tests/integration/update_cluster/minimal-etcd/data/aws_launch_template_nodes.minimal-etcd.example.com_user_data
+@@ -153,7 +153,7 @@ ConfigServer:
+   - https://kops-controller.internal.minimal-etcd.example.com:3988/
+ InstanceGroupName: nodes
+ InstanceGroupRole: Node
+-NodeupConfigHash: qMPXs8wmKwPxZannZKRTEDoP/p+XQBRkQFx05e5Am6s=
++NodeupConfigHash: sVaequi5EDWoi7YXdE2bMBobMvzL9iG+K+7fqTHqfmc=
+ 
+ __EOF_KUBE_ENV
+ 
+diff --git a/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_cluster-completed.spec_content b/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_cluster-completed.spec_content
+index 0075492716..c1452106c5 100644
+--- a/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_cluster-completed.spec_content
++++ b/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_cluster-completed.spec_content
+@@ -28,6 +28,7 @@ spec:
+     logLevel: info
+     runc:
+       version: 1.2.4
++    sandboxImage: registry.k8s.io/pause:3.10.1
+     version: 1.7.25
+   dnsZone: Z1AFAKE1ZON3YO
+   etcdClusters:
+@@ -151,7 +152,6 @@ spec:
+     evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
+     kubeconfigPath: /var/lib/kubelet/kubeconfig
+     logLevel: 2
+-    podInfraContainerImage: registry.k8s.io/pause:3.9
+     podManifestPath: /etc/kubernetes/manifests
+     protectKernelDefaults: true
+     registerSchedulable: true
+@@ -171,7 +171,6 @@ spec:
+     evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
+     kubeconfigPath: /var/lib/kubelet/kubeconfig
+     logLevel: 2
+-    podInfraContainerImage: registry.k8s.io/pause:3.9
+     podManifestPath: /etc/kubernetes/manifests
+     protectKernelDefaults: true
+     registerSchedulable: true
+diff --git a/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_nodeupconfig-master-us-test-1a_content b/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+index 117aa46f10..283a3afca5 100644
+--- a/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
++++ b/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+@@ -292,7 +292,6 @@ KubeletConfig:
+     kops.k8s.io/kops-controller-pki: ""
+     node-role.kubernetes.io/control-plane: ""
+     node.kubernetes.io/exclude-from-external-load-balancers: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -314,6 +313,7 @@ containerdConfig:
+   logLevel: info
+   runc:
+     version: 1.2.4
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.7.25
+ etcdManifests:
+ - memfs://clusters.example.com/minimal-etcd.example.com/manifests/etcd/main-master-us-test-1a.yaml
+diff --git a/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_nodeupconfig-nodes_content b/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_nodeupconfig-nodes_content
+index b5174b44eb..10ec005566 100644
+--- a/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_nodeupconfig-nodes_content
++++ b/tests/integration/update_cluster/minimal-etcd/data/aws_s3_object_nodeupconfig-nodes_content
+@@ -43,7 +43,6 @@ KubeletConfig:
+   logLevel: 2
+   nodeLabels:
+     node-role.kubernetes.io/node: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -58,6 +57,7 @@ containerdConfig:
+   logLevel: info
+   runc:
+     version: 1.2.4
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.7.25
+ usesLegacyGossip: false
+ usesNoneDNS: false
+diff --git a/tests/integration/update_cluster/minimal-gp3/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data b/tests/integration/update_cluster/minimal-gp3/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
+index 5477ff9838..7bc96dd065 100644
+--- a/tests/integration/update_cluster/minimal-gp3/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
++++ b/tests/integration/update_cluster/minimal-gp3/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
+@@ -130,7 +130,7 @@ ClusterName: minimal.example.com
+ ConfigBase: memfs://clusters.example.com/minimal.example.com
+ InstanceGroupName: master-us-test-1a
+ InstanceGroupRole: ControlPlane
+-NodeupConfigHash: ucsdJGKI6NlyxcMuxNbIl5QTQ9XH7jlClzx6w6ZSu+I=
++NodeupConfigHash: QgVGs/0YUwUnI6Kqga5EjoUYo40di+z7q9qJkhMgdO4=
+ 
+ __EOF_KUBE_ENV
+ 
+diff --git a/tests/integration/update_cluster/minimal-gp3/data/aws_launch_template_nodes.minimal.example.com_user_data b/tests/integration/update_cluster/minimal-gp3/data/aws_launch_template_nodes.minimal.example.com_user_data
+index 4b6fe88318..13b9b6d58a 100644
+--- a/tests/integration/update_cluster/minimal-gp3/data/aws_launch_template_nodes.minimal.example.com_user_data
++++ b/tests/integration/update_cluster/minimal-gp3/data/aws_launch_template_nodes.minimal.example.com_user_data
+@@ -153,7 +153,7 @@ ConfigServer:
+   - https://kops-controller.internal.minimal.example.com:3988/
+ InstanceGroupName: nodes
+ InstanceGroupRole: Node
+-NodeupConfigHash: RwbCzWuKwqBp91KWu4IEZpgBJ0UVI0mpR+lv9mY5/nQ=
++NodeupConfigHash: MBILso1750yJWFfuk5/KINzohd8nOsHTvT6sHBIZjgU=
+ 
+ __EOF_KUBE_ENV
+ 
+diff --git a/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_cluster-completed.spec_content b/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_cluster-completed.spec_content
+index 7a6ce56b5c..6c37115611 100644
+--- a/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_cluster-completed.spec_content
++++ b/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_cluster-completed.spec_content
+@@ -28,6 +28,7 @@ spec:
+     logLevel: info
+     runc:
+       version: 1.2.4
++    sandboxImage: registry.k8s.io/pause:3.10.1
+     version: 1.7.25
+   dnsZone: Z1AFAKE1ZON3YO
+   etcdClusters:
+@@ -149,7 +150,6 @@ spec:
+     evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
+     kubeconfigPath: /var/lib/kubelet/kubeconfig
+     logLevel: 2
+-    podInfraContainerImage: registry.k8s.io/pause:3.9
+     podManifestPath: /etc/kubernetes/manifests
+     protectKernelDefaults: true
+     registerSchedulable: true
+@@ -169,7 +169,6 @@ spec:
+     evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
+     kubeconfigPath: /var/lib/kubelet/kubeconfig
+     logLevel: 2
+-    podInfraContainerImage: registry.k8s.io/pause:3.9
+     podManifestPath: /etc/kubernetes/manifests
+     protectKernelDefaults: true
+     registerSchedulable: true
+diff --git a/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_nodeupconfig-master-us-test-1a_content b/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+index ebe132ffcb..11dbc89cf6 100644
+--- a/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
++++ b/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+@@ -292,7 +292,6 @@ KubeletConfig:
+     kops.k8s.io/kops-controller-pki: ""
+     node-role.kubernetes.io/control-plane: ""
+     node.kubernetes.io/exclude-from-external-load-balancers: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -314,6 +313,7 @@ containerdConfig:
+   logLevel: info
+   runc:
+     version: 1.2.4
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.7.25
+ etcdManifests:
+ - memfs://clusters.example.com/minimal.example.com/manifests/etcd/main-master-us-test-1a.yaml
+diff --git a/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_nodeupconfig-nodes_content b/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_nodeupconfig-nodes_content
+index 2d88fa5a47..fe36f97d54 100644
+--- a/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_nodeupconfig-nodes_content
++++ b/tests/integration/update_cluster/minimal-gp3/data/aws_s3_object_nodeupconfig-nodes_content
+@@ -43,7 +43,6 @@ KubeletConfig:
+   logLevel: 2
+   nodeLabels:
+     node-role.kubernetes.io/node: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -58,6 +57,7 @@ containerdConfig:
+   logLevel: info
+   runc:
+     version: 1.2.4
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.7.25
+ usesLegacyGossip: false
+ usesNoneDNS: false
+diff --git a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_launch_template_master-us-test-1a.masters.minimal-ipv6.example.com_user_data b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_launch_template_master-us-test-1a.masters.minimal-ipv6.example.com_user_data
+index e773e1461b..72eff39186 100644
+--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_launch_template_master-us-test-1a.masters.minimal-ipv6.example.com_user_data
++++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_launch_template_master-us-test-1a.masters.minimal-ipv6.example.com_user_data
+@@ -130,7 +130,7 @@ ClusterName: minimal-ipv6.example.com
+ ConfigBase: memfs://clusters.example.com/minimal-ipv6.example.com
+ InstanceGroupName: master-us-test-1a
+ InstanceGroupRole: ControlPlane
+-NodeupConfigHash: M7ndkjvJERSRki0z89GVExUKFTzCnwAeiLREesJvrnQ=
++NodeupConfigHash: woZjaCL1s6+zxD/KUSUaz1Mqe0I7IgiYDIOfrEXhV3c=
+ 
+ __EOF_KUBE_ENV
+ 
+diff --git a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_launch_template_nodes.minimal-ipv6.example.com_user_data b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_launch_template_nodes.minimal-ipv6.example.com_user_data
+index 024bd19d7c..c5d659a7e1 100644
+--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_launch_template_nodes.minimal-ipv6.example.com_user_data
++++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_launch_template_nodes.minimal-ipv6.example.com_user_data
+@@ -153,7 +153,7 @@ ConfigServer:
+   - https://kops-controller.internal.minimal-ipv6.example.com:3988/
+ InstanceGroupName: nodes
+ InstanceGroupRole: Node
+-NodeupConfigHash: vdOVMANxTQvs56OO10QgX3Dxe3GKWHsIsPP2IhNL6II=
++NodeupConfigHash: 8yreY3pSm7JS8MhecOzwUB7J/VZUIYyYonpcXt85njE=
+ 
+ __EOF_KUBE_ENV
+ 
+diff --git a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_cluster-completed.spec_content b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_cluster-completed.spec_content
+index 19d8c5cd25..7394a86543 100644
+--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_cluster-completed.spec_content
++++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_cluster-completed.spec_content
+@@ -32,6 +32,7 @@ spec:
+     logLevel: info
+     runc:
+       version: 1.2.4
++    sandboxImage: registry.k8s.io/pause:3.10.1
+     version: 1.7.25
+   dnsZone: Z1AFAKE1ZON3YO
+   etcdClusters:
+@@ -150,7 +151,6 @@ spec:
+     evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
+     kubeconfigPath: /var/lib/kubelet/kubeconfig
+     logLevel: 2
+-    podInfraContainerImage: registry.k8s.io/pause:3.9
+     podManifestPath: /etc/kubernetes/manifests
+     protectKernelDefaults: true
+     registerSchedulable: true
+@@ -171,7 +171,6 @@ spec:
+     evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
+     kubeconfigPath: /var/lib/kubelet/kubeconfig
+     logLevel: 2
+-    podInfraContainerImage: registry.k8s.io/pause:3.9
+     podManifestPath: /etc/kubernetes/manifests
+     protectKernelDefaults: true
+     registerSchedulable: true
+diff --git a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_nodeupconfig-master-us-test-1a_content b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+index c59c0c8172..0a127d5da5 100644
+--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
++++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+@@ -289,7 +289,6 @@ KubeletConfig:
+     kops.k8s.io/kops-controller-pki: ""
+     node-role.kubernetes.io/control-plane: ""
+     node.kubernetes.io/exclude-from-external-load-balancers: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -312,6 +311,7 @@ containerdConfig:
+   logLevel: info
+   runc:
+     version: 1.2.4
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.7.25
+ etcdManifests:
+ - memfs://clusters.example.com/minimal-ipv6.example.com/manifests/etcd/main-master-us-test-1a.yaml
+diff --git a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_nodeupconfig-nodes_content b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_nodeupconfig-nodes_content
+index eed63c722a..dbc47df827 100644
+--- a/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_nodeupconfig-nodes_content
++++ b/tests/integration/update_cluster/minimal-ipv6-calico/data/aws_s3_object_nodeupconfig-nodes_content
+@@ -39,7 +39,6 @@ KubeletConfig:
+   logLevel: 2
+   nodeLabels:
+     node-role.kubernetes.io/node: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -55,6 +54,7 @@ containerdConfig:
+   logLevel: info
+   runc:
+     version: 1.2.4
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.7.25
+ usesLegacyGossip: false
+ usesNoneDNS: false
+diff --git a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_launch_template_master-us-test-1a.masters.minimal-ipv6.example.com_user_data b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_launch_template_master-us-test-1a.masters.minimal-ipv6.example.com_user_data
+index e1598255dd..1efa8dd59b 100644
+--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_launch_template_master-us-test-1a.masters.minimal-ipv6.example.com_user_data
++++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_launch_template_master-us-test-1a.masters.minimal-ipv6.example.com_user_data
+@@ -130,7 +130,7 @@ ClusterName: minimal-ipv6.example.com
+ ConfigBase: memfs://clusters.example.com/minimal-ipv6.example.com
+ InstanceGroupName: master-us-test-1a
+ InstanceGroupRole: ControlPlane
+-NodeupConfigHash: 7NTdxRtKVh9ioc8DNOrZsntfcZGf4Fr0URVP1LihSR4=
++NodeupConfigHash: CYAPUpXCetYPUJ0xNTbqR1MqVVbq99xmTp5psPOn63Y=
+ 
+ __EOF_KUBE_ENV
+ 
+diff --git a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_launch_template_nodes.minimal-ipv6.example.com_user_data b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_launch_template_nodes.minimal-ipv6.example.com_user_data
+index 5abc8e55a7..e11620499d 100644
+--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_launch_template_nodes.minimal-ipv6.example.com_user_data
++++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_launch_template_nodes.minimal-ipv6.example.com_user_data
+@@ -153,7 +153,7 @@ ConfigServer:
+   - https://kops-controller.internal.minimal-ipv6.example.com:3988/
+ InstanceGroupName: nodes
+ InstanceGroupRole: Node
+-NodeupConfigHash: 3T4K+BrGPt4eY67qlimaWK+6QSDLREdIW3xxIcZs1Wk=
++NodeupConfigHash: OHD+4ykY5dhfrPOrMNpwYPVXgJqpymtWFtdwrgvniO8=
+ 
+ __EOF_KUBE_ENV
+ 
+diff --git a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_cluster-completed.spec_content b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_cluster-completed.spec_content
+index 85c7e3db5e..2969c06869 100644
+--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_cluster-completed.spec_content
++++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_cluster-completed.spec_content
+@@ -32,6 +32,7 @@ spec:
+     logLevel: info
+     runc:
+       version: 1.2.4
++    sandboxImage: registry.k8s.io/pause:3.10.1
+     version: 1.7.25
+   dnsZone: Z1AFAKE1ZON3YO
+   etcdClusters:
+@@ -150,7 +151,6 @@ spec:
+     evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
+     kubeconfigPath: /var/lib/kubelet/kubeconfig
+     logLevel: 2
+-    podInfraContainerImage: registry.k8s.io/pause:3.9
+     podManifestPath: /etc/kubernetes/manifests
+     protectKernelDefaults: true
+     registerSchedulable: true
+@@ -171,7 +171,6 @@ spec:
+     evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
+     kubeconfigPath: /var/lib/kubelet/kubeconfig
+     logLevel: 2
+-    podInfraContainerImage: registry.k8s.io/pause:3.9
+     podManifestPath: /etc/kubernetes/manifests
+     protectKernelDefaults: true
+     registerSchedulable: true
+diff --git a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_nodeupconfig-master-us-test-1a_content b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+index fc0d8c4f73..2273f29c15 100644
+--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
++++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+@@ -289,7 +289,6 @@ KubeletConfig:
+     kops.k8s.io/kops-controller-pki: ""
+     node-role.kubernetes.io/control-plane: ""
+     node.kubernetes.io/exclude-from-external-load-balancers: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -312,6 +311,7 @@ containerdConfig:
+   logLevel: info
+   runc:
+     version: 1.2.4
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.7.25
+ etcdManifests:
+ - memfs://clusters.example.com/minimal-ipv6.example.com/manifests/etcd/main-master-us-test-1a.yaml
+diff --git a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_nodeupconfig-nodes_content b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_nodeupconfig-nodes_content
+index 69c35de064..9da67a8c96 100644
+--- a/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_nodeupconfig-nodes_content
++++ b/tests/integration/update_cluster/minimal-ipv6-cilium/data/aws_s3_object_nodeupconfig-nodes_content
+@@ -39,7 +39,6 @@ KubeletConfig:
+   logLevel: 2
+   nodeLabels:
+     node-role.kubernetes.io/node: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -55,6 +54,7 @@ containerdConfig:
+   logLevel: info
+   runc:
+     version: 1.2.4
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.7.25
+ usesLegacyGossip: false
+ usesNoneDNS: false
+diff --git a/tests/integration/update_cluster/minimal-ipv6-kindnet/data/aws_launch_template_master-us-test-1a.masters.minimal-ipv6.example.com_user_data b/tests/integration/update_cluster/minimal-ipv6-kindnet/data/aws_launch_template_master-us-test-1a.masters.minimal-ipv6.example.com_user_data
+index 04ef961f64..fa27454f3c 100644
+--- a/tests/integration/update_cluster/minimal-ipv6-kindnet/data/aws_launch_template_master-us-test-1a.masters.minimal-ipv6.example.com_user_data
++++ b/tests/integration/update_cluster/minimal-ipv6-kindnet/data/aws_launch_template_master-us-test-1a.masters.minimal-ipv6.example.com_user_data
+@@ -130,7 +130,7 @@ ClusterName: minimal-ipv6.example.com
+ ConfigBase: memfs://clusters.example.com/minimal-ipv6.example.com
+ InstanceGroupName: master-us-test-1a
+ InstanceGroupRole: ControlPlane
+-NodeupConfigHash: q8kLNtOV2pM9f2TrQWZFR89LwNcQ2/ReO9ahngdCpSM=
++NodeupConfigHash: 0FsQM3wDtupXXdQA58v+pqsnJnmTGFtmrDsO2FeGOmc=
+ 
+ __EOF_KUBE_ENV
+ 
+diff --git a/tests/integration/update_cluster/minimal-ipv6-kindnet/data/aws_launch_template_nodes.minimal-ipv6.example.com_user_data b/tests/integration/update_cluster/minimal-ipv6-kindnet/data/aws_launch_template_nodes.minimal-ipv6.example.com_user_data
+index 44529c783d..6f630da61d 100644
+--- a/tests/integration/update_cluster/minimal-ipv6-kindnet/data/aws_launch_template_nodes.minimal-ipv6.example.com_user_data
++++ b/tests/integration/update_cluster/minimal-ipv6-kindnet/data/aws_launch_template_nodes.minimal-ipv6.example.com_user_data
+@@ -153,7 +153,7 @@ ConfigServer:
+   - https://kops-controller.internal.minimal-ipv6.example.com:3988/
+ InstanceGroupName: nodes
+ InstanceGroupRole: Node
+-NodeupConfigHash: IU6TO8wvxhLBfOj9ng9BD8IX0OJyY297etMOofRIvg0=
++NodeupConfigHash: Db0NYL6UZfo2aIn89mRDWzbdH0rd6LBE6z025CdwC7s=
+ 
+ __EOF_KUBE_ENV
+ 
+diff --git a/tests/integration/update_cluster/minimal-ipv6-kindnet/data/aws_s3_object_cluster-completed.spec_content b/tests/integration/update_cluster/minimal-ipv6-kindnet/data/aws_s3_object_cluster-completed.spec_content
+index caee56bc36..101f725335 100644
+--- a/tests/integration/update_cluster/minimal-ipv6-kindnet/data/aws_s3_object_cluster-completed.spec_content
++++ b/tests/integration/update_cluster/minimal-ipv6-kindnet/data/aws_s3_object_cluster-completed.spec_content
+@@ -32,6 +32,7 @@ spec:
+     logLevel: info
+     runc:
+       version: 1.2.4
++    sandboxImage: registry.k8s.io/pause:3.10.1
+     version: 1.7.25
+   dnsZone: Z1AFAKE1ZON3YO
+   etcdClusters:
+@@ -150,7 +151,6 @@ spec:
+     evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
+     kubeconfigPath: /var/lib/kubelet/kubeconfig
+     logLevel: 2
+-    podInfraContainerImage: registry.k8s.io/pause:3.9
+     podManifestPath: /etc/kubernetes/manifests
+     protectKernelDefaults: true
+     registerSchedulable: true
+@@ -171,7 +171,6 @@ spec:
+     evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
+     kubeconfigPath: /var/lib/kubelet/kubeconfig
+     logLevel: 2
+-    podInfraContainerImage: registry.k8s.io/pause:3.9
+     podManifestPath: /etc/kubernetes/manifests
+     protectKernelDefaults: true
+     registerSchedulable: true
+diff --git a/tests/integration/update_cluster/minimal-ipv6-kindnet/data/aws_s3_object_nodeupconfig-master-us-test-1a_content b/tests/integration/update_cluster/minimal-ipv6-kindnet/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+index ab57b08511..55017e3dc0 100644
+--- a/tests/integration/update_cluster/minimal-ipv6-kindnet/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
++++ b/tests/integration/update_cluster/minimal-ipv6-kindnet/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+@@ -292,7 +292,6 @@ KubeletConfig:
+     kops.k8s.io/kops-controller-pki: ""
+     node-role.kubernetes.io/control-plane: ""
+     node.kubernetes.io/exclude-from-external-load-balancers: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -315,6 +314,7 @@ containerdConfig:
+   logLevel: info
+   runc:
+     version: 1.2.4
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.7.25
+ etcdManifests:
+ - memfs://clusters.example.com/minimal-ipv6.example.com/manifests/etcd/main-master-us-test-1a.yaml
+diff --git a/tests/integration/update_cluster/minimal-ipv6-kindnet/data/aws_s3_object_nodeupconfig-nodes_content b/tests/integration/update_cluster/minimal-ipv6-kindnet/data/aws_s3_object_nodeupconfig-nodes_content
+index 1503c46ce1..788a9d6816 100644
+--- a/tests/integration/update_cluster/minimal-ipv6-kindnet/data/aws_s3_object_nodeupconfig-nodes_content
++++ b/tests/integration/update_cluster/minimal-ipv6-kindnet/data/aws_s3_object_nodeupconfig-nodes_content
+@@ -42,7 +42,6 @@ KubeletConfig:
+   logLevel: 2
+   nodeLabels:
+     node-role.kubernetes.io/node: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -58,6 +57,7 @@ containerdConfig:
+   logLevel: info
+   runc:
+     version: 1.2.4
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.7.25
+ usesLegacyGossip: false
+ usesNoneDNS: false
+diff --git a/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_launch_template_master-us-test-1a.masters.minimal-ipv6.example.com_user_data b/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_launch_template_master-us-test-1a.masters.minimal-ipv6.example.com_user_data
+index 9575fb3341..c5982be68a 100644
+--- a/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_launch_template_master-us-test-1a.masters.minimal-ipv6.example.com_user_data
++++ b/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_launch_template_master-us-test-1a.masters.minimal-ipv6.example.com_user_data
+@@ -130,7 +130,7 @@ ClusterName: minimal-ipv6.example.com
+ ConfigBase: memfs://clusters.example.com/minimal-ipv6.example.com
+ InstanceGroupName: master-us-test-1a
+ InstanceGroupRole: ControlPlane
+-NodeupConfigHash: QXMgcfHCS2DCGFxjYjV5Z/hdL3dPNYk2U3pqIgUuSIc=
++NodeupConfigHash: Inz7L/YSaqqx+caV0c15SbHl9/+xqF5WA1symPd3DWM=
+ 
+ __EOF_KUBE_ENV
+ 
+diff --git a/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_launch_template_nodes.minimal-ipv6.example.com_user_data b/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_launch_template_nodes.minimal-ipv6.example.com_user_data
+index aab0338391..fd9b19c2f9 100644
+--- a/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_launch_template_nodes.minimal-ipv6.example.com_user_data
++++ b/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_launch_template_nodes.minimal-ipv6.example.com_user_data
+@@ -153,7 +153,7 @@ ConfigServer:
+   - https://kops-controller.internal.minimal-ipv6.example.com:3988/
+ InstanceGroupName: nodes
+ InstanceGroupRole: Node
+-NodeupConfigHash: v5f3fdfGKoObcimpgX3OWSOCcfXvo1j0yAWONGF2g8o=
++NodeupConfigHash: 7xEqooXP6NiadwfV+Jrfb1cai0qYh6k6UHTVAB1umqI=
+ 
+ __EOF_KUBE_ENV
+ 
+diff --git a/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_cluster-completed.spec_content b/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_cluster-completed.spec_content
+index b55b0e3a19..e439f5180c 100644
+--- a/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_cluster-completed.spec_content
++++ b/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_cluster-completed.spec_content
+@@ -32,6 +32,7 @@ spec:
+     logLevel: info
+     runc:
+       version: 1.2.4
++    sandboxImage: registry.k8s.io/pause:3.10.1
+     version: 1.7.25
+   dnsZone: Z1AFAKE1ZON3YO
+   etcdClusters:
+@@ -150,7 +151,6 @@ spec:
+     evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
+     kubeconfigPath: /var/lib/kubelet/kubeconfig
+     logLevel: 2
+-    podInfraContainerImage: registry.k8s.io/pause:3.9
+     podManifestPath: /etc/kubernetes/manifests
+     protectKernelDefaults: true
+     registerSchedulable: true
+@@ -171,7 +171,6 @@ spec:
+     evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
+     kubeconfigPath: /var/lib/kubelet/kubeconfig
+     logLevel: 2
+-    podInfraContainerImage: registry.k8s.io/pause:3.9
+     podManifestPath: /etc/kubernetes/manifests
+     protectKernelDefaults: true
+     registerSchedulable: true
+diff --git a/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_nodeupconfig-master-us-test-1a_content b/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+index dcef6a5afb..a7fd1fddb6 100644
+--- a/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
++++ b/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+@@ -292,7 +292,6 @@ KubeletConfig:
+     kops.k8s.io/kops-controller-pki: ""
+     node-role.kubernetes.io/control-plane: ""
+     node.kubernetes.io/exclude-from-external-load-balancers: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -314,6 +313,7 @@ containerdConfig:
+   logLevel: info
+   runc:
+     version: 1.2.4
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.7.25
+ etcdManifests:
+ - memfs://clusters.example.com/minimal-ipv6.example.com/manifests/etcd/main-master-us-test-1a.yaml
+diff --git a/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_nodeupconfig-nodes_content b/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_nodeupconfig-nodes_content
+index e65e650650..dc92e97d60 100644
+--- a/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_nodeupconfig-nodes_content
++++ b/tests/integration/update_cluster/minimal-ipv6-no-subnet-prefix/data/aws_s3_object_nodeupconfig-nodes_content
+@@ -42,7 +42,6 @@ KubeletConfig:
+   logLevel: 2
+   nodeLabels:
+     node-role.kubernetes.io/node: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -57,6 +56,7 @@ containerdConfig:
+   logLevel: info
+   runc:
+     version: 1.2.4
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.7.25
+ usesLegacyGossip: false
+ usesNoneDNS: false
+diff --git a/tests/integration/update_cluster/minimal-ipv6/data/aws_launch_template_master-us-test-1a.masters.minimal-ipv6.example.com_user_data b/tests/integration/update_cluster/minimal-ipv6/data/aws_launch_template_master-us-test-1a.masters.minimal-ipv6.example.com_user_data
+index 9575fb3341..c5982be68a 100644
+--- a/tests/integration/update_cluster/minimal-ipv6/data/aws_launch_template_master-us-test-1a.masters.minimal-ipv6.example.com_user_data
++++ b/tests/integration/update_cluster/minimal-ipv6/data/aws_launch_template_master-us-test-1a.masters.minimal-ipv6.example.com_user_data
+@@ -130,7 +130,7 @@ ClusterName: minimal-ipv6.example.com
+ ConfigBase: memfs://clusters.example.com/minimal-ipv6.example.com
+ InstanceGroupName: master-us-test-1a
+ InstanceGroupRole: ControlPlane
+-NodeupConfigHash: QXMgcfHCS2DCGFxjYjV5Z/hdL3dPNYk2U3pqIgUuSIc=
++NodeupConfigHash: Inz7L/YSaqqx+caV0c15SbHl9/+xqF5WA1symPd3DWM=
+ 
+ __EOF_KUBE_ENV
+ 
+diff --git a/tests/integration/update_cluster/minimal-ipv6/data/aws_launch_template_nodes.minimal-ipv6.example.com_user_data b/tests/integration/update_cluster/minimal-ipv6/data/aws_launch_template_nodes.minimal-ipv6.example.com_user_data
+index aab0338391..fd9b19c2f9 100644
+--- a/tests/integration/update_cluster/minimal-ipv6/data/aws_launch_template_nodes.minimal-ipv6.example.com_user_data
++++ b/tests/integration/update_cluster/minimal-ipv6/data/aws_launch_template_nodes.minimal-ipv6.example.com_user_data
+@@ -153,7 +153,7 @@ ConfigServer:
+   - https://kops-controller.internal.minimal-ipv6.example.com:3988/
+ InstanceGroupName: nodes
+ InstanceGroupRole: Node
+-NodeupConfigHash: v5f3fdfGKoObcimpgX3OWSOCcfXvo1j0yAWONGF2g8o=
++NodeupConfigHash: 7xEqooXP6NiadwfV+Jrfb1cai0qYh6k6UHTVAB1umqI=
+ 
+ __EOF_KUBE_ENV
+ 
+diff --git a/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_cluster-completed.spec_content b/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_cluster-completed.spec_content
+index fe4695fc17..14e17b7cf6 100644
+--- a/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_cluster-completed.spec_content
++++ b/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_cluster-completed.spec_content
+@@ -32,6 +32,7 @@ spec:
+     logLevel: info
+     runc:
+       version: 1.2.4
++    sandboxImage: registry.k8s.io/pause:3.10.1
+     version: 1.7.25
+   dnsZone: Z1AFAKE1ZON3YO
+   etcdClusters:
+@@ -150,7 +151,6 @@ spec:
+     evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
+     kubeconfigPath: /var/lib/kubelet/kubeconfig
+     logLevel: 2
+-    podInfraContainerImage: registry.k8s.io/pause:3.9
+     podManifestPath: /etc/kubernetes/manifests
+     protectKernelDefaults: true
+     registerSchedulable: true
+@@ -171,7 +171,6 @@ spec:
+     evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
+     kubeconfigPath: /var/lib/kubelet/kubeconfig
+     logLevel: 2
+-    podInfraContainerImage: registry.k8s.io/pause:3.9
+     podManifestPath: /etc/kubernetes/manifests
+     protectKernelDefaults: true
+     registerSchedulable: true
+diff --git a/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_nodeupconfig-master-us-test-1a_content b/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+index dcef6a5afb..a7fd1fddb6 100644
+--- a/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
++++ b/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+@@ -292,7 +292,6 @@ KubeletConfig:
+     kops.k8s.io/kops-controller-pki: ""
+     node-role.kubernetes.io/control-plane: ""
+     node.kubernetes.io/exclude-from-external-load-balancers: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -314,6 +313,7 @@ containerdConfig:
+   logLevel: info
+   runc:
+     version: 1.2.4
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.7.25
+ etcdManifests:
+ - memfs://clusters.example.com/minimal-ipv6.example.com/manifests/etcd/main-master-us-test-1a.yaml
+diff --git a/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_nodeupconfig-nodes_content b/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_nodeupconfig-nodes_content
+index e65e650650..dc92e97d60 100644
+--- a/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_nodeupconfig-nodes_content
++++ b/tests/integration/update_cluster/minimal-ipv6/data/aws_s3_object_nodeupconfig-nodes_content
+@@ -42,7 +42,6 @@ KubeletConfig:
+   logLevel: 2
+   nodeLabels:
+     node-role.kubernetes.io/node: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -57,6 +56,7 @@ containerdConfig:
+   logLevel: info
+   runc:
+     version: 1.2.4
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.7.25
+ usesLegacyGossip: false
+ usesNoneDNS: false
+diff --git a/tests/integration/update_cluster/minimal-longclustername/data/aws_launch_template_master-us-test-1a.masters.this.is.truly.a.really.really.long.cluster-name.minimal.example.com_user_data b/tests/integration/update_cluster/minimal-longclustername/data/aws_launch_template_master-us-test-1a.masters.this.is.truly.a.really.really.long.cluster-name.minimal.example.com_user_data
+index da20475203..5fc352b4c9 100644
+--- a/tests/integration/update_cluster/minimal-longclustername/data/aws_launch_template_master-us-test-1a.masters.this.is.truly.a.really.really.long.cluster-name.minimal.example.com_user_data
++++ b/tests/integration/update_cluster/minimal-longclustername/data/aws_launch_template_master-us-test-1a.masters.this.is.truly.a.really.really.long.cluster-name.minimal.example.com_user_data
+@@ -130,7 +130,7 @@ ClusterName: this.is.truly.a.really.really.long.cluster-name.minimal.example.com
+ ConfigBase: memfs://clusters.example.com/this.is.truly.a.really.really.long.cluster-name.minimal.example.com
+ InstanceGroupName: master-us-test-1a
+ InstanceGroupRole: ControlPlane
+-NodeupConfigHash: 0b3oYSJc0wrmxfmT1vv14x2Rqh19Uvn7iRHE1JIVbyg=
++NodeupConfigHash: vNcHHav+IMKhhJ3fnnB9QekuePH9Bw9I08OOHDbaW1E=
+ 
+ __EOF_KUBE_ENV
+ 
+diff --git a/tests/integration/update_cluster/minimal-longclustername/data/aws_launch_template_nodes.this.is.truly.a.really.really.long.cluster-name.minimal.example.com_user_data b/tests/integration/update_cluster/minimal-longclustername/data/aws_launch_template_nodes.this.is.truly.a.really.really.long.cluster-name.minimal.example.com_user_data
+index ae4d1ddf54..2393f60f3c 100644
+--- a/tests/integration/update_cluster/minimal-longclustername/data/aws_launch_template_nodes.this.is.truly.a.really.really.long.cluster-name.minimal.example.com_user_data
++++ b/tests/integration/update_cluster/minimal-longclustername/data/aws_launch_template_nodes.this.is.truly.a.really.really.long.cluster-name.minimal.example.com_user_data
+@@ -153,7 +153,7 @@ ConfigServer:
+   - https://kops-controller.internal.this.is.truly.a.really.really.long.cluster-name.minimal.example.com:3988/
+ InstanceGroupName: nodes
+ InstanceGroupRole: Node
+-NodeupConfigHash: oIgrLuH5YowVbMZE2wukOcO8rwIR4mHAkKQA5Ekiv4g=
++NodeupConfigHash: u69u7Epy8pQzrSi5dnVQrGlDnRl3OCVKes9Z985IhR8=
+ 
+ __EOF_KUBE_ENV
+ 
+diff --git a/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_cluster-completed.spec_content b/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_cluster-completed.spec_content
+index 191c7c06d1..89bf04c1d2 100644
+--- a/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_cluster-completed.spec_content
++++ b/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_cluster-completed.spec_content
+@@ -28,6 +28,7 @@ spec:
+     logLevel: info
+     runc:
+       version: 1.2.4
++    sandboxImage: registry.k8s.io/pause:3.10.1
+     version: 1.7.25
+   dnsZone: Z1AFAKE1ZON3YO
+   etcdClusters:
+@@ -140,7 +141,6 @@ spec:
+     evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
+     kubeconfigPath: /var/lib/kubelet/kubeconfig
+     logLevel: 2
+-    podInfraContainerImage: registry.k8s.io/pause:3.9
+     podManifestPath: /etc/kubernetes/manifests
+     protectKernelDefaults: true
+     registerSchedulable: true
+@@ -159,7 +159,6 @@ spec:
+     evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
+     kubeconfigPath: /var/lib/kubelet/kubeconfig
+     logLevel: 2
+-    podInfraContainerImage: registry.k8s.io/pause:3.9
+     podManifestPath: /etc/kubernetes/manifests
+     protectKernelDefaults: true
+     registerSchedulable: true
+diff --git a/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_nodeupconfig-master-us-test-1a_content b/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+index 5e1d4a1a80..0191b4dc80 100644
+--- a/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
++++ b/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+@@ -291,7 +291,6 @@ KubeletConfig:
+     kops.k8s.io/kops-controller-pki: ""
+     node-role.kubernetes.io/control-plane: ""
+     node.kubernetes.io/exclude-from-external-load-balancers: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -313,6 +312,7 @@ containerdConfig:
+   logLevel: info
+   runc:
+     version: 1.2.4
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.7.25
+ etcdManifests:
+ - memfs://clusters.example.com/this.is.truly.a.really.really.long.cluster-name.minimal.example.com/manifests/etcd/main-master-us-test-1a.yaml
+diff --git a/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_nodeupconfig-nodes_content b/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_nodeupconfig-nodes_content
+index 6e7eb69fff..7aff90f901 100644
+--- a/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_nodeupconfig-nodes_content
++++ b/tests/integration/update_cluster/minimal-longclustername/data/aws_s3_object_nodeupconfig-nodes_content
+@@ -42,7 +42,6 @@ KubeletConfig:
+   logLevel: 2
+   nodeLabels:
+     node-role.kubernetes.io/node: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -57,6 +56,7 @@ containerdConfig:
+   logLevel: info
+   runc:
+     version: 1.2.4
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.7.25
+ usesLegacyGossip: false
+ usesNoneDNS: false
+diff --git a/tests/integration/update_cluster/minimal-warmpool/data/aws_launch_template_master-us-test-1a.masters.minimal-warmpool.example.com_user_data b/tests/integration/update_cluster/minimal-warmpool/data/aws_launch_template_master-us-test-1a.masters.minimal-warmpool.example.com_user_data
+index 3b5a9056b7..f186a18deb 100644
+--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_launch_template_master-us-test-1a.masters.minimal-warmpool.example.com_user_data
++++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_launch_template_master-us-test-1a.masters.minimal-warmpool.example.com_user_data
+@@ -130,7 +130,7 @@ ClusterName: minimal-warmpool.example.com
+ ConfigBase: memfs://clusters.example.com/minimal-warmpool.example.com
+ InstanceGroupName: master-us-test-1a
+ InstanceGroupRole: ControlPlane
+-NodeupConfigHash: 2lg6Q1XjXpscq4MkgFPXs+Nxv2cxzMVcc4bg60CZLGc=
++NodeupConfigHash: 81ZZ1wudKv83nQvtZtC06ONvLn4hHSn6awJnFVqNS1I=
+ 
+ __EOF_KUBE_ENV
+ 
+diff --git a/tests/integration/update_cluster/minimal-warmpool/data/aws_launch_template_nodes.minimal-warmpool.example.com_user_data b/tests/integration/update_cluster/minimal-warmpool/data/aws_launch_template_nodes.minimal-warmpool.example.com_user_data
+index 980be6f62c..89f8b501a5 100644
+--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_launch_template_nodes.minimal-warmpool.example.com_user_data
++++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_launch_template_nodes.minimal-warmpool.example.com_user_data
+@@ -153,7 +153,7 @@ ConfigServer:
+   - https://kops-controller.internal.minimal-warmpool.example.com:3988/
+ InstanceGroupName: nodes
+ InstanceGroupRole: Node
+-NodeupConfigHash: 5uju3TyrpJia7EVXjpE80ZhpgiJ8lkHOSz6oHXR8ekE=
++NodeupConfigHash: mPQ7Bk581gSsWPjf9TmORPvvukmcan5vr5lkVhvLR78=
+ 
+ __EOF_KUBE_ENV
+ 
+diff --git a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_cluster-completed.spec_content b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_cluster-completed.spec_content
+index 5d410403eb..f830554786 100644
+--- a/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_cluster-completed.spec_content
++++ b/tests/integration/update_cluster/minimal-warmpool/data/aws_s3_object_cluster-completed.spec_content
+@@ -28,6 +28,7 @@ spec:
+     logLevel: info
+     runc:
+       version: 1.2.4
++    sandboxImage: registry.k8s.io/pause:3.10.1
+     version: 1.7.25
+   dnsZone: Z1AFAKE1ZON3YO
+   etcdClusters:
+diff --git a/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_cluster-completed.spec_content b/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_cluster-completed.spec_content
+index f50524fdc6..dc0dcd88c9 100644
+--- a/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_cluster-completed.spec_content
++++ b/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_cluster-completed.spec_content
+@@ -33,6 +33,7 @@ spec:
+     logLevel: info
+     runc:
+       version: 1.2.4
++    sandboxImage: registry.k8s.io/pause:3.10.1
+     version: 1.7.25
+   dnsZone: "1"
+   etcdClusters:
+@@ -153,7 +154,6 @@ spec:
+     hairpinMode: promiscuous-bridge
+     kubeconfigPath: /var/lib/kubelet/kubeconfig
+     logLevel: 2
+-    podInfraContainerImage: registry.k8s.io/pause:3.9
+     podManifestPath: /etc/kubernetes/manifests
+     protectKernelDefaults: true
+     registerSchedulable: true
+@@ -175,7 +175,6 @@ spec:
+     hairpinMode: promiscuous-bridge
+     kubeconfigPath: /var/lib/kubelet/kubeconfig
+     logLevel: 2
+-    podInfraContainerImage: registry.k8s.io/pause:3.9
+     podManifestPath: /etc/kubernetes/manifests
+     protectKernelDefaults: true
+     registerSchedulable: true
+diff --git a/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_nodeupconfig-master-us-test1-a_content b/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_nodeupconfig-master-us-test1-a_content
+index 5454db6c55..86e4e1e727 100644
+--- a/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_nodeupconfig-master-us-test1-a_content
++++ b/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_nodeupconfig-master-us-test1-a_content
+@@ -295,7 +295,6 @@ KubeletConfig:
+     kops.k8s.io/kops-controller-pki: ""
+     node-role.kubernetes.io/control-plane: ""
+     node.kubernetes.io/exclude-from-external-load-balancers: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -317,6 +316,7 @@ containerdConfig:
+   logLevel: info
+   runc:
+     version: 1.2.4
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.7.25
+ etcdManifests:
+ - memfs://tests/minimal-gce.example.com/manifests/etcd/main-master-us-test1-a.yaml
+diff --git a/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_nodeupconfig-nodes_content b/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_nodeupconfig-nodes_content
+index c848ac787b..3cd9eeca4f 100644
+--- a/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_nodeupconfig-nodes_content
++++ b/tests/integration/update_cluster/minimal_gce/data/aws_s3_object_nodeupconfig-nodes_content
+@@ -46,7 +46,6 @@ KubeletConfig:
+   logLevel: 2
+   nodeLabels:
+     node-role.kubernetes.io/node: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -61,6 +60,7 @@ containerdConfig:
+   logLevel: info
+   runc:
+     version: 1.2.4
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.7.25
+ multizone: true
+ nodeTags: minimal-gce-example-com-k8s-io-role-node
+diff --git a/tests/integration/update_cluster/minimal_gce/data/google_compute_instance_template_master-us-test1-a-minimal-gce-example-com_metadata_user-data b/tests/integration/update_cluster/minimal_gce/data/google_compute_instance_template_master-us-test1-a-minimal-gce-example-com_metadata_user-data
+index e300081b14..1f8163147c 100644
+--- a/tests/integration/update_cluster/minimal_gce/data/google_compute_instance_template_master-us-test1-a-minimal-gce-example-com_metadata_user-data
++++ b/tests/integration/update_cluster/minimal_gce/data/google_compute_instance_template_master-us-test1-a-minimal-gce-example-com_metadata_user-data
+@@ -129,7 +129,7 @@ ClusterName: minimal-gce.example.com
+ ConfigBase: memfs://tests/minimal-gce.example.com
+ InstanceGroupName: master-us-test1-a
+ InstanceGroupRole: ControlPlane
+-NodeupConfigHash: MQyr9OkizulZn4IUyd+WXjqNTmwvUVqWTB5ICwzyujo=
++NodeupConfigHash: Q5xAF4+rODM8DtTjQxhkA/Z8vGklS7bh0CRY+SjY5vo=
+ 
+ __EOF_KUBE_ENV
+ 
+diff --git a/tests/integration/update_cluster/minimal_gce/data/google_compute_instance_template_nodes-minimal-gce-example-com_metadata_user-data b/tests/integration/update_cluster/minimal_gce/data/google_compute_instance_template_nodes-minimal-gce-example-com_metadata_user-data
+index 25b6d777b4..751d531547 100644
+--- a/tests/integration/update_cluster/minimal_gce/data/google_compute_instance_template_nodes-minimal-gce-example-com_metadata_user-data
++++ b/tests/integration/update_cluster/minimal_gce/data/google_compute_instance_template_nodes-minimal-gce-example-com_metadata_user-data
+@@ -152,7 +152,7 @@ ConfigServer:
+   - https://kops-controller.internal.minimal-gce.example.com:3988/
+ InstanceGroupName: nodes
+ InstanceGroupRole: Node
+-NodeupConfigHash: FachNdyRAsZFHgg0pUAm+WBdCr05oflKRFIQWZxwubE=
++NodeupConfigHash: AI4QtninqeS9fhk/I/4DCvsy9ElVqNxOTuTB9vwwgtU=
+ 
+ __EOF_KUBE_ENV
+ 
+diff --git a/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_cluster-completed.spec_content b/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_cluster-completed.spec_content
+index e284cb88f6..effb543805 100644
+--- a/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_cluster-completed.spec_content
++++ b/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_cluster-completed.spec_content
+@@ -36,6 +36,7 @@ spec:
+     logLevel: info
+     runc:
+       version: 1.2.4
++    sandboxImage: registry.k8s.io/pause:3.10.1
+     version: 1.7.25
+   etcdClusters:
+   - backups:
+@@ -153,7 +154,6 @@ spec:
+     hairpinMode: promiscuous-bridge
+     kubeconfigPath: /var/lib/kubelet/kubeconfig
+     logLevel: 2
+-    podInfraContainerImage: registry.k8s.io/pause:3.9
+     podManifestPath: /etc/kubernetes/manifests
+     protectKernelDefaults: true
+     registerSchedulable: true
+@@ -175,7 +175,6 @@ spec:
+     hairpinMode: promiscuous-bridge
+     kubeconfigPath: /var/lib/kubelet/kubeconfig
+     logLevel: 2
+-    podInfraContainerImage: registry.k8s.io/pause:3.9
+     podManifestPath: /etc/kubernetes/manifests
+     protectKernelDefaults: true
+     registerSchedulable: true
+diff --git a/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_nodeupconfig-master-us-test1-a_content b/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_nodeupconfig-master-us-test1-a_content
+index 1ef4f93435..03cbf7a379 100644
+--- a/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_nodeupconfig-master-us-test1-a_content
++++ b/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_nodeupconfig-master-us-test1-a_content
+@@ -295,7 +295,6 @@ KubeletConfig:
+     kops.k8s.io/kops-controller-pki: ""
+     node-role.kubernetes.io/control-plane: ""
+     node.kubernetes.io/exclude-from-external-load-balancers: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -317,6 +316,7 @@ containerdConfig:
+   logLevel: info
+   runc:
+     version: 1.2.4
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.7.25
+ etcdManifests:
+ - memfs://tests/minimal-gce.example.com/manifests/etcd/main-master-us-test1-a.yaml
+diff --git a/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_nodeupconfig-nodes_content b/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_nodeupconfig-nodes_content
+index 5c42807e28..7c62086394 100644
+--- a/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_nodeupconfig-nodes_content
++++ b/tests/integration/update_cluster/minimal_gce_dns-none/data/aws_s3_object_nodeupconfig-nodes_content
+@@ -46,7 +46,6 @@ KubeletConfig:
+   logLevel: 2
+   nodeLabels:
+     node-role.kubernetes.io/node: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -61,6 +60,7 @@ containerdConfig:
+   logLevel: info
+   runc:
+     version: 1.2.4
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.7.25
+ multizone: true
+ nodeTags: minimal-gce-example-com-k8s-io-role-node
+diff --git a/tests/integration/update_cluster/minimal_gce_dns-none/data/google_compute_instance_template_master-us-test1-a-minimal-gce-example-com_metadata_user-data b/tests/integration/update_cluster/minimal_gce_dns-none/data/google_compute_instance_template_master-us-test1-a-minimal-gce-example-com_metadata_user-data
+index 2d6c65b4bd..be8a80c2b0 100644
+--- a/tests/integration/update_cluster/minimal_gce_dns-none/data/google_compute_instance_template_master-us-test1-a-minimal-gce-example-com_metadata_user-data
++++ b/tests/integration/update_cluster/minimal_gce_dns-none/data/google_compute_instance_template_master-us-test1-a-minimal-gce-example-com_metadata_user-data
+@@ -129,7 +129,7 @@ ClusterName: minimal-gce.example.com
+ ConfigBase: memfs://tests/minimal-gce.example.com
+ InstanceGroupName: master-us-test1-a
+ InstanceGroupRole: ControlPlane
+-NodeupConfigHash: 6n5Kf5k3F75/9LJUC+qqhBvOR7qND4VjtsV58dphOuo=
++NodeupConfigHash: uEmwwc1iWO+bWNpKJWaeHrmDu/YYh+gqnoHgOdZSx2A=
+ 
+ __EOF_KUBE_ENV
+ 
+diff --git a/tests/integration/update_cluster/minimal_gce_dns-none/data/google_compute_instance_template_nodes-minimal-gce-example-com_metadata_user-data b/tests/integration/update_cluster/minimal_gce_dns-none/data/google_compute_instance_template_nodes-minimal-gce-example-com_metadata_user-data
+index a97143914d..2e2c5faf7c 100644
+--- a/tests/integration/update_cluster/minimal_gce_dns-none/data/google_compute_instance_template_nodes-minimal-gce-example-com_metadata_user-data
++++ b/tests/integration/update_cluster/minimal_gce_dns-none/data/google_compute_instance_template_nodes-minimal-gce-example-com_metadata_user-data
+@@ -152,7 +152,7 @@ ConfigServer:
+   - https://kops-controller.internal.minimal-gce.example.com:3988/
+ InstanceGroupName: nodes
+ InstanceGroupRole: Node
+-NodeupConfigHash: MS2MBEvNzuE8PUu/MfuvATdgK7HXOsW2XX6H/DKMLhY=
++NodeupConfigHash: yb6xFR6K6rSlYJ2o1g+OnjaYySi9YiRGlQiipBxXDSs=
+ 
+ __EOF_KUBE_ENV
+ 
+diff --git a/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_cluster-completed.spec_content b/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_cluster-completed.spec_content
+index 101627481c..02f80977e2 100644
+--- a/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_cluster-completed.spec_content
++++ b/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_cluster-completed.spec_content
+@@ -37,6 +37,7 @@ spec:
+     logLevel: info
+     runc:
+       version: 1.2.4
++    sandboxImage: registry.k8s.io/pause:3.10.1
+     version: 1.7.25
+   dnsZone: "1"
+   etcdClusters:
+@@ -157,7 +158,6 @@ spec:
+     hairpinMode: promiscuous-bridge
+     kubeconfigPath: /var/lib/kubelet/kubeconfig
+     logLevel: 2
+-    podInfraContainerImage: registry.k8s.io/pause:3.9
+     podManifestPath: /etc/kubernetes/manifests
+     protectKernelDefaults: true
+     registerSchedulable: true
+@@ -179,7 +179,6 @@ spec:
+     hairpinMode: promiscuous-bridge
+     kubeconfigPath: /var/lib/kubelet/kubeconfig
+     logLevel: 2
+-    podInfraContainerImage: registry.k8s.io/pause:3.9
+     podManifestPath: /etc/kubernetes/manifests
+     protectKernelDefaults: true
+     registerSchedulable: true
+diff --git a/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_nodeupconfig-master-us-test1-a_content b/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_nodeupconfig-master-us-test1-a_content
+index e59f2d49e9..e3c3682d68 100644
+--- a/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_nodeupconfig-master-us-test1-a_content
++++ b/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_nodeupconfig-master-us-test1-a_content
+@@ -296,7 +296,6 @@ KubeletConfig:
+     kops.k8s.io/kops-controller-pki: ""
+     node-role.kubernetes.io/control-plane: ""
+     node.kubernetes.io/exclude-from-external-load-balancers: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -318,6 +317,7 @@ containerdConfig:
+   logLevel: info
+   runc:
+     version: 1.2.4
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.7.25
+ etcdManifests:
+ - memfs://tests/minimal-gce-ilb.example.com/manifests/etcd/main-master-us-test1-a.yaml
+diff --git a/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_nodeupconfig-nodes_content b/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_nodeupconfig-nodes_content
+index 91d07f7459..0e442b1b33 100644
+--- a/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_nodeupconfig-nodes_content
++++ b/tests/integration/update_cluster/minimal_gce_ilb/data/aws_s3_object_nodeupconfig-nodes_content
+@@ -46,7 +46,6 @@ KubeletConfig:
+   logLevel: 2
+   nodeLabels:
+     node-role.kubernetes.io/node: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -61,6 +60,7 @@ containerdConfig:
+   logLevel: info
+   runc:
+     version: 1.2.4
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.7.25
+ multizone: true
+ nodeTags: minimal-gce-ilb-example-com-k8s-io-role-node
+diff --git a/tests/integration/update_cluster/minimal_gce_ilb/data/google_compute_instance_template_master-us-test1-a-minimal-gce-ilb-example-com_metadata_user-data b/tests/integration/update_cluster/minimal_gce_ilb/data/google_compute_instance_template_master-us-test1-a-minimal-gce-ilb-example-com_metadata_user-data
+index d024fae2c3..8ca51e6270 100644
+--- a/tests/integration/update_cluster/minimal_gce_ilb/data/google_compute_instance_template_master-us-test1-a-minimal-gce-ilb-example-com_metadata_user-data
++++ b/tests/integration/update_cluster/minimal_gce_ilb/data/google_compute_instance_template_master-us-test1-a-minimal-gce-ilb-example-com_metadata_user-data
+@@ -129,7 +129,7 @@ ClusterName: minimal-gce-ilb.example.com
+ ConfigBase: memfs://tests/minimal-gce-ilb.example.com
+ InstanceGroupName: master-us-test1-a
+ InstanceGroupRole: ControlPlane
+-NodeupConfigHash: ajK+CrYwSBwXOyH5y8ij/pZTIrSnRHvyTJ7HE4uKXYs=
++NodeupConfigHash: S9APuqqsyTSQWbg5rNkA/uWkNugPlspeJhmLsY7jZyA=
+ 
+ __EOF_KUBE_ENV
+ 
+diff --git a/tests/integration/update_cluster/minimal_gce_ilb/data/google_compute_instance_template_nodes-minimal-gce-ilb-example-com_metadata_user-data b/tests/integration/update_cluster/minimal_gce_ilb/data/google_compute_instance_template_nodes-minimal-gce-ilb-example-com_metadata_user-data
+index d895156cb8..04f21b5c00 100644
+--- a/tests/integration/update_cluster/minimal_gce_ilb/data/google_compute_instance_template_nodes-minimal-gce-ilb-example-com_metadata_user-data
++++ b/tests/integration/update_cluster/minimal_gce_ilb/data/google_compute_instance_template_nodes-minimal-gce-ilb-example-com_metadata_user-data
+@@ -152,7 +152,7 @@ ConfigServer:
+   - https://kops-controller.internal.minimal-gce-ilb.example.com:3988/
+ InstanceGroupName: nodes
+ InstanceGroupRole: Node
+-NodeupConfigHash: 0MYTLVqpNgDohTnmamH4tUTpoq4U17JwzoBkegcSxHM=
++NodeupConfigHash: bsqVEhY91c4r5bRHXpQJGn1cdPFnO6Dj/9mWmuWoVUE=
+ 
+ __EOF_KUBE_ENV
+ 
+diff --git a/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_cluster-completed.spec_content b/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_cluster-completed.spec_content
+index 680bdcf256..1f2f41d321 100644
+--- a/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_cluster-completed.spec_content
++++ b/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_cluster-completed.spec_content
+@@ -37,6 +37,7 @@ spec:
+     logLevel: info
+     runc:
+       version: 1.2.4
++    sandboxImage: registry.k8s.io/pause:3.10.1
+     version: 1.7.25
+   dnsZone: "1"
+   etcdClusters:
+@@ -157,7 +158,6 @@ spec:
+     hairpinMode: promiscuous-bridge
+     kubeconfigPath: /var/lib/kubelet/kubeconfig
+     logLevel: 2
+-    podInfraContainerImage: registry.k8s.io/pause:3.9
+     podManifestPath: /etc/kubernetes/manifests
+     protectKernelDefaults: true
+     registerSchedulable: true
+@@ -179,7 +179,6 @@ spec:
+     hairpinMode: promiscuous-bridge
+     kubeconfigPath: /var/lib/kubelet/kubeconfig
+     logLevel: 2
+-    podInfraContainerImage: registry.k8s.io/pause:3.9
+     podManifestPath: /etc/kubernetes/manifests
+     protectKernelDefaults: true
+     registerSchedulable: true
+diff --git a/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_nodeupconfig-master-us-test1-a_content b/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_nodeupconfig-master-us-test1-a_content
+index 2f252c5d4f..cf7cae115f 100644
+--- a/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_nodeupconfig-master-us-test1-a_content
++++ b/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_nodeupconfig-master-us-test1-a_content
+@@ -296,7 +296,6 @@ KubeletConfig:
+     kops.k8s.io/kops-controller-pki: ""
+     node-role.kubernetes.io/control-plane: ""
+     node.kubernetes.io/exclude-from-external-load-balancers: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -318,6 +317,7 @@ containerdConfig:
+   logLevel: info
+   runc:
+     version: 1.2.4
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.7.25
+ etcdManifests:
+ - memfs://tests/minimal-gce-with-a-very-very-very-very-very-long-name.example.com/manifests/etcd/main-master-us-test1-a.yaml
+diff --git a/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_nodeupconfig-nodes_content b/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_nodeupconfig-nodes_content
+index 01b46eb421..5698017231 100644
+--- a/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_nodeupconfig-nodes_content
++++ b/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/aws_s3_object_nodeupconfig-nodes_content
+@@ -46,7 +46,6 @@ KubeletConfig:
+   logLevel: 2
+   nodeLabels:
+     node-role.kubernetes.io/node: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -61,6 +60,7 @@ containerdConfig:
+   logLevel: info
+   runc:
+     version: 1.2.4
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.7.25
+ multizone: true
+ nodeTags: minimal-gce-with-a-very-very-very-very--96dqvi-k8s-io-role-node
+diff --git a/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/google_compute_instance_template_master-us-test1-a-minimal-gce-with-a-very-very-very-very-very-long-name-example-com_metadata_user-data b/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/google_compute_instance_template_master-us-test1-a-minimal-gce-with-a-very-very-very-very-very-long-name-example-com_metadata_user-data
+index 70de0b4eac..5de7cf6192 100644
+--- a/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/google_compute_instance_template_master-us-test1-a-minimal-gce-with-a-very-very-very-very-very-long-name-example-com_metadata_user-data
++++ b/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/google_compute_instance_template_master-us-test1-a-minimal-gce-with-a-very-very-very-very-very-long-name-example-com_metadata_user-data
+@@ -129,7 +129,7 @@ ClusterName: minimal-gce-with-a-very-very-very-very-very-long-name.example.com
+ ConfigBase: memfs://tests/minimal-gce-with-a-very-very-very-very-very-long-name.example.com
+ InstanceGroupName: master-us-test1-a
+ InstanceGroupRole: ControlPlane
+-NodeupConfigHash: ICLSTOs/byZwG4zlkhkHFzOQpTEF8vU2PYk/jHu4lZA=
++NodeupConfigHash: cSG44d3j84lPw+JQ1OVXJkEohbDQ+jrlpUgp5HV23JI=
+ 
+ __EOF_KUBE_ENV
+ 
+diff --git a/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/google_compute_instance_template_nodes-minimal-gce-with-a-very-very-very-very-very-long-name-example-com_metadata_user-data b/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/google_compute_instance_template_nodes-minimal-gce-with-a-very-very-very-very-very-long-name-example-com_metadata_user-data
+index 43e4c3477b..49e4032e1e 100644
+--- a/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/google_compute_instance_template_nodes-minimal-gce-with-a-very-very-very-very-very-long-name-example-com_metadata_user-data
++++ b/tests/integration/update_cluster/minimal_gce_ilb_longclustername/data/google_compute_instance_template_nodes-minimal-gce-with-a-very-very-very-very-very-long-name-example-com_metadata_user-data
+@@ -152,7 +152,7 @@ ConfigServer:
+   - https://kops-controller.internal.minimal-gce-with-a-very-very-very-very-very-long-name.example.com:3988/
+ InstanceGroupName: nodes
+ InstanceGroupRole: Node
+-NodeupConfigHash: vA+QLHHsYDx3EfCiX234K7GTLcN95y8bk/xsqJKWrN4=
++NodeupConfigHash: 0FQaT16lrWP3fzSTbc6IX1vbIj+gHJRsADFlXsuCUn0=
+ 
+ __EOF_KUBE_ENV
+ 
+diff --git a/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_cluster-completed.spec_content b/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_cluster-completed.spec_content
+index 8cf819ba03..ef5a65f321 100644
+--- a/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_cluster-completed.spec_content
++++ b/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_cluster-completed.spec_content
+@@ -34,6 +34,7 @@ spec:
+     logLevel: info
+     runc:
+       version: 1.2.4
++    sandboxImage: registry.k8s.io/pause:3.10.1
+     version: 1.7.25
+   dnsZone: "1"
+   etcdClusters:
+@@ -154,7 +155,6 @@ spec:
+     hairpinMode: promiscuous-bridge
+     kubeconfigPath: /var/lib/kubelet/kubeconfig
+     logLevel: 2
+-    podInfraContainerImage: registry.k8s.io/pause:3.9
+     podManifestPath: /etc/kubernetes/manifests
+     protectKernelDefaults: true
+     registerSchedulable: true
+@@ -176,7 +176,6 @@ spec:
+     hairpinMode: promiscuous-bridge
+     kubeconfigPath: /var/lib/kubelet/kubeconfig
+     logLevel: 2
+-    podInfraContainerImage: registry.k8s.io/pause:3.9
+     podManifestPath: /etc/kubernetes/manifests
+     protectKernelDefaults: true
+     registerSchedulable: true
+diff --git a/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_nodeupconfig-master-us-test1-a_content b/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_nodeupconfig-master-us-test1-a_content
+index 316585e322..89430272f9 100644
+--- a/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_nodeupconfig-master-us-test1-a_content
++++ b/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_nodeupconfig-master-us-test1-a_content
+@@ -295,7 +295,6 @@ KubeletConfig:
+     kops.k8s.io/kops-controller-pki: ""
+     node-role.kubernetes.io/control-plane: ""
+     node.kubernetes.io/exclude-from-external-load-balancers: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -317,6 +316,7 @@ containerdConfig:
+   logLevel: info
+   runc:
+     version: 1.2.4
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.7.25
+ etcdManifests:
+ - memfs://tests/minimal-gce-with-a-very-very-very-very-very-long-name.example.com/manifests/etcd/main-master-us-test1-a.yaml
+diff --git a/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_nodeupconfig-nodes_content b/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_nodeupconfig-nodes_content
+index 01b46eb421..5698017231 100644
+--- a/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_nodeupconfig-nodes_content
++++ b/tests/integration/update_cluster/minimal_gce_longclustername/data/aws_s3_object_nodeupconfig-nodes_content
+@@ -46,7 +46,6 @@ KubeletConfig:
+   logLevel: 2
+   nodeLabels:
+     node-role.kubernetes.io/node: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -61,6 +60,7 @@ containerdConfig:
+   logLevel: info
+   runc:
+     version: 1.2.4
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.7.25
+ multizone: true
+ nodeTags: minimal-gce-with-a-very-very-very-very--96dqvi-k8s-io-role-node
+diff --git a/tests/integration/update_cluster/minimal_gce_longclustername/data/google_compute_instance_template_master-us-test1-a-minimal-gce-with-a-very-very-very-very-very-long-name-example-com_metadata_startup-script b/tests/integration/update_cluster/minimal_gce_longclustername/data/google_compute_instance_template_master-us-test1-a-minimal-gce-with-a-very-very-very-very-very-long-name-example-com_metadata_startup-script
+index 8c5c66ea0c..4d861ec4ca 100644
+--- a/tests/integration/update_cluster/minimal_gce_longclustername/data/google_compute_instance_template_master-us-test1-a-minimal-gce-with-a-very-very-very-very-very-long-name-example-com_metadata_startup-script
++++ b/tests/integration/update_cluster/minimal_gce_longclustername/data/google_compute_instance_template_master-us-test1-a-minimal-gce-with-a-very-very-very-very-very-long-name-example-com_metadata_startup-script
+@@ -129,7 +129,7 @@ ClusterName: minimal-gce-with-a-very-very-very-very-very-long-name.example.com
+ ConfigBase: memfs://tests/minimal-gce-with-a-very-very-very-very-very-long-name.example.com
+ InstanceGroupName: master-us-test1-a
+ InstanceGroupRole: ControlPlane
+-NodeupConfigHash: bM6RbO/AJnRRy0MwsgZtY/DClZ5anpHLgLPMx4cLQqU=
++NodeupConfigHash: CWwrLmMcrwWqOTH7nwctrx0P6egiYmLLPityYbWWPq8=
+ 
+ __EOF_KUBE_ENV
+ 
+diff --git a/tests/integration/update_cluster/minimal_gce_longclustername/data/google_compute_instance_template_nodes-minimal-gce-with-a-very-very-very-very-very-long-name-example-com_metadata_startup-script b/tests/integration/update_cluster/minimal_gce_longclustername/data/google_compute_instance_template_nodes-minimal-gce-with-a-very-very-very-very-very-long-name-example-com_metadata_startup-script
+index 43e4c3477b..49e4032e1e 100644
+--- a/tests/integration/update_cluster/minimal_gce_longclustername/data/google_compute_instance_template_nodes-minimal-gce-with-a-very-very-very-very-very-long-name-example-com_metadata_startup-script
++++ b/tests/integration/update_cluster/minimal_gce_longclustername/data/google_compute_instance_template_nodes-minimal-gce-with-a-very-very-very-very-very-long-name-example-com_metadata_startup-script
+@@ -152,7 +152,7 @@ ConfigServer:
+   - https://kops-controller.internal.minimal-gce-with-a-very-very-very-very-very-long-name.example.com:3988/
+ InstanceGroupName: nodes
+ InstanceGroupRole: Node
+-NodeupConfigHash: vA+QLHHsYDx3EfCiX234K7GTLcN95y8bk/xsqJKWrN4=
++NodeupConfigHash: 0FQaT16lrWP3fzSTbc6IX1vbIj+gHJRsADFlXsuCUn0=
+ 
+ __EOF_KUBE_ENV
+ 
+diff --git a/tests/integration/update_cluster/minimal_gce_plb/data/aws_s3_object_cluster-completed.spec_content b/tests/integration/update_cluster/minimal_gce_plb/data/aws_s3_object_cluster-completed.spec_content
+index 21acf10386..520bb5ba13 100644
+--- a/tests/integration/update_cluster/minimal_gce_plb/data/aws_s3_object_cluster-completed.spec_content
++++ b/tests/integration/update_cluster/minimal_gce_plb/data/aws_s3_object_cluster-completed.spec_content
+@@ -37,6 +37,7 @@ spec:
+     logLevel: info
+     runc:
+       version: 1.2.4
++    sandboxImage: registry.k8s.io/pause:3.10.1
+     version: 1.7.25
+   dnsZone: "1"
+   etcdClusters:
+@@ -157,7 +158,6 @@ spec:
+     hairpinMode: promiscuous-bridge
+     kubeconfigPath: /var/lib/kubelet/kubeconfig
+     logLevel: 2
+-    podInfraContainerImage: registry.k8s.io/pause:3.9
+     podManifestPath: /etc/kubernetes/manifests
+     protectKernelDefaults: true
+     registerSchedulable: true
+@@ -179,7 +179,6 @@ spec:
+     hairpinMode: promiscuous-bridge
+     kubeconfigPath: /var/lib/kubelet/kubeconfig
+     logLevel: 2
+-    podInfraContainerImage: registry.k8s.io/pause:3.9
+     podManifestPath: /etc/kubernetes/manifests
+     protectKernelDefaults: true
+     registerSchedulable: true
+diff --git a/tests/integration/update_cluster/minimal_gce_plb/data/aws_s3_object_nodeupconfig-master-us-test1-a_content b/tests/integration/update_cluster/minimal_gce_plb/data/aws_s3_object_nodeupconfig-master-us-test1-a_content
+index ba1e120806..9a4d53c934 100644
+--- a/tests/integration/update_cluster/minimal_gce_plb/data/aws_s3_object_nodeupconfig-master-us-test1-a_content
++++ b/tests/integration/update_cluster/minimal_gce_plb/data/aws_s3_object_nodeupconfig-master-us-test1-a_content
+@@ -296,7 +296,6 @@ KubeletConfig:
+     kops.k8s.io/kops-controller-pki: ""
+     node-role.kubernetes.io/control-plane: ""
+     node.kubernetes.io/exclude-from-external-load-balancers: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -318,6 +317,7 @@ containerdConfig:
+   logLevel: info
+   runc:
+     version: 1.2.4
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.7.25
+ etcdManifests:
+ - memfs://tests/minimal-gce-plb.example.com/manifests/etcd/main-master-us-test1-a.yaml
+diff --git a/tests/integration/update_cluster/minimal_gce_plb/data/aws_s3_object_nodeupconfig-nodes_content b/tests/integration/update_cluster/minimal_gce_plb/data/aws_s3_object_nodeupconfig-nodes_content
+index c61fa52c46..0171ef1a69 100644
+--- a/tests/integration/update_cluster/minimal_gce_plb/data/aws_s3_object_nodeupconfig-nodes_content
++++ b/tests/integration/update_cluster/minimal_gce_plb/data/aws_s3_object_nodeupconfig-nodes_content
+@@ -46,7 +46,6 @@ KubeletConfig:
+   logLevel: 2
+   nodeLabels:
+     node-role.kubernetes.io/node: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -61,6 +60,7 @@ containerdConfig:
+   logLevel: info
+   runc:
+     version: 1.2.4
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.7.25
+ multizone: true
+ nodeTags: minimal-gce-plb-example-com-k8s-io-role-node
+diff --git a/tests/integration/update_cluster/minimal_gce_plb/data/google_compute_instance_template_master-us-test1-a-minimal-gce-plb-example-com_metadata_user-data b/tests/integration/update_cluster/minimal_gce_plb/data/google_compute_instance_template_master-us-test1-a-minimal-gce-plb-example-com_metadata_user-data
+index 254a19afd7..37fd1c5060 100644
+--- a/tests/integration/update_cluster/minimal_gce_plb/data/google_compute_instance_template_master-us-test1-a-minimal-gce-plb-example-com_metadata_user-data
++++ b/tests/integration/update_cluster/minimal_gce_plb/data/google_compute_instance_template_master-us-test1-a-minimal-gce-plb-example-com_metadata_user-data
+@@ -129,7 +129,7 @@ ClusterName: minimal-gce-plb.example.com
+ ConfigBase: memfs://tests/minimal-gce-plb.example.com
+ InstanceGroupName: master-us-test1-a
+ InstanceGroupRole: ControlPlane
+-NodeupConfigHash: Nxng6cHsMGRyi8CVEiRQh/mQNZF7xzUMiCtlKUyrfBI=
++NodeupConfigHash: 1NKMNPf2CBRNQBUiaupF6E7uAHKhWFBv+OMoh5Rxjo4=
+ 
+ __EOF_KUBE_ENV
+ 
+diff --git a/tests/integration/update_cluster/minimal_gce_plb/data/google_compute_instance_template_nodes-minimal-gce-plb-example-com_metadata_user-data b/tests/integration/update_cluster/minimal_gce_plb/data/google_compute_instance_template_nodes-minimal-gce-plb-example-com_metadata_user-data
+index e150390a68..dbf2f0b70a 100644
+--- a/tests/integration/update_cluster/minimal_gce_plb/data/google_compute_instance_template_nodes-minimal-gce-plb-example-com_metadata_user-data
++++ b/tests/integration/update_cluster/minimal_gce_plb/data/google_compute_instance_template_nodes-minimal-gce-plb-example-com_metadata_user-data
+@@ -152,7 +152,7 @@ ConfigServer:
+   - https://kops-controller.internal.minimal-gce-plb.example.com:3988/
+ InstanceGroupName: nodes
+ InstanceGroupRole: Node
+-NodeupConfigHash: HmjCFWoXm6NW1wMZOu/IOkmUIoVl9U6Y4IMvQobNrpI=
++NodeupConfigHash: +4wUN8GfGjBAResE3+K6G7Ud/aVU+wKX7mxxa2yeoBE=
+ 
+ __EOF_KUBE_ENV
+ 
+diff --git a/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_cluster-completed.spec_content b/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_cluster-completed.spec_content
+index 8b8b9a15bb..fc067cdc0a 100644
+--- a/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_cluster-completed.spec_content
++++ b/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_cluster-completed.spec_content
+@@ -33,6 +33,7 @@ spec:
+     logLevel: info
+     runc:
+       version: 1.2.4
++    sandboxImage: registry.k8s.io/pause:3.10.1
+     version: 1.7.25
+   dnsZone: "1"
+   etcdClusters:
+@@ -153,7 +154,6 @@ spec:
+     hairpinMode: promiscuous-bridge
+     kubeconfigPath: /var/lib/kubelet/kubeconfig
+     logLevel: 2
+-    podInfraContainerImage: registry.k8s.io/pause:3.9
+     podManifestPath: /etc/kubernetes/manifests
+     protectKernelDefaults: true
+     registerSchedulable: true
+@@ -175,7 +175,6 @@ spec:
+     hairpinMode: promiscuous-bridge
+     kubeconfigPath: /var/lib/kubelet/kubeconfig
+     logLevel: 2
+-    podInfraContainerImage: registry.k8s.io/pause:3.9
+     podManifestPath: /etc/kubernetes/manifests
+     protectKernelDefaults: true
+     registerSchedulable: true
+diff --git a/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_nodeupconfig-master-us-test1-a_content b/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_nodeupconfig-master-us-test1-a_content
+index 9ed39d80e2..bc333ca796 100644
+--- a/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_nodeupconfig-master-us-test1-a_content
++++ b/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_nodeupconfig-master-us-test1-a_content
+@@ -295,7 +295,6 @@ KubeletConfig:
+     kops.k8s.io/kops-controller-pki: ""
+     node-role.kubernetes.io/control-plane: ""
+     node.kubernetes.io/exclude-from-external-load-balancers: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -317,6 +316,7 @@ containerdConfig:
+   logLevel: info
+   runc:
+     version: 1.2.4
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.7.25
+ etcdManifests:
+ - memfs://tests/minimal-gce-private.example.com/manifests/etcd/main-master-us-test1-a.yaml
+diff --git a/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_nodeupconfig-nodes_content b/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_nodeupconfig-nodes_content
+index f6934c6748..ab40c88298 100644
+--- a/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_nodeupconfig-nodes_content
++++ b/tests/integration/update_cluster/minimal_gce_private/data/aws_s3_object_nodeupconfig-nodes_content
+@@ -46,7 +46,6 @@ KubeletConfig:
+   logLevel: 2
+   nodeLabels:
+     node-role.kubernetes.io/node: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -61,6 +60,7 @@ containerdConfig:
+   logLevel: info
+   runc:
+     version: 1.2.4
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.7.25
+ multizone: true
+ nodeTags: minimal-gce-private-example-com-k8s-io-role-node
+diff --git a/tests/integration/update_cluster/minimal_gce_private/data/google_compute_instance_template_master-us-test1-a-minimal-gce-private-example-com_metadata_user-data b/tests/integration/update_cluster/minimal_gce_private/data/google_compute_instance_template_master-us-test1-a-minimal-gce-private-example-com_metadata_user-data
+index 1f671a3aab..6ee4c284af 100644
+--- a/tests/integration/update_cluster/minimal_gce_private/data/google_compute_instance_template_master-us-test1-a-minimal-gce-private-example-com_metadata_user-data
++++ b/tests/integration/update_cluster/minimal_gce_private/data/google_compute_instance_template_master-us-test1-a-minimal-gce-private-example-com_metadata_user-data
+@@ -129,7 +129,7 @@ ClusterName: minimal-gce-private.example.com
+ ConfigBase: memfs://tests/minimal-gce-private.example.com
+ InstanceGroupName: master-us-test1-a
+ InstanceGroupRole: ControlPlane
+-NodeupConfigHash: jAnt2SDcq3dmaAGNWXaGaNyK6pPy6Qgh02MAIvlT2WA=
++NodeupConfigHash: 8nyk8cjypla/J6OMzJYS0gXHqUng7mBD25iBwSnLSnk=
+ 
+ __EOF_KUBE_ENV
+ 
+diff --git a/tests/integration/update_cluster/minimal_gce_private/data/google_compute_instance_template_nodes-minimal-gce-private-example-com_metadata_user-data b/tests/integration/update_cluster/minimal_gce_private/data/google_compute_instance_template_nodes-minimal-gce-private-example-com_metadata_user-data
+index 9690560e38..1f27f6f221 100644
+--- a/tests/integration/update_cluster/minimal_gce_private/data/google_compute_instance_template_nodes-minimal-gce-private-example-com_metadata_user-data
++++ b/tests/integration/update_cluster/minimal_gce_private/data/google_compute_instance_template_nodes-minimal-gce-private-example-com_metadata_user-data
+@@ -152,7 +152,7 @@ ConfigServer:
+   - https://kops-controller.internal.minimal-gce-private.example.com:3988/
+ InstanceGroupName: nodes
+ InstanceGroupRole: Node
+-NodeupConfigHash: ux02fYsmv+extym0Z61HA8H+e0Xvi9cD37IVSkB20Og=
++NodeupConfigHash: GIZjNa+qJjCOffv7ESBMzm0QYwWdCtbqCF44zInUnD8=
+ 
+ __EOF_KUBE_ENV
+ 
+diff --git a/tests/integration/update_cluster/minimal_gossip/data/aws_launch_template_master-us-test-1a.masters.minimal.k8s.local_user_data b/tests/integration/update_cluster/minimal_gossip/data/aws_launch_template_master-us-test-1a.masters.minimal.k8s.local_user_data
+index 44b0f304e1..44f887a11a 100644
+--- a/tests/integration/update_cluster/minimal_gossip/data/aws_launch_template_master-us-test-1a.masters.minimal.k8s.local_user_data
++++ b/tests/integration/update_cluster/minimal_gossip/data/aws_launch_template_master-us-test-1a.masters.minimal.k8s.local_user_data
+@@ -130,7 +130,7 @@ ClusterName: minimal.k8s.local
+ ConfigBase: memfs://clusters.example.com/minimal.k8s.local
+ InstanceGroupName: master-us-test-1a
+ InstanceGroupRole: ControlPlane
+-NodeupConfigHash: FIzAmdrBWCqKyk9wL30kxdFoLkUEPxK902npHXQASmI=
++NodeupConfigHash: 9PULlz/iyM/V7PiuolcSWA32Jvk0C9b+R8gbzdNnZDU=
+ 
+ __EOF_KUBE_ENV
+ 
+diff --git a/tests/integration/update_cluster/minimal_gossip/data/aws_launch_template_nodes.minimal.k8s.local_user_data b/tests/integration/update_cluster/minimal_gossip/data/aws_launch_template_nodes.minimal.k8s.local_user_data
+index c46b861a52..e55084fe2c 100644
+--- a/tests/integration/update_cluster/minimal_gossip/data/aws_launch_template_nodes.minimal.k8s.local_user_data
++++ b/tests/integration/update_cluster/minimal_gossip/data/aws_launch_template_nodes.minimal.k8s.local_user_data
+@@ -130,7 +130,7 @@ ClusterName: minimal.k8s.local
+ ConfigBase: memfs://clusters.example.com/minimal.k8s.local
+ InstanceGroupName: nodes
+ InstanceGroupRole: Node
+-NodeupConfigHash: BK9ONlmKUzrmpsxoFmbfxS/FAIdvYJ4T7d52iC3GsBI=
++NodeupConfigHash: KjL1fif9P08hrKcCHNQvnb5sNHZ42+hk9+v1I2a+nGA=
+ 
+ __EOF_KUBE_ENV
+ 
+diff --git a/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_cluster-completed.spec_content b/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_cluster-completed.spec_content
+index 1fa1f6cab6..668303b437 100644
+--- a/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_cluster-completed.spec_content
++++ b/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_cluster-completed.spec_content
+@@ -28,6 +28,7 @@ spec:
+     logLevel: info
+     runc:
+       version: 1.2.4
++    sandboxImage: registry.k8s.io/pause:3.10.1
+     version: 1.7.25
+   etcdClusters:
+   - backups:
+@@ -142,7 +143,6 @@ spec:
+     evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
+     kubeconfigPath: /var/lib/kubelet/kubeconfig
+     logLevel: 2
+-    podInfraContainerImage: registry.k8s.io/pause:3.9
+     podManifestPath: /etc/kubernetes/manifests
+     protectKernelDefaults: true
+     registerSchedulable: true
+@@ -162,7 +162,6 @@ spec:
+     evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
+     kubeconfigPath: /var/lib/kubelet/kubeconfig
+     logLevel: 2
+-    podInfraContainerImage: registry.k8s.io/pause:3.9
+     podManifestPath: /etc/kubernetes/manifests
+     protectKernelDefaults: true
+     registerSchedulable: true
+diff --git a/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_nodeupconfig-master-us-test-1a_content b/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+index fadef65d6d..25a6ccc74a 100644
+--- a/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
++++ b/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+@@ -291,7 +291,6 @@ KubeletConfig:
+     kops.k8s.io/kops-controller-pki: ""
+     node-role.kubernetes.io/control-plane: ""
+     node.kubernetes.io/exclude-from-external-load-balancers: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -313,6 +312,7 @@ containerdConfig:
+   logLevel: info
+   runc:
+     version: 1.2.4
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.7.25
+ etcdManifests:
+ - memfs://clusters.example.com/minimal.k8s.local/manifests/etcd/main-master-us-test-1a.yaml
+diff --git a/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_nodeupconfig-nodes_content b/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_nodeupconfig-nodes_content
+index 88c2bf0d61..1b5e2e1b59 100644
+--- a/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_nodeupconfig-nodes_content
++++ b/tests/integration/update_cluster/minimal_gossip/data/aws_s3_object_nodeupconfig-nodes_content
+@@ -68,7 +68,6 @@ KubeletConfig:
+   logLevel: 2
+   nodeLabels:
+     node-role.kubernetes.io/node: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -88,6 +87,7 @@ containerdConfig:
+   logLevel: info
+   runc:
+     version: 1.2.4
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.7.25
+ usesLegacyGossip: true
+ usesNoneDNS: false
+diff --git a/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_launch_template_master-us-test-1a.masters.minimal.k8s.local_user_data b/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_launch_template_master-us-test-1a.masters.minimal.k8s.local_user_data
+index 1d254dc5a3..4ff52b3fb6 100644
+--- a/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_launch_template_master-us-test-1a.masters.minimal.k8s.local_user_data
++++ b/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_launch_template_master-us-test-1a.masters.minimal.k8s.local_user_data
+@@ -130,7 +130,7 @@ ClusterName: minimal.k8s.local
+ ConfigBase: memfs://clusters.example.com/minimal.k8s.local
+ InstanceGroupName: master-us-test-1a
+ InstanceGroupRole: ControlPlane
+-NodeupConfigHash: K+iqNxfwReNnVnLF1h/wpAgHS4OZS4BiL4OulUkOrNA=
++NodeupConfigHash: 9GKLVmV1SJaeHQSt1DNpNr6hceFGm5ED/rPzC2bM5tY=
+ 
+ __EOF_KUBE_ENV
+ 
+diff --git a/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_launch_template_nodes.minimal.k8s.local_user_data b/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_launch_template_nodes.minimal.k8s.local_user_data
+index c46b861a52..e55084fe2c 100644
+--- a/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_launch_template_nodes.minimal.k8s.local_user_data
++++ b/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_launch_template_nodes.minimal.k8s.local_user_data
+@@ -130,7 +130,7 @@ ClusterName: minimal.k8s.local
+ ConfigBase: memfs://clusters.example.com/minimal.k8s.local
+ InstanceGroupName: nodes
+ InstanceGroupRole: Node
+-NodeupConfigHash: BK9ONlmKUzrmpsxoFmbfxS/FAIdvYJ4T7d52iC3GsBI=
++NodeupConfigHash: KjL1fif9P08hrKcCHNQvnb5sNHZ42+hk9+v1I2a+nGA=
+ 
+ __EOF_KUBE_ENV
+ 
+diff --git a/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_cluster-completed.spec_content b/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_cluster-completed.spec_content
+index 811b6328c2..c6661aa014 100644
+--- a/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_cluster-completed.spec_content
++++ b/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_cluster-completed.spec_content
+@@ -28,6 +28,7 @@ spec:
+     logLevel: info
+     runc:
+       version: 1.2.4
++    sandboxImage: registry.k8s.io/pause:3.10.1
+     version: 1.7.25
+   etcdClusters:
+   - backups:
+@@ -143,7 +144,6 @@ spec:
+     evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
+     kubeconfigPath: /var/lib/kubelet/kubeconfig
+     logLevel: 2
+-    podInfraContainerImage: registry.k8s.io/pause:3.9
+     podManifestPath: /etc/kubernetes/manifests
+     protectKernelDefaults: true
+     registerSchedulable: true
+@@ -163,7 +163,6 @@ spec:
+     evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
+     kubeconfigPath: /var/lib/kubelet/kubeconfig
+     logLevel: 2
+-    podInfraContainerImage: registry.k8s.io/pause:3.9
+     podManifestPath: /etc/kubernetes/manifests
+     protectKernelDefaults: true
+     registerSchedulable: true
+diff --git a/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_nodeupconfig-master-us-test-1a_content b/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+index 3f2c5a0fda..633e172041 100644
+--- a/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
++++ b/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+@@ -291,7 +291,6 @@ KubeletConfig:
+     kops.k8s.io/kops-controller-pki: ""
+     node-role.kubernetes.io/control-plane: ""
+     node.kubernetes.io/exclude-from-external-load-balancers: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -313,6 +312,7 @@ containerdConfig:
+   logLevel: info
+   runc:
+     version: 1.2.4
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.7.25
+ etcdManifests:
+ - memfs://clusters.example.com/minimal.k8s.local/manifests/etcd/main-master-us-test-1a.yaml
+diff --git a/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_nodeupconfig-nodes_content b/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_nodeupconfig-nodes_content
+index 88c2bf0d61..1b5e2e1b59 100644
+--- a/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_nodeupconfig-nodes_content
++++ b/tests/integration/update_cluster/minimal_gossip_irsa/data/aws_s3_object_nodeupconfig-nodes_content
+@@ -68,7 +68,6 @@ KubeletConfig:
+   logLevel: 2
+   nodeLabels:
+     node-role.kubernetes.io/node: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -88,6 +87,7 @@ containerdConfig:
+   logLevel: info
+   runc:
+     version: 1.2.4
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.7.25
+ usesLegacyGossip: true
+ usesNoneDNS: false
+diff --git a/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_cluster-completed.spec_content b/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_cluster-completed.spec_content
+index 0423e5f47c..3f34c006ce 100644
+--- a/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_cluster-completed.spec_content
++++ b/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_cluster-completed.spec_content
+@@ -28,6 +28,7 @@ spec:
+     logLevel: info
+     runc:
+       version: 1.2.4
++    sandboxImage: registry.k8s.io/pause:3.10.1
+     version: 1.7.25
+   etcdClusters:
+   - backups:
+@@ -145,7 +146,6 @@ spec:
+     evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
+     kubeconfigPath: /var/lib/kubelet/kubeconfig
+     logLevel: 2
+-    podInfraContainerImage: registry.k8s.io/pause:3.9
+     podManifestPath: /etc/kubernetes/manifests
+     protectKernelDefaults: true
+     registerSchedulable: true
+@@ -166,7 +166,6 @@ spec:
+     evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
+     kubeconfigPath: /var/lib/kubelet/kubeconfig
+     logLevel: 2
+-    podInfraContainerImage: registry.k8s.io/pause:3.9
+     podManifestPath: /etc/kubernetes/manifests
+     protectKernelDefaults: true
+     registerSchedulable: true
+diff --git a/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_nodeupconfig-master-fsn1_content b/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_nodeupconfig-master-fsn1_content
+index 606a26733d..d6ed166911 100644
+--- a/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_nodeupconfig-master-fsn1_content
++++ b/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_nodeupconfig-master-fsn1_content
+@@ -287,7 +287,6 @@ KubeletConfig:
+     kops.k8s.io/kops-controller-pki: ""
+     node-role.kubernetes.io/control-plane: ""
+     node.kubernetes.io/exclude-from-external-load-balancers: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -309,6 +308,7 @@ containerdConfig:
+   logLevel: info
+   runc:
+     version: 1.2.4
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.7.25
+ etcdManifests:
+ - memfs://tests/minimal.example.com/manifests/etcd/main-master-fsn1.yaml
+diff --git a/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_nodeupconfig-nodes-fsn1_content b/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_nodeupconfig-nodes-fsn1_content
+index f752e21e24..2b6c180ab9 100644
+--- a/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_nodeupconfig-nodes-fsn1_content
++++ b/tests/integration/update_cluster/minimal_hetzner/data/aws_s3_object_nodeupconfig-nodes-fsn1_content
+@@ -41,7 +41,6 @@ KubeletConfig:
+   logLevel: 2
+   nodeLabels:
+     node-role.kubernetes.io/node: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -56,6 +55,7 @@ containerdConfig:
+   logLevel: info
+   runc:
+     version: 1.2.4
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.7.25
+ usesLegacyGossip: false
+ usesNoneDNS: true
+diff --git a/tests/integration/update_cluster/minimal_hetzner/data/hcloud_server_master-fsn1_user_data b/tests/integration/update_cluster/minimal_hetzner/data/hcloud_server_master-fsn1_user_data
+index c5bd702348..d68ea9715a 100644
+--- a/tests/integration/update_cluster/minimal_hetzner/data/hcloud_server_master-fsn1_user_data
++++ b/tests/integration/update_cluster/minimal_hetzner/data/hcloud_server_master-fsn1_user_data
+@@ -130,7 +130,7 @@ ClusterName: minimal.example.com
+ ConfigBase: memfs://tests/minimal.example.com
+ InstanceGroupName: master-fsn1
+ InstanceGroupRole: ControlPlane
+-NodeupConfigHash: I4IMHy+hHHrlMnK9KoAxM8g8N6PBH2fMdghdRio+KTI=
++NodeupConfigHash: erIJvYAWyZU2mp57oFohQA457IlgtLYIUqz/xBgAHAw=
+ 
+ __EOF_KUBE_ENV
+ 
+diff --git a/tests/integration/update_cluster/minimal_hetzner/data/hcloud_server_nodes-fsn1_user_data b/tests/integration/update_cluster/minimal_hetzner/data/hcloud_server_nodes-fsn1_user_data
+index 891d78f1a6..ec54db6f1b 100644
+--- a/tests/integration/update_cluster/minimal_hetzner/data/hcloud_server_nodes-fsn1_user_data
++++ b/tests/integration/update_cluster/minimal_hetzner/data/hcloud_server_nodes-fsn1_user_data
+@@ -152,7 +152,7 @@ ConfigServer:
+   - https://kops-controller.internal.minimal.example.com:3988/
+ InstanceGroupName: nodes-fsn1
+ InstanceGroupRole: Node
+-NodeupConfigHash: hN9esvQunRMdWmroF9A824FWnaT4lcFVbkWiZcLaKoE=
++NodeupConfigHash: uIvFqn/i9NsptAoMnV1VmP4DOSXnJF5P7FyFewjJ/rg=
+ 
+ __EOF_KUBE_ENV
+ 
+diff --git a/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_cluster-completed.spec_content b/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_cluster-completed.spec_content
+index 9b3c37f093..2d3fee914c 100644
+--- a/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_cluster-completed.spec_content
++++ b/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_cluster-completed.spec_content
+@@ -19,6 +19,7 @@ spec:
+     logLevel: info
+     runc:
+       version: 1.2.4
++    sandboxImage: registry.k8s.io/pause:3.10.1
+     version: 1.7.25
+   etcdClusters:
+   - backups:
+@@ -139,7 +140,6 @@ spec:
+     evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
+     kubeconfigPath: /var/lib/kubelet/kubeconfig
+     logLevel: 2
+-    podInfraContainerImage: registry.k8s.io/pause:3.9
+     podManifestPath: /etc/kubernetes/manifests
+     protectKernelDefaults: true
+     registerSchedulable: true
+@@ -160,7 +160,6 @@ spec:
+     evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
+     kubeconfigPath: /var/lib/kubelet/kubeconfig
+     logLevel: 2
+-    podInfraContainerImage: registry.k8s.io/pause:3.9
+     podManifestPath: /etc/kubernetes/manifests
+     protectKernelDefaults: true
+     registerSchedulable: true
+diff --git a/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_nodeupconfig-control-plane-fr-par-1_content b/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_nodeupconfig-control-plane-fr-par-1_content
+index b00646afd7..99f99d968b 100644
+--- a/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_nodeupconfig-control-plane-fr-par-1_content
++++ b/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_nodeupconfig-control-plane-fr-par-1_content
+@@ -280,7 +280,6 @@ KubeletConfig:
+     kops.k8s.io/kops-controller-pki: ""
+     node-role.kubernetes.io/control-plane: ""
+     node.kubernetes.io/exclude-from-external-load-balancers: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -303,6 +302,7 @@ containerdConfig:
+   logLevel: info
+   runc:
+     version: 1.2.4
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.7.25
+ etcdManifests:
+ - memfs://tests/scw-minimal.k8s.local/manifests/etcd/main-control-plane-fr-par-1.yaml
+diff --git a/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_nodeupconfig-nodes-fr-par-1_content b/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_nodeupconfig-nodes-fr-par-1_content
+index 281b98fd46..b92ffb4571 100644
+--- a/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_nodeupconfig-nodes-fr-par-1_content
++++ b/tests/integration/update_cluster/minimal_scaleway/data/aws_s3_object_nodeupconfig-nodes-fr-par-1_content
+@@ -38,7 +38,6 @@ KubeletConfig:
+   logLevel: 2
+   nodeLabels:
+     node-role.kubernetes.io/node: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -56,6 +55,7 @@ containerdConfig:
+   logLevel: info
+   runc:
+     version: 1.2.4
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.7.25
+ usesLegacyGossip: true
+ usesNoneDNS: false
+diff --git a/tests/integration/update_cluster/minimal_scaleway/data/scaleway_instance_server_control-plane-fr-par-1-0_user_data b/tests/integration/update_cluster/minimal_scaleway/data/scaleway_instance_server_control-plane-fr-par-1-0_user_data
+index 0627f6bc5c..5e5429b8be 100644
+--- a/tests/integration/update_cluster/minimal_scaleway/data/scaleway_instance_server_control-plane-fr-par-1-0_user_data
++++ b/tests/integration/update_cluster/minimal_scaleway/data/scaleway_instance_server_control-plane-fr-par-1-0_user_data
+@@ -132,7 +132,7 @@ ClusterName: scw-minimal.k8s.local
+ ConfigBase: memfs://tests/scw-minimal.k8s.local
+ InstanceGroupName: control-plane-fr-par-1
+ InstanceGroupRole: ControlPlane
+-NodeupConfigHash: Cvh4OMb1R+HjXuXQpPKC4VXUkGgPGrc2VcMYrqpqyE4=
++NodeupConfigHash: WgbfDL//k7bKmDRL0eDRIN0Rj93Q5VqxJ04+Sf9TNuU=
+ 
+ __EOF_KUBE_ENV
+ 
+diff --git a/tests/integration/update_cluster/minimal_scaleway/data/scaleway_instance_server_nodes-fr-par-1-0_user_data b/tests/integration/update_cluster/minimal_scaleway/data/scaleway_instance_server_nodes-fr-par-1-0_user_data
+index 221d37a21c..8f830e8925 100644
+--- a/tests/integration/update_cluster/minimal_scaleway/data/scaleway_instance_server_nodes-fr-par-1-0_user_data
++++ b/tests/integration/update_cluster/minimal_scaleway/data/scaleway_instance_server_nodes-fr-par-1-0_user_data
+@@ -155,7 +155,7 @@ ConfigServer:
+   - https://kops-controller.internal.scw-minimal.k8s.local:3988/
+ InstanceGroupName: nodes-fr-par-1
+ InstanceGroupRole: Node
+-NodeupConfigHash: 541VNZJglUWeo/loOOSV8FJF0AqvnYxh9/rJvQfQZfg=
++NodeupConfigHash: I60+2SWGejHtqGIEJVD488Xkol5btpVRhnctn7iN+PM=
+ 
+ __EOF_KUBE_ENV
+ 
+diff --git a/tests/integration/update_cluster/mixed_instances/data/aws_launch_template_master-us-test-1a.masters.mixedinstances.example.com_user_data b/tests/integration/update_cluster/mixed_instances/data/aws_launch_template_master-us-test-1a.masters.mixedinstances.example.com_user_data
+index 4298f69152..38d446d689 100644
+--- a/tests/integration/update_cluster/mixed_instances/data/aws_launch_template_master-us-test-1a.masters.mixedinstances.example.com_user_data
++++ b/tests/integration/update_cluster/mixed_instances/data/aws_launch_template_master-us-test-1a.masters.mixedinstances.example.com_user_data
+@@ -130,7 +130,7 @@ ClusterName: mixedinstances.example.com
+ ConfigBase: memfs://clusters.example.com/mixedinstances.example.com
+ InstanceGroupName: master-us-test-1a
+ InstanceGroupRole: ControlPlane
+-NodeupConfigHash: QmN7LE7VnkjU+GUmFdLQRBr/h+Pf+MruP1CfNte8WoQ=
++NodeupConfigHash: DacPgRQHknYSd/mCwgt+EJP/W9wekobUhg8y/9U5gsU=
+ 
+ __EOF_KUBE_ENV
+ 
+diff --git a/tests/integration/update_cluster/mixed_instances/data/aws_launch_template_master-us-test-1b.masters.mixedinstances.example.com_user_data b/tests/integration/update_cluster/mixed_instances/data/aws_launch_template_master-us-test-1b.masters.mixedinstances.example.com_user_data
+index 4dbfeb3cfd..50bc5ce9cc 100644
+--- a/tests/integration/update_cluster/mixed_instances/data/aws_launch_template_master-us-test-1b.masters.mixedinstances.example.com_user_data
++++ b/tests/integration/update_cluster/mixed_instances/data/aws_launch_template_master-us-test-1b.masters.mixedinstances.example.com_user_data
+@@ -130,7 +130,7 @@ ClusterName: mixedinstances.example.com
+ ConfigBase: memfs://clusters.example.com/mixedinstances.example.com
+ InstanceGroupName: master-us-test-1b
+ InstanceGroupRole: ControlPlane
+-NodeupConfigHash: 3p7ErmXWWW4Db4nDcRXHdMW0iEms20vgAJpC6Yu8KW0=
++NodeupConfigHash: VWnw+Awp2AQxhCZDPEeyYt2Cc+KI30ZioKfNcxuX8io=
+ 
+ __EOF_KUBE_ENV
+ 
+diff --git a/tests/integration/update_cluster/mixed_instances/data/aws_launch_template_master-us-test-1c.masters.mixedinstances.example.com_user_data b/tests/integration/update_cluster/mixed_instances/data/aws_launch_template_master-us-test-1c.masters.mixedinstances.example.com_user_data
+index 710c556e74..dc383e776d 100644
+--- a/tests/integration/update_cluster/mixed_instances/data/aws_launch_template_master-us-test-1c.masters.mixedinstances.example.com_user_data
++++ b/tests/integration/update_cluster/mixed_instances/data/aws_launch_template_master-us-test-1c.masters.mixedinstances.example.com_user_data
+@@ -130,7 +130,7 @@ ClusterName: mixedinstances.example.com
+ ConfigBase: memfs://clusters.example.com/mixedinstances.example.com
+ InstanceGroupName: master-us-test-1c
+ InstanceGroupRole: ControlPlane
+-NodeupConfigHash: gRz7sVhHpzWTZKt8nHKK3ygm45IwfL8mHDdF7TPFDOA=
++NodeupConfigHash: mBkVjhe/6p7QlkcpGD+0AaNeRf22kVpqgAVWLobgij0=
+ 
+ __EOF_KUBE_ENV
+ 
+diff --git a/tests/integration/update_cluster/mixed_instances/data/aws_launch_template_nodes.mixedinstances.example.com_user_data b/tests/integration/update_cluster/mixed_instances/data/aws_launch_template_nodes.mixedinstances.example.com_user_data
+index b9d83b6d36..3ef83e0a19 100644
+--- a/tests/integration/update_cluster/mixed_instances/data/aws_launch_template_nodes.mixedinstances.example.com_user_data
++++ b/tests/integration/update_cluster/mixed_instances/data/aws_launch_template_nodes.mixedinstances.example.com_user_data
+@@ -153,7 +153,7 @@ ConfigServer:
+   - https://kops-controller.internal.mixedinstances.example.com:3988/
+ InstanceGroupName: nodes
+ InstanceGroupRole: Node
+-NodeupConfigHash: gP4iMij3RObbcYQX8D1yTh/X851gaWHWN6ABDAbCA8I=
++NodeupConfigHash: H1R6ZZQVLmxLfbvBXhiD9RigXcaDvlTD9+rwsc48gQQ=
+ 
+ __EOF_KUBE_ENV
+ 
+diff --git a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_cluster-completed.spec_content b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_cluster-completed.spec_content
+index dc8b6aacbf..c64349a711 100644
+--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_cluster-completed.spec_content
++++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_cluster-completed.spec_content
+@@ -28,6 +28,7 @@ spec:
+     logLevel: info
+     runc:
+       version: 1.2.4
++    sandboxImage: registry.k8s.io/pause:3.10.1
+     version: 1.7.25
+   dnsZone: Z1AFAKE1ZON3YO
+   etcdClusters:
+@@ -151,7 +152,6 @@ spec:
+     evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
+     kubeconfigPath: /var/lib/kubelet/kubeconfig
+     logLevel: 2
+-    podInfraContainerImage: registry.k8s.io/pause:3.9
+     podManifestPath: /etc/kubernetes/manifests
+     protectKernelDefaults: true
+     registerSchedulable: true
+@@ -171,7 +171,6 @@ spec:
+     evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
+     kubeconfigPath: /var/lib/kubelet/kubeconfig
+     logLevel: 2
+-    podInfraContainerImage: registry.k8s.io/pause:3.9
+     podManifestPath: /etc/kubernetes/manifests
+     protectKernelDefaults: true
+     registerSchedulable: true
+diff --git a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_nodeupconfig-master-us-test-1a_content b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+index 00a67b2bb2..e705751755 100644
+--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
++++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+@@ -292,7 +292,6 @@ KubeletConfig:
+     kops.k8s.io/kops-controller-pki: ""
+     node-role.kubernetes.io/control-plane: ""
+     node.kubernetes.io/exclude-from-external-load-balancers: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -314,6 +313,7 @@ containerdConfig:
+   logLevel: info
+   runc:
+     version: 1.2.4
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.7.25
+ etcdManifests:
+ - memfs://clusters.example.com/mixedinstances.example.com/manifests/etcd/main-master-us-test-1a.yaml
+diff --git a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_nodeupconfig-master-us-test-1b_content b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_nodeupconfig-master-us-test-1b_content
+index 952484ccb7..be4c386ac7 100644
+--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_nodeupconfig-master-us-test-1b_content
++++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_nodeupconfig-master-us-test-1b_content
+@@ -292,7 +292,6 @@ KubeletConfig:
+     kops.k8s.io/kops-controller-pki: ""
+     node-role.kubernetes.io/control-plane: ""
+     node.kubernetes.io/exclude-from-external-load-balancers: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -314,6 +313,7 @@ containerdConfig:
+   logLevel: info
+   runc:
+     version: 1.2.4
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.7.25
+ etcdManifests:
+ - memfs://clusters.example.com/mixedinstances.example.com/manifests/etcd/main-master-us-test-1b.yaml
+diff --git a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_nodeupconfig-master-us-test-1c_content b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_nodeupconfig-master-us-test-1c_content
+index 76da76999d..a8a056bbbc 100644
+--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_nodeupconfig-master-us-test-1c_content
++++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_nodeupconfig-master-us-test-1c_content
+@@ -292,7 +292,6 @@ KubeletConfig:
+     kops.k8s.io/kops-controller-pki: ""
+     node-role.kubernetes.io/control-plane: ""
+     node.kubernetes.io/exclude-from-external-load-balancers: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -314,6 +313,7 @@ containerdConfig:
+   logLevel: info
+   runc:
+     version: 1.2.4
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.7.25
+ etcdManifests:
+ - memfs://clusters.example.com/mixedinstances.example.com/manifests/etcd/main-master-us-test-1c.yaml
+diff --git a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_nodeupconfig-nodes_content b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_nodeupconfig-nodes_content
+index 5d9ecfd17c..2b368cb667 100644
+--- a/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_nodeupconfig-nodes_content
++++ b/tests/integration/update_cluster/mixed_instances/data/aws_s3_object_nodeupconfig-nodes_content
+@@ -43,7 +43,6 @@ KubeletConfig:
+   logLevel: 2
+   nodeLabels:
+     node-role.kubernetes.io/node: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -58,6 +57,7 @@ containerdConfig:
+   logLevel: info
+   runc:
+     version: 1.2.4
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.7.25
+ usesLegacyGossip: false
+ usesNoneDNS: false
+diff --git a/tests/integration/update_cluster/mixed_instances_spot/data/aws_launch_template_master-us-test-1a.masters.mixedinstances.example.com_user_data b/tests/integration/update_cluster/mixed_instances_spot/data/aws_launch_template_master-us-test-1a.masters.mixedinstances.example.com_user_data
+index 4298f69152..38d446d689 100644
+--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_launch_template_master-us-test-1a.masters.mixedinstances.example.com_user_data
++++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_launch_template_master-us-test-1a.masters.mixedinstances.example.com_user_data
+@@ -130,7 +130,7 @@ ClusterName: mixedinstances.example.com
+ ConfigBase: memfs://clusters.example.com/mixedinstances.example.com
+ InstanceGroupName: master-us-test-1a
+ InstanceGroupRole: ControlPlane
+-NodeupConfigHash: QmN7LE7VnkjU+GUmFdLQRBr/h+Pf+MruP1CfNte8WoQ=
++NodeupConfigHash: DacPgRQHknYSd/mCwgt+EJP/W9wekobUhg8y/9U5gsU=
+ 
+ __EOF_KUBE_ENV
+ 
+diff --git a/tests/integration/update_cluster/mixed_instances_spot/data/aws_launch_template_master-us-test-1b.masters.mixedinstances.example.com_user_data b/tests/integration/update_cluster/mixed_instances_spot/data/aws_launch_template_master-us-test-1b.masters.mixedinstances.example.com_user_data
+index 4dbfeb3cfd..50bc5ce9cc 100644
+--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_launch_template_master-us-test-1b.masters.mixedinstances.example.com_user_data
++++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_launch_template_master-us-test-1b.masters.mixedinstances.example.com_user_data
+@@ -130,7 +130,7 @@ ClusterName: mixedinstances.example.com
+ ConfigBase: memfs://clusters.example.com/mixedinstances.example.com
+ InstanceGroupName: master-us-test-1b
+ InstanceGroupRole: ControlPlane
+-NodeupConfigHash: 3p7ErmXWWW4Db4nDcRXHdMW0iEms20vgAJpC6Yu8KW0=
++NodeupConfigHash: VWnw+Awp2AQxhCZDPEeyYt2Cc+KI30ZioKfNcxuX8io=
+ 
+ __EOF_KUBE_ENV
+ 
+diff --git a/tests/integration/update_cluster/mixed_instances_spot/data/aws_launch_template_master-us-test-1c.masters.mixedinstances.example.com_user_data b/tests/integration/update_cluster/mixed_instances_spot/data/aws_launch_template_master-us-test-1c.masters.mixedinstances.example.com_user_data
+index 710c556e74..dc383e776d 100644
+--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_launch_template_master-us-test-1c.masters.mixedinstances.example.com_user_data
++++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_launch_template_master-us-test-1c.masters.mixedinstances.example.com_user_data
+@@ -130,7 +130,7 @@ ClusterName: mixedinstances.example.com
+ ConfigBase: memfs://clusters.example.com/mixedinstances.example.com
+ InstanceGroupName: master-us-test-1c
+ InstanceGroupRole: ControlPlane
+-NodeupConfigHash: gRz7sVhHpzWTZKt8nHKK3ygm45IwfL8mHDdF7TPFDOA=
++NodeupConfigHash: mBkVjhe/6p7QlkcpGD+0AaNeRf22kVpqgAVWLobgij0=
+ 
+ __EOF_KUBE_ENV
+ 
+diff --git a/tests/integration/update_cluster/mixed_instances_spot/data/aws_launch_template_nodes.mixedinstances.example.com_user_data b/tests/integration/update_cluster/mixed_instances_spot/data/aws_launch_template_nodes.mixedinstances.example.com_user_data
+index b9d83b6d36..3ef83e0a19 100644
+--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_launch_template_nodes.mixedinstances.example.com_user_data
++++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_launch_template_nodes.mixedinstances.example.com_user_data
+@@ -153,7 +153,7 @@ ConfigServer:
+   - https://kops-controller.internal.mixedinstances.example.com:3988/
+ InstanceGroupName: nodes
+ InstanceGroupRole: Node
+-NodeupConfigHash: gP4iMij3RObbcYQX8D1yTh/X851gaWHWN6ABDAbCA8I=
++NodeupConfigHash: H1R6ZZQVLmxLfbvBXhiD9RigXcaDvlTD9+rwsc48gQQ=
+ 
+ __EOF_KUBE_ENV
+ 
+diff --git a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_cluster-completed.spec_content b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_cluster-completed.spec_content
+index dc8b6aacbf..c64349a711 100644
+--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_cluster-completed.spec_content
++++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_cluster-completed.spec_content
+@@ -28,6 +28,7 @@ spec:
+     logLevel: info
+     runc:
+       version: 1.2.4
++    sandboxImage: registry.k8s.io/pause:3.10.1
+     version: 1.7.25
+   dnsZone: Z1AFAKE1ZON3YO
+   etcdClusters:
+@@ -151,7 +152,6 @@ spec:
+     evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
+     kubeconfigPath: /var/lib/kubelet/kubeconfig
+     logLevel: 2
+-    podInfraContainerImage: registry.k8s.io/pause:3.9
+     podManifestPath: /etc/kubernetes/manifests
+     protectKernelDefaults: true
+     registerSchedulable: true
+@@ -171,7 +171,6 @@ spec:
+     evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
+     kubeconfigPath: /var/lib/kubelet/kubeconfig
+     logLevel: 2
+-    podInfraContainerImage: registry.k8s.io/pause:3.9
+     podManifestPath: /etc/kubernetes/manifests
+     protectKernelDefaults: true
+     registerSchedulable: true
+diff --git a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_nodeupconfig-master-us-test-1a_content b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+index 00a67b2bb2..e705751755 100644
+--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
++++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+@@ -292,7 +292,6 @@ KubeletConfig:
+     kops.k8s.io/kops-controller-pki: ""
+     node-role.kubernetes.io/control-plane: ""
+     node.kubernetes.io/exclude-from-external-load-balancers: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -314,6 +313,7 @@ containerdConfig:
+   logLevel: info
+   runc:
+     version: 1.2.4
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.7.25
+ etcdManifests:
+ - memfs://clusters.example.com/mixedinstances.example.com/manifests/etcd/main-master-us-test-1a.yaml
+diff --git a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_nodeupconfig-master-us-test-1b_content b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_nodeupconfig-master-us-test-1b_content
+index 952484ccb7..be4c386ac7 100644
+--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_nodeupconfig-master-us-test-1b_content
++++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_nodeupconfig-master-us-test-1b_content
+@@ -292,7 +292,6 @@ KubeletConfig:
+     kops.k8s.io/kops-controller-pki: ""
+     node-role.kubernetes.io/control-plane: ""
+     node.kubernetes.io/exclude-from-external-load-balancers: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -314,6 +313,7 @@ containerdConfig:
+   logLevel: info
+   runc:
+     version: 1.2.4
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.7.25
+ etcdManifests:
+ - memfs://clusters.example.com/mixedinstances.example.com/manifests/etcd/main-master-us-test-1b.yaml
+diff --git a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_nodeupconfig-master-us-test-1c_content b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_nodeupconfig-master-us-test-1c_content
+index 76da76999d..a8a056bbbc 100644
+--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_nodeupconfig-master-us-test-1c_content
++++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_nodeupconfig-master-us-test-1c_content
+@@ -292,7 +292,6 @@ KubeletConfig:
+     kops.k8s.io/kops-controller-pki: ""
+     node-role.kubernetes.io/control-plane: ""
+     node.kubernetes.io/exclude-from-external-load-balancers: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -314,6 +313,7 @@ containerdConfig:
+   logLevel: info
+   runc:
+     version: 1.2.4
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.7.25
+ etcdManifests:
+ - memfs://clusters.example.com/mixedinstances.example.com/manifests/etcd/main-master-us-test-1c.yaml
+diff --git a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_nodeupconfig-nodes_content b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_nodeupconfig-nodes_content
+index 5d9ecfd17c..2b368cb667 100644
+--- a/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_nodeupconfig-nodes_content
++++ b/tests/integration/update_cluster/mixed_instances_spot/data/aws_s3_object_nodeupconfig-nodes_content
+@@ -43,7 +43,6 @@ KubeletConfig:
+   logLevel: 2
+   nodeLabels:
+     node-role.kubernetes.io/node: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -58,6 +57,7 @@ containerdConfig:
+   logLevel: info
+   runc:
+     version: 1.2.4
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.7.25
+ usesLegacyGossip: false
+ usesNoneDNS: false
+diff --git a/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_launch_template_master-us-test-1a.masters.nthimdsprocessor.longclustername.example.com_user_data b/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_launch_template_master-us-test-1a.masters.nthimdsprocessor.longclustername.example.com_user_data
+index b6eb8c87bc..46f3dc810c 100644
+--- a/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_launch_template_master-us-test-1a.masters.nthimdsprocessor.longclustername.example.com_user_data
++++ b/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_launch_template_master-us-test-1a.masters.nthimdsprocessor.longclustername.example.com_user_data
+@@ -130,7 +130,7 @@ ClusterName: nthimdsprocessor.longclustername.example.com
+ ConfigBase: memfs://clusters.example.com/nthimdsprocessor.longclustername.example.com
+ InstanceGroupName: master-us-test-1a
+ InstanceGroupRole: ControlPlane
+-NodeupConfigHash: NeAvrNKWaznpKPiTZE8gpjXygg4SupgE6knaQcCuOOc=
++NodeupConfigHash: ic5dy6mRA7WQrF+8PjRYbW4tanAxSZ3Remq6wj22rRU=
+ 
+ __EOF_KUBE_ENV
+ 
+diff --git a/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_launch_template_nodes.nthimdsprocessor.longclustername.example.com_user_data b/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_launch_template_nodes.nthimdsprocessor.longclustername.example.com_user_data
+index a19b046c08..fc3027e471 100644
+--- a/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_launch_template_nodes.nthimdsprocessor.longclustername.example.com_user_data
++++ b/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_launch_template_nodes.nthimdsprocessor.longclustername.example.com_user_data
+@@ -153,7 +153,7 @@ ConfigServer:
+   - https://kops-controller.internal.nthimdsprocessor.longclustername.example.com:3988/
+ InstanceGroupName: nodes
+ InstanceGroupRole: Node
+-NodeupConfigHash: DMHvzJBe7htTRYtgmksOIcqKWT1TWok06esgT6f6OwM=
++NodeupConfigHash: 4AHdk4tWUFeXB/f9MsXaG+yz4hbNgyDdEUHl50RC9q4=
+ 
+ __EOF_KUBE_ENV
+ 
+diff --git a/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_cluster-completed.spec_content b/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_cluster-completed.spec_content
+index a929defbe4..278bf4c9cd 100644
+--- a/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_cluster-completed.spec_content
++++ b/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_cluster-completed.spec_content
+@@ -28,6 +28,7 @@ spec:
+     logLevel: info
+     runc:
+       version: 1.2.4
++    sandboxImage: registry.k8s.io/pause:3.10.1
+     version: 1.7.25
+   dnsZone: Z1AFAKE1ZON3YO
+   etcdClusters:
+@@ -144,7 +145,6 @@ spec:
+     evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
+     kubeconfigPath: /var/lib/kubelet/kubeconfig
+     logLevel: 2
+-    podInfraContainerImage: registry.k8s.io/pause:3.9
+     podManifestPath: /etc/kubernetes/manifests
+     protectKernelDefaults: true
+     registerSchedulable: true
+@@ -164,7 +164,6 @@ spec:
+     evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
+     kubeconfigPath: /var/lib/kubelet/kubeconfig
+     logLevel: 2
+-    podInfraContainerImage: registry.k8s.io/pause:3.9
+     podManifestPath: /etc/kubernetes/manifests
+     protectKernelDefaults: true
+     registerSchedulable: true
+diff --git a/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_nodeupconfig-master-us-test-1a_content b/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+index 65ff9f202c..36a02ca064 100644
+--- a/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
++++ b/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+@@ -292,7 +292,6 @@ KubeletConfig:
+     kops.k8s.io/kops-controller-pki: ""
+     node-role.kubernetes.io/control-plane: ""
+     node.kubernetes.io/exclude-from-external-load-balancers: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -314,6 +313,7 @@ containerdConfig:
+   logLevel: info
+   runc:
+     version: 1.2.4
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.7.25
+ etcdManifests:
+ - memfs://clusters.example.com/nthimdsprocessor.longclustername.example.com/manifests/etcd/main-master-us-test-1a.yaml
+diff --git a/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_nodeupconfig-nodes_content b/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_nodeupconfig-nodes_content
+index f93634be33..bb68c82fab 100644
+--- a/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_nodeupconfig-nodes_content
++++ b/tests/integration/update_cluster/nth-imds-processor-irsa/data/aws_s3_object_nodeupconfig-nodes_content
+@@ -43,7 +43,6 @@ KubeletConfig:
+   logLevel: 2
+   nodeLabels:
+     node-role.kubernetes.io/node: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -58,6 +57,7 @@ containerdConfig:
+   logLevel: info
+   runc:
+     version: 1.2.4
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.7.25
+ usesLegacyGossip: false
+ usesNoneDNS: false
+diff --git a/tests/integration/update_cluster/nth-imds-processor/data/aws_launch_template_master-us-test-1a.masters.nthimdsprocessor.longclustername.example.com_user_data b/tests/integration/update_cluster/nth-imds-processor/data/aws_launch_template_master-us-test-1a.masters.nthimdsprocessor.longclustername.example.com_user_data
+index d78226c887..de7b55c412 100644
+--- a/tests/integration/update_cluster/nth-imds-processor/data/aws_launch_template_master-us-test-1a.masters.nthimdsprocessor.longclustername.example.com_user_data
++++ b/tests/integration/update_cluster/nth-imds-processor/data/aws_launch_template_master-us-test-1a.masters.nthimdsprocessor.longclustername.example.com_user_data
+@@ -130,7 +130,7 @@ ClusterName: nthimdsprocessor.longclustername.example.com
+ ConfigBase: memfs://clusters.example.com/nthimdsprocessor.longclustername.example.com
+ InstanceGroupName: master-us-test-1a
+ InstanceGroupRole: ControlPlane
+-NodeupConfigHash: IuzJ3ilkEKkNsynykSr2t8yWaVZ6Nrp5wjSE0p6NxME=
++NodeupConfigHash: cybbO+NQgOGlu5zXieYnQpRvV0VKAZmRmUcmMdDYvi0=
+ 
+ __EOF_KUBE_ENV
+ 
+diff --git a/tests/integration/update_cluster/nth-imds-processor/data/aws_launch_template_nodes.nthimdsprocessor.longclustername.example.com_user_data b/tests/integration/update_cluster/nth-imds-processor/data/aws_launch_template_nodes.nthimdsprocessor.longclustername.example.com_user_data
+index a19b046c08..fc3027e471 100644
+--- a/tests/integration/update_cluster/nth-imds-processor/data/aws_launch_template_nodes.nthimdsprocessor.longclustername.example.com_user_data
++++ b/tests/integration/update_cluster/nth-imds-processor/data/aws_launch_template_nodes.nthimdsprocessor.longclustername.example.com_user_data
+@@ -153,7 +153,7 @@ ConfigServer:
+   - https://kops-controller.internal.nthimdsprocessor.longclustername.example.com:3988/
+ InstanceGroupName: nodes
+ InstanceGroupRole: Node
+-NodeupConfigHash: DMHvzJBe7htTRYtgmksOIcqKWT1TWok06esgT6f6OwM=
++NodeupConfigHash: 4AHdk4tWUFeXB/f9MsXaG+yz4hbNgyDdEUHl50RC9q4=
+ 
+ __EOF_KUBE_ENV
+ 
+diff --git a/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_cluster-completed.spec_content b/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_cluster-completed.spec_content
+index d3faf5b016..5bc26f57bc 100644
+--- a/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_cluster-completed.spec_content
++++ b/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_cluster-completed.spec_content
+@@ -28,6 +28,7 @@ spec:
+     logLevel: info
+     runc:
+       version: 1.2.4
++    sandboxImage: registry.k8s.io/pause:3.10.1
+     version: 1.7.25
+   dnsZone: Z1AFAKE1ZON3YO
+   etcdClusters:
+@@ -143,7 +144,6 @@ spec:
+     evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
+     kubeconfigPath: /var/lib/kubelet/kubeconfig
+     logLevel: 2
+-    podInfraContainerImage: registry.k8s.io/pause:3.9
+     podManifestPath: /etc/kubernetes/manifests
+     protectKernelDefaults: true
+     registerSchedulable: true
+@@ -163,7 +163,6 @@ spec:
+     evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
+     kubeconfigPath: /var/lib/kubelet/kubeconfig
+     logLevel: 2
+-    podInfraContainerImage: registry.k8s.io/pause:3.9
+     podManifestPath: /etc/kubernetes/manifests
+     protectKernelDefaults: true
+     registerSchedulable: true
+diff --git a/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_nodeupconfig-master-us-test-1a_content b/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+index f93470b738..ebad30036d 100644
+--- a/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
++++ b/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+@@ -292,7 +292,6 @@ KubeletConfig:
+     kops.k8s.io/kops-controller-pki: ""
+     node-role.kubernetes.io/control-plane: ""
+     node.kubernetes.io/exclude-from-external-load-balancers: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -314,6 +313,7 @@ containerdConfig:
+   logLevel: info
+   runc:
+     version: 1.2.4
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.7.25
+ etcdManifests:
+ - memfs://clusters.example.com/nthimdsprocessor.longclustername.example.com/manifests/etcd/main-master-us-test-1a.yaml
+diff --git a/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_nodeupconfig-nodes_content b/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_nodeupconfig-nodes_content
+index f93634be33..bb68c82fab 100644
+--- a/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_nodeupconfig-nodes_content
++++ b/tests/integration/update_cluster/nth-imds-processor/data/aws_s3_object_nodeupconfig-nodes_content
+@@ -43,7 +43,6 @@ KubeletConfig:
+   logLevel: 2
+   nodeLabels:
+     node-role.kubernetes.io/node: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -58,6 +57,7 @@ containerdConfig:
+   logLevel: info
+   runc:
+     version: 1.2.4
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.7.25
+ usesLegacyGossip: false
+ usesNoneDNS: false
+diff --git a/tests/integration/update_cluster/nvidia/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data b/tests/integration/update_cluster/nvidia/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
+index 724577b0e2..d617a086a5 100644
+--- a/tests/integration/update_cluster/nvidia/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
++++ b/tests/integration/update_cluster/nvidia/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
+@@ -130,7 +130,7 @@ ClusterName: minimal.example.com
+ ConfigBase: memfs://clusters.example.com/minimal.example.com
+ InstanceGroupName: master-us-test-1a
+ InstanceGroupRole: ControlPlane
+-NodeupConfigHash: OPD2HShq4mDwK0byP3CVmEasK/2Q+V1xN1aeFLfx544=
++NodeupConfigHash: 93Ka1SV/xL7lcIhqWk+6GpeRWAXYk2t/8F0vz92r5CA=
+ 
+ __EOF_KUBE_ENV
+ 
+diff --git a/tests/integration/update_cluster/nvidia/data/aws_launch_template_nodes.minimal.example.com_user_data b/tests/integration/update_cluster/nvidia/data/aws_launch_template_nodes.minimal.example.com_user_data
+index 2c3692b1f0..88c517cc5f 100644
+--- a/tests/integration/update_cluster/nvidia/data/aws_launch_template_nodes.minimal.example.com_user_data
++++ b/tests/integration/update_cluster/nvidia/data/aws_launch_template_nodes.minimal.example.com_user_data
+@@ -153,7 +153,7 @@ ConfigServer:
+   - https://kops-controller.internal.minimal.example.com:3988/
+ InstanceGroupName: nodes
+ InstanceGroupRole: Node
+-NodeupConfigHash: 9D9OjtcRMOfvrTkQYkBU7fH741BhPqnkrv4yBueRYXE=
++NodeupConfigHash: lQy+S6Vazi4P2dxL/9kO6wlx7UuA32QSVWnfkbMEFGU=
+ 
+ __EOF_KUBE_ENV
+ 
+diff --git a/tests/integration/update_cluster/nvidia/data/aws_s3_object_cluster-completed.spec_content b/tests/integration/update_cluster/nvidia/data/aws_s3_object_cluster-completed.spec_content
+index c72fb4b36e..dc248740ba 100644
+--- a/tests/integration/update_cluster/nvidia/data/aws_s3_object_cluster-completed.spec_content
++++ b/tests/integration/update_cluster/nvidia/data/aws_s3_object_cluster-completed.spec_content
+@@ -31,6 +31,7 @@ spec:
+       package: nvidia-driver-535-server
+     runc:
+       version: 1.2.4
++    sandboxImage: registry.k8s.io/pause:3.10.1
+     version: 1.7.25
+   dnsZone: Z1AFAKE1ZON3YO
+   etcdClusters:
+@@ -146,7 +147,6 @@ spec:
+     evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
+     kubeconfigPath: /var/lib/kubelet/kubeconfig
+     logLevel: 2
+-    podInfraContainerImage: registry.k8s.io/pause:3.9
+     podManifestPath: /etc/kubernetes/manifests
+     protectKernelDefaults: true
+     registerSchedulable: true
+@@ -166,7 +166,6 @@ spec:
+     evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
+     kubeconfigPath: /var/lib/kubelet/kubeconfig
+     logLevel: 2
+-    podInfraContainerImage: registry.k8s.io/pause:3.9
+     podManifestPath: /etc/kubernetes/manifests
+     protectKernelDefaults: true
+     registerSchedulable: true
+diff --git a/tests/integration/update_cluster/nvidia/data/aws_s3_object_nodeupconfig-master-us-test-1a_content b/tests/integration/update_cluster/nvidia/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+index 9cbc007572..91cf3c6d0a 100644
+--- a/tests/integration/update_cluster/nvidia/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
++++ b/tests/integration/update_cluster/nvidia/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+@@ -292,7 +292,6 @@ KubeletConfig:
+     kops.k8s.io/kops-controller-pki: ""
+     node-role.kubernetes.io/control-plane: ""
+     node.kubernetes.io/exclude-from-external-load-balancers: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -320,6 +319,7 @@ containerdConfig:
+     package: nvidia-driver-535-server
+   runc:
+     version: 1.2.4
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.7.25
+ etcdManifests:
+ - memfs://clusters.example.com/minimal.example.com/manifests/etcd/main-master-us-test-1a.yaml
+diff --git a/tests/integration/update_cluster/nvidia/data/aws_s3_object_nodeupconfig-nodes_content b/tests/integration/update_cluster/nvidia/data/aws_s3_object_nodeupconfig-nodes_content
+index 9b3b724421..c09baa2fcf 100644
+--- a/tests/integration/update_cluster/nvidia/data/aws_s3_object_nodeupconfig-nodes_content
++++ b/tests/integration/update_cluster/nvidia/data/aws_s3_object_nodeupconfig-nodes_content
+@@ -44,7 +44,6 @@ KubeletConfig:
+   nodeLabels:
+     kops.k8s.io/gpu: "1"
+     node-role.kubernetes.io/node: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -67,6 +66,7 @@ containerdConfig:
+     package: nvidia-driver-535-server
+   runc:
+     version: 1.2.4
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.7.25
+ usesLegacyGossip: false
+ usesNoneDNS: false
+diff --git a/tests/integration/update_cluster/private-shared-ip/data/aws_launch_template_master-us-test-1a.masters.private-shared-ip.example.com_user_data b/tests/integration/update_cluster/private-shared-ip/data/aws_launch_template_master-us-test-1a.masters.private-shared-ip.example.com_user_data
+index 57f9ee5d97..80953423b2 100644
+--- a/tests/integration/update_cluster/private-shared-ip/data/aws_launch_template_master-us-test-1a.masters.private-shared-ip.example.com_user_data
++++ b/tests/integration/update_cluster/private-shared-ip/data/aws_launch_template_master-us-test-1a.masters.private-shared-ip.example.com_user_data
+@@ -130,7 +130,7 @@ ClusterName: private-shared-ip.example.com
+ ConfigBase: memfs://clusters.example.com/private-shared-ip.example.com
+ InstanceGroupName: master-us-test-1a
+ InstanceGroupRole: ControlPlane
+-NodeupConfigHash: NR0m//flv1IhePcHqmdyh0pqRbafb5c/bY5XMR/cKTg=
++NodeupConfigHash: MjUvN7gVwgKqe9COFQ4MRT0TO3sA8o39e7WiHEIiKk0=
+ 
+ __EOF_KUBE_ENV
+ 
+diff --git a/tests/integration/update_cluster/private-shared-ip/data/aws_launch_template_nodes.private-shared-ip.example.com_user_data b/tests/integration/update_cluster/private-shared-ip/data/aws_launch_template_nodes.private-shared-ip.example.com_user_data
+index d527c7f9e5..bdae00a861 100644
+--- a/tests/integration/update_cluster/private-shared-ip/data/aws_launch_template_nodes.private-shared-ip.example.com_user_data
++++ b/tests/integration/update_cluster/private-shared-ip/data/aws_launch_template_nodes.private-shared-ip.example.com_user_data
+@@ -153,7 +153,7 @@ ConfigServer:
+   - https://kops-controller.internal.private-shared-ip.example.com:3988/
+ InstanceGroupName: nodes
+ InstanceGroupRole: Node
+-NodeupConfigHash: iPCmCtlS6fM3Wb99IFEFvTGJbGP3gqJiJ9CtHX2BFeo=
++NodeupConfigHash: LfSoc5W1kJz0800P6PAT6rJV8lZCTUbcUX3gOGzD/ns=
+ 
+ __EOF_KUBE_ENV
+ 
+diff --git a/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_cluster-completed.spec_content b/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_cluster-completed.spec_content
+index 18da06c411..90ff42761c 100644
+--- a/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_cluster-completed.spec_content
++++ b/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_cluster-completed.spec_content
+@@ -30,6 +30,7 @@ spec:
+     logLevel: info
+     runc:
+       version: 1.2.4
++    sandboxImage: registry.k8s.io/pause:3.10.1
+     version: 1.7.25
+   dnsZone: Z1AFAKE1ZON3YO
+   etcdClusters:
+@@ -145,7 +146,6 @@ spec:
+     evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
+     kubeconfigPath: /var/lib/kubelet/kubeconfig
+     logLevel: 2
+-    podInfraContainerImage: registry.k8s.io/pause:3.9
+     podManifestPath: /etc/kubernetes/manifests
+     protectKernelDefaults: true
+     registerSchedulable: true
+@@ -165,7 +165,6 @@ spec:
+     evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
+     kubeconfigPath: /var/lib/kubelet/kubeconfig
+     logLevel: 2
+-    podInfraContainerImage: registry.k8s.io/pause:3.9
+     podManifestPath: /etc/kubernetes/manifests
+     protectKernelDefaults: true
+     registerSchedulable: true
+diff --git a/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_nodeupconfig-master-us-test-1a_content b/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+index 83b95c125d..738a3f7243 100644
+--- a/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
++++ b/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+@@ -291,7 +291,6 @@ KubeletConfig:
+     kops.k8s.io/kops-controller-pki: ""
+     node-role.kubernetes.io/control-plane: ""
+     node.kubernetes.io/exclude-from-external-load-balancers: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -313,6 +312,7 @@ containerdConfig:
+   logLevel: info
+   runc:
+     version: 1.2.4
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.7.25
+ etcdManifests:
+ - memfs://clusters.example.com/private-shared-ip.example.com/manifests/etcd/main-master-us-test-1a.yaml
+diff --git a/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_nodeupconfig-nodes_content b/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_nodeupconfig-nodes_content
+index 851cf1fbee..ae2083f4f2 100644
+--- a/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_nodeupconfig-nodes_content
++++ b/tests/integration/update_cluster/private-shared-ip/data/aws_s3_object_nodeupconfig-nodes_content
+@@ -43,7 +43,6 @@ KubeletConfig:
+   logLevel: 2
+   nodeLabels:
+     node-role.kubernetes.io/node: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -58,6 +57,7 @@ containerdConfig:
+   logLevel: info
+   runc:
+     version: 1.2.4
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.7.25
+ usesLegacyGossip: false
+ usesNoneDNS: false
+diff --git a/tests/integration/update_cluster/private-shared-subnet/data/aws_launch_template_master-us-test-1a.masters.private-shared-subnet.example.com_user_data b/tests/integration/update_cluster/private-shared-subnet/data/aws_launch_template_master-us-test-1a.masters.private-shared-subnet.example.com_user_data
+index d01c38b6c1..d6be4dac95 100644
+--- a/tests/integration/update_cluster/private-shared-subnet/data/aws_launch_template_master-us-test-1a.masters.private-shared-subnet.example.com_user_data
++++ b/tests/integration/update_cluster/private-shared-subnet/data/aws_launch_template_master-us-test-1a.masters.private-shared-subnet.example.com_user_data
+@@ -130,7 +130,7 @@ ClusterName: private-shared-subnet.example.com
+ ConfigBase: memfs://clusters.example.com/private-shared-subnet.example.com
+ InstanceGroupName: master-us-test-1a
+ InstanceGroupRole: ControlPlane
+-NodeupConfigHash: ff1czYItjv6+8IjRcjd7dmOHE7KCNvYUTlxB6GDIKzg=
++NodeupConfigHash: xUePgS4RmQEwXXgDwucmYMVcVW3Xs/VXAf4wV7JqfzY=
+ 
+ __EOF_KUBE_ENV
+ 
+diff --git a/tests/integration/update_cluster/private-shared-subnet/data/aws_launch_template_nodes.private-shared-subnet.example.com_user_data b/tests/integration/update_cluster/private-shared-subnet/data/aws_launch_template_nodes.private-shared-subnet.example.com_user_data
+index 539a34625d..e9a8f68437 100644
+--- a/tests/integration/update_cluster/private-shared-subnet/data/aws_launch_template_nodes.private-shared-subnet.example.com_user_data
++++ b/tests/integration/update_cluster/private-shared-subnet/data/aws_launch_template_nodes.private-shared-subnet.example.com_user_data
+@@ -153,7 +153,7 @@ ConfigServer:
+   - https://kops-controller.internal.private-shared-subnet.example.com:3988/
+ InstanceGroupName: nodes
+ InstanceGroupRole: Node
+-NodeupConfigHash: dAhQBuKEYaUFmNgE6qsj4V+Z+7v2UAKymrdgnatkl4g=
++NodeupConfigHash: 1DLAMP5ZqUiN7S+PpebUvLq/yxKkB1kkR9H9lxEYJMI=
+ 
+ __EOF_KUBE_ENV
+ 
+diff --git a/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_cluster-completed.spec_content b/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_cluster-completed.spec_content
+index aa63dfaa1d..94133078c0 100644
+--- a/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_cluster-completed.spec_content
++++ b/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_cluster-completed.spec_content
+@@ -30,6 +30,7 @@ spec:
+     logLevel: info
+     runc:
+       version: 1.2.4
++    sandboxImage: registry.k8s.io/pause:3.10.1
+     version: 1.7.25
+   dnsZone: Z1AFAKE1ZON3YO
+   etcdClusters:
+@@ -145,7 +146,6 @@ spec:
+     evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
+     kubeconfigPath: /var/lib/kubelet/kubeconfig
+     logLevel: 2
+-    podInfraContainerImage: registry.k8s.io/pause:3.9
+     podManifestPath: /etc/kubernetes/manifests
+     protectKernelDefaults: true
+     registerSchedulable: true
+@@ -165,7 +165,6 @@ spec:
+     evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
+     kubeconfigPath: /var/lib/kubelet/kubeconfig
+     logLevel: 2
+-    podInfraContainerImage: registry.k8s.io/pause:3.9
+     podManifestPath: /etc/kubernetes/manifests
+     protectKernelDefaults: true
+     registerSchedulable: true
+diff --git a/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_nodeupconfig-master-us-test-1a_content b/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+index 7c2467734f..1aab5d5b6c 100644
+--- a/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
++++ b/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+@@ -291,7 +291,6 @@ KubeletConfig:
+     kops.k8s.io/kops-controller-pki: ""
+     node-role.kubernetes.io/control-plane: ""
+     node.kubernetes.io/exclude-from-external-load-balancers: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -313,6 +312,7 @@ containerdConfig:
+   logLevel: info
+   runc:
+     version: 1.2.4
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.7.25
+ etcdManifests:
+ - memfs://clusters.example.com/private-shared-subnet.example.com/manifests/etcd/main-master-us-test-1a.yaml
+diff --git a/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_nodeupconfig-nodes_content b/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_nodeupconfig-nodes_content
+index 8ea7addef2..27decbfc59 100644
+--- a/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_nodeupconfig-nodes_content
++++ b/tests/integration/update_cluster/private-shared-subnet/data/aws_s3_object_nodeupconfig-nodes_content
+@@ -43,7 +43,6 @@ KubeletConfig:
+   logLevel: 2
+   nodeLabels:
+     node-role.kubernetes.io/node: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -58,6 +57,7 @@ containerdConfig:
+   logLevel: info
+   runc:
+     version: 1.2.4
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.7.25
+ usesLegacyGossip: false
+ usesNoneDNS: false
+diff --git a/tests/integration/update_cluster/privatecalico/data/aws_launch_template_master-us-test-1a.masters.privatecalico.example.com_user_data b/tests/integration/update_cluster/privatecalico/data/aws_launch_template_master-us-test-1a.masters.privatecalico.example.com_user_data
+index f459a11dd2..ce47226a51 100644
+--- a/tests/integration/update_cluster/privatecalico/data/aws_launch_template_master-us-test-1a.masters.privatecalico.example.com_user_data
++++ b/tests/integration/update_cluster/privatecalico/data/aws_launch_template_master-us-test-1a.masters.privatecalico.example.com_user_data
+@@ -130,7 +130,7 @@ ClusterName: privatecalico.example.com
+ ConfigBase: memfs://clusters.example.com/privatecalico.example.com
+ InstanceGroupName: master-us-test-1a
+ InstanceGroupRole: ControlPlane
+-NodeupConfigHash: vqxeejBXs0qRLoSf3S23RIWwUsvnYQiAGi+UrvSSHc8=
++NodeupConfigHash: 6P71Ly3byaEwbODmzLnLDvZHeHQw37fuF0j9NLf5Gh8=
+ 
+ __EOF_KUBE_ENV
+ 
+diff --git a/tests/integration/update_cluster/privatecalico/data/aws_launch_template_nodes.privatecalico.example.com_user_data b/tests/integration/update_cluster/privatecalico/data/aws_launch_template_nodes.privatecalico.example.com_user_data
+index 61528a0803..d57dfd43f0 100644
+--- a/tests/integration/update_cluster/privatecalico/data/aws_launch_template_nodes.privatecalico.example.com_user_data
++++ b/tests/integration/update_cluster/privatecalico/data/aws_launch_template_nodes.privatecalico.example.com_user_data
+@@ -153,7 +153,7 @@ ConfigServer:
+   - https://kops-controller.internal.privatecalico.example.com:3988/
+ InstanceGroupName: nodes
+ InstanceGroupRole: Node
+-NodeupConfigHash: TNV6VDjC1S4N0OzWbgKcwJCtmblsosDq9bC3Uvqo20c=
++NodeupConfigHash: iF0f7pVdXDcQbbwacjgDBw0dJBOYJEUyYBnq803dgqU=
+ 
+ __EOF_KUBE_ENV
+ 
+diff --git a/tests/integration/update_cluster/privatecalico/data/aws_s3_object_cluster-completed.spec_content b/tests/integration/update_cluster/privatecalico/data/aws_s3_object_cluster-completed.spec_content
+index e1bf4dfd8b..82c310c9ef 100644
+--- a/tests/integration/update_cluster/privatecalico/data/aws_s3_object_cluster-completed.spec_content
++++ b/tests/integration/update_cluster/privatecalico/data/aws_s3_object_cluster-completed.spec_content
+@@ -30,6 +30,7 @@ spec:
+     logLevel: info
+     runc:
+       version: 1.2.4
++    sandboxImage: registry.k8s.io/pause:3.10.1
+     version: 1.7.25
+   dnsZone: Z1AFAKE1ZON3YO
+   etcdClusters:
+@@ -146,7 +147,6 @@ spec:
+     evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
+     kubeconfigPath: /var/lib/kubelet/kubeconfig
+     logLevel: 2
+-    podInfraContainerImage: registry.k8s.io/pause:3.9
+     podManifestPath: /etc/kubernetes/manifests
+     protectKernelDefaults: true
+     registerSchedulable: true
+@@ -167,7 +167,6 @@ spec:
+     evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
+     kubeconfigPath: /var/lib/kubelet/kubeconfig
+     logLevel: 2
+-    podInfraContainerImage: registry.k8s.io/pause:3.9
+     podManifestPath: /etc/kubernetes/manifests
+     protectKernelDefaults: true
+     registerSchedulable: true
+diff --git a/tests/integration/update_cluster/privatecalico/data/aws_s3_object_nodeupconfig-master-us-test-1a_content b/tests/integration/update_cluster/privatecalico/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+index 615f094ae6..bad77b1447 100644
+--- a/tests/integration/update_cluster/privatecalico/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
++++ b/tests/integration/update_cluster/privatecalico/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+@@ -288,7 +288,6 @@ KubeletConfig:
+     kops.k8s.io/kops-controller-pki: ""
+     node-role.kubernetes.io/control-plane: ""
+     node.kubernetes.io/exclude-from-external-load-balancers: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -311,6 +310,7 @@ containerdConfig:
+   logLevel: info
+   runc:
+     version: 1.2.4
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.7.25
+ etcdManifests:
+ - memfs://clusters.example.com/privatecalico.example.com/manifests/etcd/main-master-us-test-1a.yaml
+diff --git a/tests/integration/update_cluster/privatecalico/data/aws_s3_object_nodeupconfig-nodes_content b/tests/integration/update_cluster/privatecalico/data/aws_s3_object_nodeupconfig-nodes_content
+index 9af41a22b1..67947f018b 100644
+--- a/tests/integration/update_cluster/privatecalico/data/aws_s3_object_nodeupconfig-nodes_content
++++ b/tests/integration/update_cluster/privatecalico/data/aws_s3_object_nodeupconfig-nodes_content
+@@ -40,7 +40,6 @@ KubeletConfig:
+   logLevel: 2
+   nodeLabels:
+     node-role.kubernetes.io/node: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -56,6 +55,7 @@ containerdConfig:
+   logLevel: info
+   runc:
+     version: 1.2.4
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.7.25
+ usesLegacyGossip: false
+ usesNoneDNS: false
+diff --git a/tests/integration/update_cluster/privatecilium-eni/data/aws_launch_template_master-us-test-1a.masters.privatecilium.example.com_user_data b/tests/integration/update_cluster/privatecilium-eni/data/aws_launch_template_master-us-test-1a.masters.privatecilium.example.com_user_data
+index 47a2a5596e..f9b16d2b2d 100644
+--- a/tests/integration/update_cluster/privatecilium-eni/data/aws_launch_template_master-us-test-1a.masters.privatecilium.example.com_user_data
++++ b/tests/integration/update_cluster/privatecilium-eni/data/aws_launch_template_master-us-test-1a.masters.privatecilium.example.com_user_data
+@@ -130,7 +130,7 @@ ClusterName: privatecilium.example.com
+ ConfigBase: memfs://clusters.example.com/privatecilium.example.com
+ InstanceGroupName: master-us-test-1a
+ InstanceGroupRole: ControlPlane
+-NodeupConfigHash: /0JN5kiNeO4we3yF0avTmolNRu1MH9aU/vhpavZ/CpM=
++NodeupConfigHash: B6q0VDGBeWh3MthbtkxPswIUXCoD7iVAzTiySymX60M=
+ 
+ __EOF_KUBE_ENV
+ 
+diff --git a/tests/integration/update_cluster/privatecilium-eni/data/aws_launch_template_nodes.privatecilium.example.com_user_data b/tests/integration/update_cluster/privatecilium-eni/data/aws_launch_template_nodes.privatecilium.example.com_user_data
+index daafa8b210..1b8adf4bc3 100644
+--- a/tests/integration/update_cluster/privatecilium-eni/data/aws_launch_template_nodes.privatecilium.example.com_user_data
++++ b/tests/integration/update_cluster/privatecilium-eni/data/aws_launch_template_nodes.privatecilium.example.com_user_data
+@@ -153,7 +153,7 @@ ConfigServer:
+   - https://kops-controller.internal.privatecilium.example.com:3988/
+ InstanceGroupName: nodes
+ InstanceGroupRole: Node
+-NodeupConfigHash: k/1mcZ/pp9tyTJD2l1DOg8Ik62D3qHW//b/KrWltq5A=
++NodeupConfigHash: fEnYSB6FceTynCW5+qwsG43flZKSUDt9DTfxsqsXans=
+ 
+ __EOF_KUBE_ENV
+ 
+diff --git a/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_cluster-completed.spec_content b/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_cluster-completed.spec_content
+index 8b7c2769e8..c75da2684f 100644
+--- a/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_cluster-completed.spec_content
++++ b/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_cluster-completed.spec_content
+@@ -30,6 +30,7 @@ spec:
+     logLevel: info
+     runc:
+       version: 1.2.4
++    sandboxImage: registry.k8s.io/pause:3.10.1
+     version: 1.7.25
+   dnsZone: Z1AFAKE1ZON3YO
+   etcdClusters:
+@@ -145,7 +146,6 @@ spec:
+     evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
+     kubeconfigPath: /var/lib/kubelet/kubeconfig
+     logLevel: 2
+-    podInfraContainerImage: registry.k8s.io/pause:3.9
+     podManifestPath: /etc/kubernetes/manifests
+     protectKernelDefaults: true
+     registerSchedulable: true
+@@ -165,7 +165,6 @@ spec:
+     evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
+     kubeconfigPath: /var/lib/kubelet/kubeconfig
+     logLevel: 2
+-    podInfraContainerImage: registry.k8s.io/pause:3.9
+     podManifestPath: /etc/kubernetes/manifests
+     protectKernelDefaults: true
+     registerSchedulable: true
+diff --git a/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_nodeupconfig-master-us-test-1a_content b/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+index 6ca8df4de1..94c5dd766e 100644
+--- a/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
++++ b/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+@@ -288,7 +288,6 @@ KubeletConfig:
+     kops.k8s.io/kops-controller-pki: ""
+     node-role.kubernetes.io/control-plane: ""
+     node.kubernetes.io/exclude-from-external-load-balancers: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -312,6 +311,7 @@ containerdConfig:
+   logLevel: info
+   runc:
+     version: 1.2.4
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.7.25
+ etcdManifests:
+ - memfs://clusters.example.com/privatecilium.example.com/manifests/etcd/main-master-us-test-1a.yaml
+diff --git a/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_nodeupconfig-nodes_content b/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_nodeupconfig-nodes_content
+index e1ecb3d686..936b305463 100644
+--- a/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_nodeupconfig-nodes_content
++++ b/tests/integration/update_cluster/privatecilium-eni/data/aws_s3_object_nodeupconfig-nodes_content
+@@ -40,7 +40,6 @@ KubeletConfig:
+   logLevel: 2
+   nodeLabels:
+     node-role.kubernetes.io/node: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -57,6 +56,7 @@ containerdConfig:
+   logLevel: info
+   runc:
+     version: 1.2.4
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.7.25
+ usesLegacyGossip: false
+ usesNoneDNS: false
+diff --git a/tests/integration/update_cluster/privatecilium/data/aws_launch_template_master-us-test-1a.masters.privatecilium.example.com_user_data b/tests/integration/update_cluster/privatecilium/data/aws_launch_template_master-us-test-1a.masters.privatecilium.example.com_user_data
+index 15ae54327f..4577cbc040 100644
+--- a/tests/integration/update_cluster/privatecilium/data/aws_launch_template_master-us-test-1a.masters.privatecilium.example.com_user_data
++++ b/tests/integration/update_cluster/privatecilium/data/aws_launch_template_master-us-test-1a.masters.privatecilium.example.com_user_data
+@@ -130,7 +130,7 @@ ClusterName: privatecilium.example.com
+ ConfigBase: memfs://clusters.example.com/privatecilium.example.com
+ InstanceGroupName: master-us-test-1a
+ InstanceGroupRole: ControlPlane
+-NodeupConfigHash: dZaSHZD7Xhc23BIMSbb00cXhGnpDVXx1gFsto39ylUs=
++NodeupConfigHash: tgDyCtxvGWSt8+tclohi90ttZIAY5zCRLeKr5TugWZY=
+ 
+ __EOF_KUBE_ENV
+ 
+diff --git a/tests/integration/update_cluster/privatecilium/data/aws_launch_template_nodes.privatecilium.example.com_user_data b/tests/integration/update_cluster/privatecilium/data/aws_launch_template_nodes.privatecilium.example.com_user_data
+index e5ebdb6745..b8c9f819e0 100644
+--- a/tests/integration/update_cluster/privatecilium/data/aws_launch_template_nodes.privatecilium.example.com_user_data
++++ b/tests/integration/update_cluster/privatecilium/data/aws_launch_template_nodes.privatecilium.example.com_user_data
+@@ -153,7 +153,7 @@ ConfigServer:
+   - https://kops-controller.internal.privatecilium.example.com:3988/
+ InstanceGroupName: nodes
+ InstanceGroupRole: Node
+-NodeupConfigHash: 5sQy1IM9ONY1rT+5BqTp+Ld/bHAc45clA4EKbg9Kf1c=
++NodeupConfigHash: tHYprOskqC9VmuBE6hC0OCBakahhnEm7F/5B1qPAwms=
+ 
+ __EOF_KUBE_ENV
+ 
+diff --git a/tests/integration/update_cluster/privatecilium/data/aws_s3_object_cluster-completed.spec_content b/tests/integration/update_cluster/privatecilium/data/aws_s3_object_cluster-completed.spec_content
+index 2b1751bc92..03919870f5 100644
+--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_object_cluster-completed.spec_content
++++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_object_cluster-completed.spec_content
+@@ -30,6 +30,7 @@ spec:
+     logLevel: info
+     runc:
+       version: 1.2.4
++    sandboxImage: registry.k8s.io/pause:3.10.1
+     version: 1.7.25
+   dnsZone: Z1AFAKE1ZON3YO
+   etcdClusters:
+@@ -145,7 +146,6 @@ spec:
+     evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
+     kubeconfigPath: /var/lib/kubelet/kubeconfig
+     logLevel: 2
+-    podInfraContainerImage: registry.k8s.io/pause:3.9
+     podManifestPath: /etc/kubernetes/manifests
+     protectKernelDefaults: true
+     registerSchedulable: true
+@@ -165,7 +165,6 @@ spec:
+     evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
+     kubeconfigPath: /var/lib/kubelet/kubeconfig
+     logLevel: 2
+-    podInfraContainerImage: registry.k8s.io/pause:3.9
+     podManifestPath: /etc/kubernetes/manifests
+     protectKernelDefaults: true
+     registerSchedulable: true
+diff --git a/tests/integration/update_cluster/privatecilium/data/aws_s3_object_nodeupconfig-master-us-test-1a_content b/tests/integration/update_cluster/privatecilium/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+index d10f4cb42b..88aa6335ec 100644
+--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
++++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+@@ -288,7 +288,6 @@ KubeletConfig:
+     kops.k8s.io/kops-controller-pki: ""
+     node-role.kubernetes.io/control-plane: ""
+     node.kubernetes.io/exclude-from-external-load-balancers: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -311,6 +310,7 @@ containerdConfig:
+   logLevel: info
+   runc:
+     version: 1.2.4
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.7.25
+ etcdManifests:
+ - memfs://clusters.example.com/privatecilium.example.com/manifests/etcd/main-master-us-test-1a.yaml
+diff --git a/tests/integration/update_cluster/privatecilium/data/aws_s3_object_nodeupconfig-nodes_content b/tests/integration/update_cluster/privatecilium/data/aws_s3_object_nodeupconfig-nodes_content
+index 7baafba096..e810d0a882 100644
+--- a/tests/integration/update_cluster/privatecilium/data/aws_s3_object_nodeupconfig-nodes_content
++++ b/tests/integration/update_cluster/privatecilium/data/aws_s3_object_nodeupconfig-nodes_content
+@@ -40,7 +40,6 @@ KubeletConfig:
+   logLevel: 2
+   nodeLabels:
+     node-role.kubernetes.io/node: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -56,6 +55,7 @@ containerdConfig:
+   logLevel: info
+   runc:
+     version: 1.2.4
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.7.25
+ usesLegacyGossip: false
+ usesNoneDNS: false
+diff --git a/tests/integration/update_cluster/privatecilium2/data/aws_launch_template_master-us-test-1a.masters.privatecilium.example.com_user_data b/tests/integration/update_cluster/privatecilium2/data/aws_launch_template_master-us-test-1a.masters.privatecilium.example.com_user_data
+index 38b1bdb586..902f95d4f7 100644
+--- a/tests/integration/update_cluster/privatecilium2/data/aws_launch_template_master-us-test-1a.masters.privatecilium.example.com_user_data
++++ b/tests/integration/update_cluster/privatecilium2/data/aws_launch_template_master-us-test-1a.masters.privatecilium.example.com_user_data
+@@ -130,7 +130,7 @@ ClusterName: privatecilium.example.com
+ ConfigBase: memfs://clusters.example.com/privatecilium.example.com
+ InstanceGroupName: master-us-test-1a
+ InstanceGroupRole: ControlPlane
+-NodeupConfigHash: K6RO3W8eE4trX4o90ArORslYC+x1m4ZOlXrvNp8Ms0k=
++NodeupConfigHash: 2BJrDuV2HVn+0OsDrjW+Gi9nmdRpyuMQsRXPSGZDWbc=
+ 
+ __EOF_KUBE_ENV
+ 
+diff --git a/tests/integration/update_cluster/privatecilium2/data/aws_launch_template_nodes.privatecilium.example.com_user_data b/tests/integration/update_cluster/privatecilium2/data/aws_launch_template_nodes.privatecilium.example.com_user_data
+index 162e3559f3..b99462d2f9 100644
+--- a/tests/integration/update_cluster/privatecilium2/data/aws_launch_template_nodes.privatecilium.example.com_user_data
++++ b/tests/integration/update_cluster/privatecilium2/data/aws_launch_template_nodes.privatecilium.example.com_user_data
+@@ -153,7 +153,7 @@ ConfigServer:
+   - https://kops-controller.internal.privatecilium.example.com:3988/
+ InstanceGroupName: nodes
+ InstanceGroupRole: Node
+-NodeupConfigHash: i99R9YLx9wmr1qZR5AkNQYJhfVGSjkBZtaNwN1Lp608=
++NodeupConfigHash: q/WiOtofjEyOh5aVDuwwYWbmnaEhsn7PvAlNCCsICGg=
+ 
+ __EOF_KUBE_ENV
+ 
+diff --git a/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_cluster-completed.spec_content b/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_cluster-completed.spec_content
+index e18f8379b7..21a50e0625 100644
+--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_cluster-completed.spec_content
++++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_cluster-completed.spec_content
+@@ -32,6 +32,7 @@ spec:
+     logLevel: info
+     runc:
+       version: 1.2.4
++    sandboxImage: registry.k8s.io/pause:3.10.1
+     version: 1.7.25
+   dnsZone: Z1AFAKE1ZON3YO
+   etcdClusters:
+@@ -155,7 +156,6 @@ spec:
+       InTreePluginAWSUnregister: "true"
+     kubeconfigPath: /var/lib/kubelet/kubeconfig
+     logLevel: 2
+-    podInfraContainerImage: registry.k8s.io/pause:3.9
+     podManifestPath: /etc/kubernetes/manifests
+     protectKernelDefaults: true
+     registerSchedulable: true
+@@ -177,7 +177,6 @@ spec:
+       InTreePluginAWSUnregister: "true"
+     kubeconfigPath: /var/lib/kubelet/kubeconfig
+     logLevel: 2
+-    podInfraContainerImage: registry.k8s.io/pause:3.9
+     podManifestPath: /etc/kubernetes/manifests
+     protectKernelDefaults: true
+     registerSchedulable: true
+diff --git a/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_nodeupconfig-master-us-test-1a_content b/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+index 9711f9c02a..f3ae10ca7b 100644
+--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
++++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+@@ -296,7 +296,6 @@ KubeletConfig:
+     kops.k8s.io/kops-controller-pki: ""
+     node-role.kubernetes.io/control-plane: ""
+     node.kubernetes.io/exclude-from-external-load-balancers: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -319,6 +318,7 @@ containerdConfig:
+   logLevel: info
+   runc:
+     version: 1.2.4
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.7.25
+ etcdManifests:
+ - memfs://clusters.example.com/privatecilium.example.com/manifests/etcd/main-master-us-test-1a.yaml
+diff --git a/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_nodeupconfig-nodes_content b/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_nodeupconfig-nodes_content
+index 2e2dacd5b6..ed751db557 100644
+--- a/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_nodeupconfig-nodes_content
++++ b/tests/integration/update_cluster/privatecilium2/data/aws_s3_object_nodeupconfig-nodes_content
+@@ -42,7 +42,6 @@ KubeletConfig:
+   logLevel: 2
+   nodeLabels:
+     node-role.kubernetes.io/node: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -58,6 +57,7 @@ containerdConfig:
+   logLevel: info
+   runc:
+     version: 1.2.4
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.7.25
+ usesLegacyGossip: false
+ usesNoneDNS: false
+diff --git a/tests/integration/update_cluster/privateciliumadvanced/data/aws_launch_template_master-us-test-1a.masters.privateciliumadvanced.example.com_user_data b/tests/integration/update_cluster/privateciliumadvanced/data/aws_launch_template_master-us-test-1a.masters.privateciliumadvanced.example.com_user_data
+index c266d5f8d7..ea5b872aed 100644
+--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_launch_template_master-us-test-1a.masters.privateciliumadvanced.example.com_user_data
++++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_launch_template_master-us-test-1a.masters.privateciliumadvanced.example.com_user_data
+@@ -130,7 +130,7 @@ ClusterName: privateciliumadvanced.example.com
+ ConfigBase: memfs://clusters.example.com/privateciliumadvanced.example.com
+ InstanceGroupName: master-us-test-1a
+ InstanceGroupRole: ControlPlane
+-NodeupConfigHash: TqUBztAoAvQAj82Zc/lDom15ie5ZGzWei0XG3H/h3cc=
++NodeupConfigHash: Z4CbsEw7szeZoU5tVt1bd02lAONjs1eiTXrU/xIJJNM=
+ 
+ __EOF_KUBE_ENV
+ 
+diff --git a/tests/integration/update_cluster/privateciliumadvanced/data/aws_launch_template_nodes.privateciliumadvanced.example.com_user_data b/tests/integration/update_cluster/privateciliumadvanced/data/aws_launch_template_nodes.privateciliumadvanced.example.com_user_data
+index 5b79602180..99fba2ffdb 100644
+--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_launch_template_nodes.privateciliumadvanced.example.com_user_data
++++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_launch_template_nodes.privateciliumadvanced.example.com_user_data
+@@ -153,7 +153,7 @@ ConfigServer:
+   - https://kops-controller.internal.privateciliumadvanced.example.com:3988/
+ InstanceGroupName: nodes
+ InstanceGroupRole: Node
+-NodeupConfigHash: f3bZwrPFBiSF9T8TrKiXMzJTnlrRn3a1VWr0Awskg7g=
++NodeupConfigHash: MxshikRq4/T70nQmmndhWykh9QCmJtO+wuHdaBjjB9Y=
+ 
+ __EOF_KUBE_ENV
+ 
+diff --git a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_cluster-completed.spec_content b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_cluster-completed.spec_content
+index a4a4aa5411..57c01668c1 100644
+--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_cluster-completed.spec_content
++++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_cluster-completed.spec_content
+@@ -30,6 +30,7 @@ spec:
+     logLevel: info
+     runc:
+       version: 1.2.4
++    sandboxImage: registry.k8s.io/pause:3.10.1
+     version: 1.7.25
+   dnsZone: Z1AFAKE1ZON3YO
+   etcdClusters:
+@@ -155,7 +156,6 @@ spec:
+     evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
+     kubeconfigPath: /var/lib/kubelet/kubeconfig
+     logLevel: 2
+-    podInfraContainerImage: registry.k8s.io/pause:3.9
+     podManifestPath: /etc/kubernetes/manifests
+     protectKernelDefaults: true
+     registerSchedulable: true
+@@ -175,7 +175,6 @@ spec:
+     evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
+     kubeconfigPath: /var/lib/kubelet/kubeconfig
+     logLevel: 2
+-    podInfraContainerImage: registry.k8s.io/pause:3.9
+     podManifestPath: /etc/kubernetes/manifests
+     protectKernelDefaults: true
+     registerSchedulable: true
+diff --git a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_nodeupconfig-master-us-test-1a_content b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+index 17c644100a..276247e655 100644
+--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
++++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+@@ -355,7 +355,6 @@ KubeletConfig:
+     kops.k8s.io/kops-controller-pki: ""
+     node-role.kubernetes.io/control-plane: ""
+     node.kubernetes.io/exclude-from-external-load-balancers: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -380,6 +379,7 @@ containerdConfig:
+   logLevel: info
+   runc:
+     version: 1.2.4
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.7.25
+ etcdManifests:
+ - memfs://clusters.example.com/privateciliumadvanced.example.com/manifests/etcd/main-master-us-test-1a.yaml
+diff --git a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_nodeupconfig-nodes_content b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_nodeupconfig-nodes_content
+index 7d8ce4b412..cdd826ac85 100644
+--- a/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_nodeupconfig-nodes_content
++++ b/tests/integration/update_cluster/privateciliumadvanced/data/aws_s3_object_nodeupconfig-nodes_content
+@@ -60,7 +60,6 @@ KubeletConfig:
+   logLevel: 2
+   nodeLabels:
+     node-role.kubernetes.io/node: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -78,6 +77,7 @@ containerdConfig:
+   logLevel: info
+   runc:
+     version: 1.2.4
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.7.25
+ usesLegacyGossip: false
+ usesNoneDNS: false
+diff --git a/tests/integration/update_cluster/privatedns1/data/aws_launch_template_master-us-test-1a.masters.privatedns1.example.com_user_data b/tests/integration/update_cluster/privatedns1/data/aws_launch_template_master-us-test-1a.masters.privatedns1.example.com_user_data
+index 01bf184c99..8c2e662557 100644
+--- a/tests/integration/update_cluster/privatedns1/data/aws_launch_template_master-us-test-1a.masters.privatedns1.example.com_user_data
++++ b/tests/integration/update_cluster/privatedns1/data/aws_launch_template_master-us-test-1a.masters.privatedns1.example.com_user_data
+@@ -130,7 +130,7 @@ ClusterName: privatedns1.example.com
+ ConfigBase: memfs://clusters.example.com/privatedns1.example.com
+ InstanceGroupName: master-us-test-1a
+ InstanceGroupRole: ControlPlane
+-NodeupConfigHash: DvzNFle9myzln0bcmwkZ6iDrkQIvDUJOEFYmbgMx4sA=
++NodeupConfigHash: CJ2V77mDG8SQLUwwM2W9akQxWlTbGLLfD0oG6qT4sn8=
+ 
+ __EOF_KUBE_ENV
+ 
+diff --git a/tests/integration/update_cluster/privatedns1/data/aws_launch_template_nodes.privatedns1.example.com_user_data b/tests/integration/update_cluster/privatedns1/data/aws_launch_template_nodes.privatedns1.example.com_user_data
+index 39ce97752b..7d6b5a9f34 100644
+--- a/tests/integration/update_cluster/privatedns1/data/aws_launch_template_nodes.privatedns1.example.com_user_data
++++ b/tests/integration/update_cluster/privatedns1/data/aws_launch_template_nodes.privatedns1.example.com_user_data
+@@ -153,7 +153,7 @@ ConfigServer:
+   - https://kops-controller.internal.privatedns1.example.com:3988/
+ InstanceGroupName: nodes
+ InstanceGroupRole: Node
+-NodeupConfigHash: 6oFibbZvlwnKUu0YGD8+d1eAKtgbC0Z7FW7pLvQ9pEo=
++NodeupConfigHash: S1mUNOaTXT1Cknrl8JnIOnQPnCLSf2mJJMVPZLrb1Jk=
+ 
+ __EOF_KUBE_ENV
+ 
+diff --git a/tests/integration/update_cluster/privatedns1/data/aws_s3_object_cluster-completed.spec_content b/tests/integration/update_cluster/privatedns1/data/aws_s3_object_cluster-completed.spec_content
+index 8e5e7ab0f7..97e306a3f6 100644
+--- a/tests/integration/update_cluster/privatedns1/data/aws_s3_object_cluster-completed.spec_content
++++ b/tests/integration/update_cluster/privatedns1/data/aws_s3_object_cluster-completed.spec_content
+@@ -33,6 +33,7 @@ spec:
+     logLevel: info
+     runc:
+       version: 1.1.5
++    sandboxImage: registry.k8s.io/pause:3.10.1
+     version: 1.6.20
+   dnsZone: internal.example.com
+   etcdClusters:
+@@ -156,7 +157,6 @@ spec:
+       InTreePluginAWSUnregister: "true"
+     kubeconfigPath: /var/lib/kubelet/kubeconfig
+     logLevel: 2
+-    podInfraContainerImage: registry.k8s.io/pause:3.9
+     podManifestPath: /etc/kubernetes/manifests
+     protectKernelDefaults: true
+     registerSchedulable: true
+@@ -178,7 +178,6 @@ spec:
+       InTreePluginAWSUnregister: "true"
+     kubeconfigPath: /var/lib/kubelet/kubeconfig
+     logLevel: 2
+-    podInfraContainerImage: registry.k8s.io/pause:3.9
+     podManifestPath: /etc/kubernetes/manifests
+     protectKernelDefaults: true
+     registerSchedulable: true
+diff --git a/tests/integration/update_cluster/privatedns1/data/aws_s3_object_nodeupconfig-master-us-test-1a_content b/tests/integration/update_cluster/privatedns1/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+index 21a31ff4e2..93f8099264 100644
+--- a/tests/integration/update_cluster/privatedns1/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
++++ b/tests/integration/update_cluster/privatedns1/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+@@ -299,7 +299,6 @@ KubeletConfig:
+     kops.k8s.io/kops-controller-pki: ""
+     node-role.kubernetes.io/control-plane: ""
+     node.kubernetes.io/exclude-from-external-load-balancers: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -321,6 +320,7 @@ containerdConfig:
+   logLevel: info
+   runc:
+     version: 1.1.5
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.6.20
+ etcdManifests:
+ - memfs://clusters.example.com/privatedns1.example.com/manifests/etcd/main-master-us-test-1a.yaml
+diff --git a/tests/integration/update_cluster/privatedns1/data/aws_s3_object_nodeupconfig-nodes_content b/tests/integration/update_cluster/privatedns1/data/aws_s3_object_nodeupconfig-nodes_content
+index 27bb0d8782..61b4e6e651 100644
+--- a/tests/integration/update_cluster/privatedns1/data/aws_s3_object_nodeupconfig-nodes_content
++++ b/tests/integration/update_cluster/privatedns1/data/aws_s3_object_nodeupconfig-nodes_content
+@@ -45,7 +45,6 @@ KubeletConfig:
+   logLevel: 2
+   nodeLabels:
+     node-role.kubernetes.io/node: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -60,6 +59,7 @@ containerdConfig:
+   logLevel: info
+   runc:
+     version: 1.1.5
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.6.20
+ usesLegacyGossip: false
+ usesNoneDNS: false
+diff --git a/tests/integration/update_cluster/privatedns2/data/aws_launch_template_master-us-test-1a.masters.privatedns2.example.com_user_data b/tests/integration/update_cluster/privatedns2/data/aws_launch_template_master-us-test-1a.masters.privatedns2.example.com_user_data
+index 177b861e1f..a6de1cb032 100644
+--- a/tests/integration/update_cluster/privatedns2/data/aws_launch_template_master-us-test-1a.masters.privatedns2.example.com_user_data
++++ b/tests/integration/update_cluster/privatedns2/data/aws_launch_template_master-us-test-1a.masters.privatedns2.example.com_user_data
+@@ -130,7 +130,7 @@ ClusterName: privatedns2.example.com
+ ConfigBase: memfs://clusters.example.com/privatedns2.example.com
+ InstanceGroupName: master-us-test-1a
+ InstanceGroupRole: ControlPlane
+-NodeupConfigHash: rkw0Ri6g84jp+00cqYGR8jGYAerQedAKajlYDTuJDEg=
++NodeupConfigHash: cLmDG8lyQ1lP2tolzxSkTG4BWWA6VvwdjWviWZWTxZc=
+ 
+ __EOF_KUBE_ENV
+ 
+diff --git a/tests/integration/update_cluster/privatedns2/data/aws_launch_template_nodes.privatedns2.example.com_user_data b/tests/integration/update_cluster/privatedns2/data/aws_launch_template_nodes.privatedns2.example.com_user_data
+index ff36cc64a0..b8df4a902b 100644
+--- a/tests/integration/update_cluster/privatedns2/data/aws_launch_template_nodes.privatedns2.example.com_user_data
++++ b/tests/integration/update_cluster/privatedns2/data/aws_launch_template_nodes.privatedns2.example.com_user_data
+@@ -153,7 +153,7 @@ ConfigServer:
+   - https://kops-controller.internal.privatedns2.example.com:3988/
+ InstanceGroupName: nodes
+ InstanceGroupRole: Node
+-NodeupConfigHash: ywf/AvXBeu6MX66oAC3L6O6ZzJ6YlrpKC3nVFi0eAKI=
++NodeupConfigHash: 1wkuh9lQuE9SVCsp2rh+7JSLUi85KawPWwnxz9HWx5s=
+ 
+ __EOF_KUBE_ENV
+ 
+diff --git a/tests/integration/update_cluster/privatedns2/data/aws_s3_object_cluster-completed.spec_content b/tests/integration/update_cluster/privatedns2/data/aws_s3_object_cluster-completed.spec_content
+index df2d45e9da..e4d5bd5ffa 100644
+--- a/tests/integration/update_cluster/privatedns2/data/aws_s3_object_cluster-completed.spec_content
++++ b/tests/integration/update_cluster/privatedns2/data/aws_s3_object_cluster-completed.spec_content
+@@ -30,6 +30,7 @@ spec:
+     logLevel: info
+     runc:
+       version: 1.2.4
++    sandboxImage: registry.k8s.io/pause:3.10.1
+     version: 1.7.25
+   dnsZone: private.example.com
+   etcdClusters:
+@@ -145,7 +146,6 @@ spec:
+     evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
+     kubeconfigPath: /var/lib/kubelet/kubeconfig
+     logLevel: 2
+-    podInfraContainerImage: registry.k8s.io/pause:3.9
+     podManifestPath: /etc/kubernetes/manifests
+     protectKernelDefaults: true
+     registerSchedulable: true
+@@ -165,7 +165,6 @@ spec:
+     evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
+     kubeconfigPath: /var/lib/kubelet/kubeconfig
+     logLevel: 2
+-    podInfraContainerImage: registry.k8s.io/pause:3.9
+     podManifestPath: /etc/kubernetes/manifests
+     protectKernelDefaults: true
+     registerSchedulable: true
+diff --git a/tests/integration/update_cluster/privatedns2/data/aws_s3_object_nodeupconfig-master-us-test-1a_content b/tests/integration/update_cluster/privatedns2/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+index 2734865b76..fdb32576d4 100644
+--- a/tests/integration/update_cluster/privatedns2/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
++++ b/tests/integration/update_cluster/privatedns2/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+@@ -291,7 +291,6 @@ KubeletConfig:
+     kops.k8s.io/kops-controller-pki: ""
+     node-role.kubernetes.io/control-plane: ""
+     node.kubernetes.io/exclude-from-external-load-balancers: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -313,6 +312,7 @@ containerdConfig:
+   logLevel: info
+   runc:
+     version: 1.2.4
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.7.25
+ etcdManifests:
+ - memfs://clusters.example.com/privatedns2.example.com/manifests/etcd/main-master-us-test-1a.yaml
+diff --git a/tests/integration/update_cluster/privatedns2/data/aws_s3_object_nodeupconfig-nodes_content b/tests/integration/update_cluster/privatedns2/data/aws_s3_object_nodeupconfig-nodes_content
+index be72eeca46..4c78f6548c 100644
+--- a/tests/integration/update_cluster/privatedns2/data/aws_s3_object_nodeupconfig-nodes_content
++++ b/tests/integration/update_cluster/privatedns2/data/aws_s3_object_nodeupconfig-nodes_content
+@@ -43,7 +43,6 @@ KubeletConfig:
+   logLevel: 2
+   nodeLabels:
+     node-role.kubernetes.io/node: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -58,6 +57,7 @@ containerdConfig:
+   logLevel: info
+   runc:
+     version: 1.2.4
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.7.25
+ usesLegacyGossip: false
+ usesNoneDNS: false
+diff --git a/tests/integration/update_cluster/privateflannel/data/aws_launch_template_master-us-test-1a.masters.privateflannel.example.com_user_data b/tests/integration/update_cluster/privateflannel/data/aws_launch_template_master-us-test-1a.masters.privateflannel.example.com_user_data
+index 473b9d7280..026c46e368 100644
+--- a/tests/integration/update_cluster/privateflannel/data/aws_launch_template_master-us-test-1a.masters.privateflannel.example.com_user_data
++++ b/tests/integration/update_cluster/privateflannel/data/aws_launch_template_master-us-test-1a.masters.privateflannel.example.com_user_data
+@@ -130,7 +130,7 @@ ClusterName: privateflannel.example.com
+ ConfigBase: memfs://clusters.example.com/privateflannel.example.com
+ InstanceGroupName: master-us-test-1a
+ InstanceGroupRole: ControlPlane
+-NodeupConfigHash: frJ+3em7tsd7U8juD4BdvZ0m8uQvv544oIco1bwtu24=
++NodeupConfigHash: Kaft2bAq2RNZa7FJmXu4Jsz3C/I2oGr677TvviGfE/w=
+ 
+ __EOF_KUBE_ENV
+ 
+diff --git a/tests/integration/update_cluster/privateflannel/data/aws_launch_template_nodes.privateflannel.example.com_user_data b/tests/integration/update_cluster/privateflannel/data/aws_launch_template_nodes.privateflannel.example.com_user_data
+index 8d2e202a89..6a705467c3 100644
+--- a/tests/integration/update_cluster/privateflannel/data/aws_launch_template_nodes.privateflannel.example.com_user_data
++++ b/tests/integration/update_cluster/privateflannel/data/aws_launch_template_nodes.privateflannel.example.com_user_data
+@@ -153,7 +153,7 @@ ConfigServer:
+   - https://kops-controller.internal.privateflannel.example.com:3988/
+ InstanceGroupName: nodes
+ InstanceGroupRole: Node
+-NodeupConfigHash: 0+QkObS6BSd1LE17caDANNiEQFr57M16T+x+OlqA7/M=
++NodeupConfigHash: JN3yaHHxFO6Qbt9eMklU/ObEOivxCeKP9pXrZZHPraU=
+ 
+ __EOF_KUBE_ENV
+ 
+diff --git a/tests/integration/update_cluster/privateflannel/data/aws_s3_object_cluster-completed.spec_content b/tests/integration/update_cluster/privateflannel/data/aws_s3_object_cluster-completed.spec_content
+index 658ce5cd68..63fc7dfe80 100644
+--- a/tests/integration/update_cluster/privateflannel/data/aws_s3_object_cluster-completed.spec_content
++++ b/tests/integration/update_cluster/privateflannel/data/aws_s3_object_cluster-completed.spec_content
+@@ -30,6 +30,7 @@ spec:
+     logLevel: info
+     runc:
+       version: 1.1.5
++    sandboxImage: registry.k8s.io/pause:3.10.1
+     version: 1.6.20
+   dnsZone: Z1AFAKE1ZON3YO
+   etcdClusters:
+@@ -153,7 +154,6 @@ spec:
+       InTreePluginAWSUnregister: "true"
+     kubeconfigPath: /var/lib/kubelet/kubeconfig
+     logLevel: 2
+-    podInfraContainerImage: registry.k8s.io/pause:3.9
+     podManifestPath: /etc/kubernetes/manifests
+     protectKernelDefaults: true
+     registerSchedulable: true
+@@ -175,7 +175,6 @@ spec:
+       InTreePluginAWSUnregister: "true"
+     kubeconfigPath: /var/lib/kubelet/kubeconfig
+     logLevel: 2
+-    podInfraContainerImage: registry.k8s.io/pause:3.9
+     podManifestPath: /etc/kubernetes/manifests
+     protectKernelDefaults: true
+     registerSchedulable: true
+diff --git a/tests/integration/update_cluster/privateflannel/data/aws_s3_object_nodeupconfig-master-us-test-1a_content b/tests/integration/update_cluster/privateflannel/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+index 096314764d..6fd86e2c5e 100644
+--- a/tests/integration/update_cluster/privateflannel/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
++++ b/tests/integration/update_cluster/privateflannel/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+@@ -299,7 +299,6 @@ KubeletConfig:
+     kops.k8s.io/kops-controller-pki: ""
+     node-role.kubernetes.io/control-plane: ""
+     node.kubernetes.io/exclude-from-external-load-balancers: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -322,6 +321,7 @@ containerdConfig:
+   logLevel: info
+   runc:
+     version: 1.1.5
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.6.20
+ etcdManifests:
+ - memfs://clusters.example.com/privateflannel.example.com/manifests/etcd/main-master-us-test-1a.yaml
+diff --git a/tests/integration/update_cluster/privateflannel/data/aws_s3_object_nodeupconfig-nodes_content b/tests/integration/update_cluster/privateflannel/data/aws_s3_object_nodeupconfig-nodes_content
+index bb3b21dbca..32f43e0c70 100644
+--- a/tests/integration/update_cluster/privateflannel/data/aws_s3_object_nodeupconfig-nodes_content
++++ b/tests/integration/update_cluster/privateflannel/data/aws_s3_object_nodeupconfig-nodes_content
+@@ -45,7 +45,6 @@ KubeletConfig:
+   logLevel: 2
+   nodeLabels:
+     node-role.kubernetes.io/node: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -61,6 +60,7 @@ containerdConfig:
+   logLevel: info
+   runc:
+     version: 1.1.5
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.6.20
+ usesLegacyGossip: false
+ usesNoneDNS: false
+diff --git a/tests/integration/update_cluster/privatekindnet/data/aws_launch_template_master-us-test-1a.masters.privatekindnet.example.com_user_data b/tests/integration/update_cluster/privatekindnet/data/aws_launch_template_master-us-test-1a.masters.privatekindnet.example.com_user_data
+index fb57784f02..76522c3236 100644
+--- a/tests/integration/update_cluster/privatekindnet/data/aws_launch_template_master-us-test-1a.masters.privatekindnet.example.com_user_data
++++ b/tests/integration/update_cluster/privatekindnet/data/aws_launch_template_master-us-test-1a.masters.privatekindnet.example.com_user_data
+@@ -130,7 +130,7 @@ ClusterName: privatekindnet.example.com
+ ConfigBase: memfs://clusters.example.com/privatekindnet.example.com
+ InstanceGroupName: master-us-test-1a
+ InstanceGroupRole: ControlPlane
+-NodeupConfigHash: jTF3I7at/1p0jwCMDz9kTq2uKvqMG+UEhKlJd1X96+8=
++NodeupConfigHash: YkpVDqHjgf3Svftylrr0h4aNqmgTDqL75NNLuQDE+7o=
+ 
+ __EOF_KUBE_ENV
+ 
+diff --git a/tests/integration/update_cluster/privatekindnet/data/aws_launch_template_nodes.privatekindnet.example.com_user_data b/tests/integration/update_cluster/privatekindnet/data/aws_launch_template_nodes.privatekindnet.example.com_user_data
+index fc4e4d4d3a..b87bdc2c00 100644
+--- a/tests/integration/update_cluster/privatekindnet/data/aws_launch_template_nodes.privatekindnet.example.com_user_data
++++ b/tests/integration/update_cluster/privatekindnet/data/aws_launch_template_nodes.privatekindnet.example.com_user_data
+@@ -153,7 +153,7 @@ ConfigServer:
+   - https://kops-controller.internal.privatekindnet.example.com:3988/
+ InstanceGroupName: nodes
+ InstanceGroupRole: Node
+-NodeupConfigHash: cSfAD0glQOSZEadx5Zq5IWOMtIYVKD/XXREkkTy/2fU=
++NodeupConfigHash: e/ZvO/5kPHUnVXMO2ZCYejO7kjvGnnPgU7TK+oZIFFg=
+ 
+ __EOF_KUBE_ENV
+ 
+diff --git a/tests/integration/update_cluster/privatekindnet/data/aws_s3_object_cluster-completed.spec_content b/tests/integration/update_cluster/privatekindnet/data/aws_s3_object_cluster-completed.spec_content
+index db49020d19..6acbc6fdf9 100644
+--- a/tests/integration/update_cluster/privatekindnet/data/aws_s3_object_cluster-completed.spec_content
++++ b/tests/integration/update_cluster/privatekindnet/data/aws_s3_object_cluster-completed.spec_content
+@@ -30,6 +30,7 @@ spec:
+     logLevel: info
+     runc:
+       version: 1.2.4
++    sandboxImage: registry.k8s.io/pause:3.10.1
+     version: 1.7.25
+   dnsZone: Z1AFAKE1ZON3YO
+   etcdClusters:
+@@ -153,7 +154,6 @@ spec:
+       InTreePluginAWSUnregister: "true"
+     kubeconfigPath: /var/lib/kubelet/kubeconfig
+     logLevel: 2
+-    podInfraContainerImage: registry.k8s.io/pause:3.9
+     podManifestPath: /etc/kubernetes/manifests
+     protectKernelDefaults: true
+     registerSchedulable: true
+@@ -175,7 +175,6 @@ spec:
+       InTreePluginAWSUnregister: "true"
+     kubeconfigPath: /var/lib/kubelet/kubeconfig
+     logLevel: 2
+-    podInfraContainerImage: registry.k8s.io/pause:3.9
+     podManifestPath: /etc/kubernetes/manifests
+     protectKernelDefaults: true
+     registerSchedulable: true
+diff --git a/tests/integration/update_cluster/privatekindnet/data/aws_s3_object_nodeupconfig-master-us-test-1a_content b/tests/integration/update_cluster/privatekindnet/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+index 87c01f1fa8..9d450d31fa 100644
+--- a/tests/integration/update_cluster/privatekindnet/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
++++ b/tests/integration/update_cluster/privatekindnet/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+@@ -299,7 +299,6 @@ KubeletConfig:
+     kops.k8s.io/kops-controller-pki: ""
+     node-role.kubernetes.io/control-plane: ""
+     node.kubernetes.io/exclude-from-external-load-balancers: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -322,6 +321,7 @@ containerdConfig:
+   logLevel: info
+   runc:
+     version: 1.2.4
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.7.25
+ etcdManifests:
+ - memfs://clusters.example.com/privatekindnet.example.com/manifests/etcd/main-master-us-test-1a.yaml
+diff --git a/tests/integration/update_cluster/privatekindnet/data/aws_s3_object_nodeupconfig-nodes_content b/tests/integration/update_cluster/privatekindnet/data/aws_s3_object_nodeupconfig-nodes_content
+index 98c2a42f35..5c8cd908fa 100644
+--- a/tests/integration/update_cluster/privatekindnet/data/aws_s3_object_nodeupconfig-nodes_content
++++ b/tests/integration/update_cluster/privatekindnet/data/aws_s3_object_nodeupconfig-nodes_content
+@@ -45,7 +45,6 @@ KubeletConfig:
+   logLevel: 2
+   nodeLabels:
+     node-role.kubernetes.io/node: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -61,6 +60,7 @@ containerdConfig:
+   logLevel: info
+   runc:
+     version: 1.2.4
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.7.25
+ usesLegacyGossip: false
+ usesNoneDNS: false
+diff --git a/tests/integration/update_cluster/privatekopeio/data/aws_launch_template_master-us-test-1a.masters.privatekopeio.example.com_user_data b/tests/integration/update_cluster/privatekopeio/data/aws_launch_template_master-us-test-1a.masters.privatekopeio.example.com_user_data
+index 45bf32f7a2..77331a7955 100644
+--- a/tests/integration/update_cluster/privatekopeio/data/aws_launch_template_master-us-test-1a.masters.privatekopeio.example.com_user_data
++++ b/tests/integration/update_cluster/privatekopeio/data/aws_launch_template_master-us-test-1a.masters.privatekopeio.example.com_user_data
+@@ -130,7 +130,7 @@ ClusterName: privatekopeio.example.com
+ ConfigBase: memfs://clusters.example.com/privatekopeio.example.com
+ InstanceGroupName: master-us-test-1a
+ InstanceGroupRole: ControlPlane
+-NodeupConfigHash: OSKo2Gb7ND2D706YlM8956ZJcf5hDxNkq37hXOX1W6Q=
++NodeupConfigHash: C5Iv+a5OC4GA8IN2dysgJjCjN+/jUvUOCqE6uE9+9Jg=
+ 
+ __EOF_KUBE_ENV
+ 
+diff --git a/tests/integration/update_cluster/privatekopeio/data/aws_launch_template_nodes.privatekopeio.example.com_user_data b/tests/integration/update_cluster/privatekopeio/data/aws_launch_template_nodes.privatekopeio.example.com_user_data
+index 32f29adb06..dba070bfea 100644
+--- a/tests/integration/update_cluster/privatekopeio/data/aws_launch_template_nodes.privatekopeio.example.com_user_data
++++ b/tests/integration/update_cluster/privatekopeio/data/aws_launch_template_nodes.privatekopeio.example.com_user_data
+@@ -153,7 +153,7 @@ ConfigServer:
+   - https://kops-controller.internal.privatekopeio.example.com:3988/
+ InstanceGroupName: nodes
+ InstanceGroupRole: Node
+-NodeupConfigHash: BJaVCIn7fp9kYcw6NUNLKvR16/4DaAtuiV9Oz9KZnYE=
++NodeupConfigHash: eKq+w88I946TVAQuRrP8pUGg5+FBl2TjAEei09NZlfk=
+ 
+ __EOF_KUBE_ENV
+ 
+diff --git a/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_cluster-completed.spec_content b/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_cluster-completed.spec_content
+index 57528bd16c..f503fa717d 100644
+--- a/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_cluster-completed.spec_content
++++ b/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_cluster-completed.spec_content
+@@ -30,6 +30,7 @@ spec:
+     logLevel: info
+     runc:
+       version: 1.2.4
++    sandboxImage: registry.k8s.io/pause:3.10.1
+     version: 1.7.25
+   dnsZone: Z1AFAKE1ZON3YO
+   etcdClusters:
+@@ -145,7 +146,6 @@ spec:
+     evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
+     kubeconfigPath: /var/lib/kubelet/kubeconfig
+     logLevel: 2
+-    podInfraContainerImage: registry.k8s.io/pause:3.9
+     podManifestPath: /etc/kubernetes/manifests
+     protectKernelDefaults: true
+     registerSchedulable: true
+@@ -165,7 +165,6 @@ spec:
+     evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
+     kubeconfigPath: /var/lib/kubelet/kubeconfig
+     logLevel: 2
+-    podInfraContainerImage: registry.k8s.io/pause:3.9
+     podManifestPath: /etc/kubernetes/manifests
+     protectKernelDefaults: true
+     registerSchedulable: true
+diff --git a/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_nodeupconfig-master-us-test-1a_content b/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+index 91c5ab66a9..6937b1ba94 100644
+--- a/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
++++ b/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+@@ -291,7 +291,6 @@ KubeletConfig:
+     kops.k8s.io/kops-controller-pki: ""
+     node-role.kubernetes.io/control-plane: ""
+     node.kubernetes.io/exclude-from-external-load-balancers: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -314,6 +313,7 @@ containerdConfig:
+   logLevel: info
+   runc:
+     version: 1.2.4
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.7.25
+ etcdManifests:
+ - memfs://clusters.example.com/privatekopeio.example.com/manifests/etcd/main-master-us-test-1a.yaml
+diff --git a/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_nodeupconfig-nodes_content b/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_nodeupconfig-nodes_content
+index 334dd00a15..0516fccdab 100644
+--- a/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_nodeupconfig-nodes_content
++++ b/tests/integration/update_cluster/privatekopeio/data/aws_s3_object_nodeupconfig-nodes_content
+@@ -43,7 +43,6 @@ KubeletConfig:
+   logLevel: 2
+   nodeLabels:
+     node-role.kubernetes.io/node: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -59,6 +58,7 @@ containerdConfig:
+   logLevel: info
+   runc:
+     version: 1.2.4
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.7.25
+ usesLegacyGossip: false
+ usesNoneDNS: false
+diff --git a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
+index dc75ae2c77..e05a2297d6 100644
+--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
++++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
+@@ -130,7 +130,7 @@ ClusterName: minimal.example.com
+ ConfigBase: memfs://clusters.example.com/minimal.example.com
+ InstanceGroupName: master-us-test-1a
+ InstanceGroupRole: ControlPlane
+-NodeupConfigHash: Ezlg7X+0EMB+R8yesFEkGkqytUQvBaHeGUBRfaEiOT0=
++NodeupConfigHash: Db4w4arjRoRXh6QIW0fJoCJ72pyAACOYQEZ1tCapayQ=
+ 
+ __EOF_KUBE_ENV
+ 
+diff --git a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_launch_template_nodes.minimal.example.com_user_data b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_launch_template_nodes.minimal.example.com_user_data
+index 1b48e745b0..7444fca464 100644
+--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_launch_template_nodes.minimal.example.com_user_data
++++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_launch_template_nodes.minimal.example.com_user_data
+@@ -153,7 +153,7 @@ ConfigServer:
+   - https://kops-controller.internal.minimal.example.com:3988/
+ InstanceGroupName: nodes
+ InstanceGroupRole: Node
+-NodeupConfigHash: JAk4NZtmkiukti7oY2Mn1bs8IDNe4Y6/jz6tez0iVlw=
++NodeupConfigHash: CEpfrFbJkjwXGISBJQol3PEwfN/25j2XEVZJj8OUy6A=
+ 
+ __EOF_KUBE_ENV
+ 
+diff --git a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_cluster-completed.spec_content b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_cluster-completed.spec_content
+index 5890e8ded4..db23d8ecaf 100644
+--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_cluster-completed.spec_content
++++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_cluster-completed.spec_content
+@@ -28,6 +28,7 @@ spec:
+     logLevel: info
+     runc:
+       version: 1.2.4
++    sandboxImage: registry.k8s.io/pause:3.10.1
+     version: 1.7.25
+   dnsZone: Z1AFAKE1ZON3YO
+   etcdClusters:
+@@ -153,7 +154,6 @@ spec:
+       InTreePluginAWSUnregister: "true"
+     kubeconfigPath: /var/lib/kubelet/kubeconfig
+     logLevel: 2
+-    podInfraContainerImage: registry.k8s.io/pause:3.9
+     podManifestPath: /etc/kubernetes/manifests
+     protectKernelDefaults: true
+     registerSchedulable: true
+@@ -175,7 +175,6 @@ spec:
+       InTreePluginAWSUnregister: "true"
+     kubeconfigPath: /var/lib/kubelet/kubeconfig
+     logLevel: 2
+-    podInfraContainerImage: registry.k8s.io/pause:3.9
+     podManifestPath: /etc/kubernetes/manifests
+     protectKernelDefaults: true
+     registerSchedulable: true
+diff --git a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_nodeupconfig-master-us-test-1a_content b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+index 23362ed645..d83543f569 100644
+--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
++++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+@@ -301,7 +301,6 @@ KubeletConfig:
+     kops.k8s.io/kops-controller-pki: ""
+     node-role.kubernetes.io/control-plane: ""
+     node.kubernetes.io/exclude-from-external-load-balancers: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -323,6 +322,7 @@ containerdConfig:
+   logLevel: info
+   runc:
+     version: 1.2.4
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.7.25
+ etcdManifests:
+ - memfs://clusters.example.com/minimal.example.com/manifests/etcd/main-master-us-test-1a.yaml
+diff --git a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_nodeupconfig-nodes_content b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_nodeupconfig-nodes_content
+index dd04f27875..f8e0928ea6 100644
+--- a/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_nodeupconfig-nodes_content
++++ b/tests/integration/update_cluster/public-jwks-apiserver/data/aws_s3_object_nodeupconfig-nodes_content
+@@ -45,7 +45,6 @@ KubeletConfig:
+   logLevel: 2
+   nodeLabels:
+     node-role.kubernetes.io/node: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -60,6 +59,7 @@ containerdConfig:
+   logLevel: info
+   runc:
+     version: 1.2.4
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.7.25
+ usesLegacyGossip: false
+ usesNoneDNS: false
+diff --git a/tests/integration/update_cluster/shared_subnet/data/aws_launch_template_master-us-test-1a.masters.sharedsubnet.example.com_user_data b/tests/integration/update_cluster/shared_subnet/data/aws_launch_template_master-us-test-1a.masters.sharedsubnet.example.com_user_data
+index cb358c7aef..30dd04f924 100644
+--- a/tests/integration/update_cluster/shared_subnet/data/aws_launch_template_master-us-test-1a.masters.sharedsubnet.example.com_user_data
++++ b/tests/integration/update_cluster/shared_subnet/data/aws_launch_template_master-us-test-1a.masters.sharedsubnet.example.com_user_data
+@@ -130,7 +130,7 @@ ClusterName: sharedsubnet.example.com
+ ConfigBase: memfs://clusters.example.com/sharedsubnet.example.com
+ InstanceGroupName: master-us-test-1a
+ InstanceGroupRole: ControlPlane
+-NodeupConfigHash: uhH5m9Z1R0Zy9uCGp9AsbXyHqAkRlqV2rGyjVfUDDt0=
++NodeupConfigHash: 7SXWsKEQddOmmJZvz3Ltr85Jh0r1D+p/nl9g2LDMSas=
+ 
+ __EOF_KUBE_ENV
+ 
+diff --git a/tests/integration/update_cluster/shared_subnet/data/aws_launch_template_nodes.sharedsubnet.example.com_user_data b/tests/integration/update_cluster/shared_subnet/data/aws_launch_template_nodes.sharedsubnet.example.com_user_data
+index 64b8831683..ff9f0f20dc 100644
+--- a/tests/integration/update_cluster/shared_subnet/data/aws_launch_template_nodes.sharedsubnet.example.com_user_data
++++ b/tests/integration/update_cluster/shared_subnet/data/aws_launch_template_nodes.sharedsubnet.example.com_user_data
+@@ -153,7 +153,7 @@ ConfigServer:
+   - https://kops-controller.internal.sharedsubnet.example.com:3988/
+ InstanceGroupName: nodes
+ InstanceGroupRole: Node
+-NodeupConfigHash: zv26Kb32hRc2l3Qp0OLlZV4bI8KRAJcP8+bqeQXoA/M=
++NodeupConfigHash: S9CLmwl+ZAbT+AyziEpv3yctnUvku3ZtbSbjn9p9eRQ=
+ 
+ __EOF_KUBE_ENV
+ 
+diff --git a/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_cluster-completed.spec_content b/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_cluster-completed.spec_content
+index 810669c332..7b60b2f3b2 100644
+--- a/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_cluster-completed.spec_content
++++ b/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_cluster-completed.spec_content
+@@ -28,6 +28,7 @@ spec:
+     logLevel: info
+     runc:
+       version: 1.2.4
++    sandboxImage: registry.k8s.io/pause:3.10.1
+     version: 1.7.25
+   dnsZone: Z1AFAKE1ZON3YO
+   etcdClusters:
+@@ -143,7 +144,6 @@ spec:
+     evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
+     kubeconfigPath: /var/lib/kubelet/kubeconfig
+     logLevel: 2
+-    podInfraContainerImage: registry.k8s.io/pause:3.9
+     podManifestPath: /etc/kubernetes/manifests
+     protectKernelDefaults: true
+     registerSchedulable: true
+@@ -163,7 +163,6 @@ spec:
+     evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
+     kubeconfigPath: /var/lib/kubelet/kubeconfig
+     logLevel: 2
+-    podInfraContainerImage: registry.k8s.io/pause:3.9
+     podManifestPath: /etc/kubernetes/manifests
+     protectKernelDefaults: true
+     registerSchedulable: true
+diff --git a/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_nodeupconfig-master-us-test-1a_content b/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+index 07fa2dc958..0596b4202c 100644
+--- a/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
++++ b/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+@@ -292,7 +292,6 @@ KubeletConfig:
+     kops.k8s.io/kops-controller-pki: ""
+     node-role.kubernetes.io/control-plane: ""
+     node.kubernetes.io/exclude-from-external-load-balancers: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -314,6 +313,7 @@ containerdConfig:
+   logLevel: info
+   runc:
+     version: 1.2.4
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.7.25
+ etcdManifests:
+ - memfs://clusters.example.com/sharedsubnet.example.com/manifests/etcd/main-master-us-test-1a.yaml
+diff --git a/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_nodeupconfig-nodes_content b/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_nodeupconfig-nodes_content
+index a82f996c07..d4b778b84d 100644
+--- a/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_nodeupconfig-nodes_content
++++ b/tests/integration/update_cluster/shared_subnet/data/aws_s3_object_nodeupconfig-nodes_content
+@@ -43,7 +43,6 @@ KubeletConfig:
+   logLevel: 2
+   nodeLabels:
+     node-role.kubernetes.io/node: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -58,6 +57,7 @@ containerdConfig:
+   logLevel: info
+   runc:
+     version: 1.2.4
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.7.25
+ usesLegacyGossip: false
+ usesNoneDNS: false
+diff --git a/tests/integration/update_cluster/shared_vpc/data/aws_launch_template_master-us-test-1a.masters.sharedvpc.example.com_user_data b/tests/integration/update_cluster/shared_vpc/data/aws_launch_template_master-us-test-1a.masters.sharedvpc.example.com_user_data
+index 86b5c8ec0c..1bed803a5d 100644
+--- a/tests/integration/update_cluster/shared_vpc/data/aws_launch_template_master-us-test-1a.masters.sharedvpc.example.com_user_data
++++ b/tests/integration/update_cluster/shared_vpc/data/aws_launch_template_master-us-test-1a.masters.sharedvpc.example.com_user_data
+@@ -130,7 +130,7 @@ ClusterName: sharedvpc.example.com
+ ConfigBase: memfs://clusters.example.com/sharedvpc.example.com
+ InstanceGroupName: master-us-test-1a
+ InstanceGroupRole: ControlPlane
+-NodeupConfigHash: vLyD793wkyY3io/cOL0TCgf6pKKp9VuHO6OjzUJUCKs=
++NodeupConfigHash: Bw8Nk3LIh6tWkVK/GbzfHlxjsnI40KZSnhpohEGhMEY=
+ 
+ __EOF_KUBE_ENV
+ 
+diff --git a/tests/integration/update_cluster/shared_vpc/data/aws_launch_template_nodes.sharedvpc.example.com_user_data b/tests/integration/update_cluster/shared_vpc/data/aws_launch_template_nodes.sharedvpc.example.com_user_data
+index b9a97464c7..106a7b327f 100644
+--- a/tests/integration/update_cluster/shared_vpc/data/aws_launch_template_nodes.sharedvpc.example.com_user_data
++++ b/tests/integration/update_cluster/shared_vpc/data/aws_launch_template_nodes.sharedvpc.example.com_user_data
+@@ -153,7 +153,7 @@ ConfigServer:
+   - https://kops-controller.internal.sharedvpc.example.com:3988/
+ InstanceGroupName: nodes
+ InstanceGroupRole: Node
+-NodeupConfigHash: GCu1cwVEHrR6dbOg4gVCcQ88zJUbAA+sOWYA/lPyWG4=
++NodeupConfigHash: BVvwe6fHSa95/ofyOEfZocPIwS3UkfWGUrHN73E3nvs=
+ 
+ __EOF_KUBE_ENV
+ 
+diff --git a/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_cluster-completed.spec_content b/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_cluster-completed.spec_content
+index 5e17f99ade..6628303871 100644
+--- a/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_cluster-completed.spec_content
++++ b/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_cluster-completed.spec_content
+@@ -28,6 +28,7 @@ spec:
+     logLevel: info
+     runc:
+       version: 1.2.4
++    sandboxImage: registry.k8s.io/pause:3.10.1
+     version: 1.7.25
+   dnsZone: Z1AFAKE1ZON3YO
+   etcdClusters:
+@@ -143,7 +144,6 @@ spec:
+     evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
+     kubeconfigPath: /var/lib/kubelet/kubeconfig
+     logLevel: 2
+-    podInfraContainerImage: registry.k8s.io/pause:3.9
+     podManifestPath: /etc/kubernetes/manifests
+     protectKernelDefaults: true
+     registerSchedulable: true
+@@ -163,7 +163,6 @@ spec:
+     evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
+     kubeconfigPath: /var/lib/kubelet/kubeconfig
+     logLevel: 2
+-    podInfraContainerImage: registry.k8s.io/pause:3.9
+     podManifestPath: /etc/kubernetes/manifests
+     protectKernelDefaults: true
+     registerSchedulable: true
+diff --git a/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_nodeupconfig-master-us-test-1a_content b/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+index 56901db06f..80f30d9de9 100644
+--- a/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
++++ b/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+@@ -292,7 +292,6 @@ KubeletConfig:
+     kops.k8s.io/kops-controller-pki: ""
+     node-role.kubernetes.io/control-plane: ""
+     node.kubernetes.io/exclude-from-external-load-balancers: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -314,6 +313,7 @@ containerdConfig:
+   logLevel: info
+   runc:
+     version: 1.2.4
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.7.25
+ etcdManifests:
+ - memfs://clusters.example.com/sharedvpc.example.com/manifests/etcd/main-master-us-test-1a.yaml
+diff --git a/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_nodeupconfig-nodes_content b/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_nodeupconfig-nodes_content
+index c46040a02e..f4cc1b37d3 100644
+--- a/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_nodeupconfig-nodes_content
++++ b/tests/integration/update_cluster/shared_vpc/data/aws_s3_object_nodeupconfig-nodes_content
+@@ -43,7 +43,6 @@ KubeletConfig:
+   logLevel: 2
+   nodeLabels:
+     node-role.kubernetes.io/node: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -58,6 +57,7 @@ containerdConfig:
+   logLevel: info
+   runc:
+     version: 1.2.4
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.7.25
+ usesLegacyGossip: false
+ usesNoneDNS: false
+diff --git a/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_launch_template_master-us-test-1a.masters.minimal-ipv6.example.com_user_data b/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_launch_template_master-us-test-1a.masters.minimal-ipv6.example.com_user_data
+index 9575fb3341..c5982be68a 100644
+--- a/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_launch_template_master-us-test-1a.masters.minimal-ipv6.example.com_user_data
++++ b/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_launch_template_master-us-test-1a.masters.minimal-ipv6.example.com_user_data
+@@ -130,7 +130,7 @@ ClusterName: minimal-ipv6.example.com
+ ConfigBase: memfs://clusters.example.com/minimal-ipv6.example.com
+ InstanceGroupName: master-us-test-1a
+ InstanceGroupRole: ControlPlane
+-NodeupConfigHash: QXMgcfHCS2DCGFxjYjV5Z/hdL3dPNYk2U3pqIgUuSIc=
++NodeupConfigHash: Inz7L/YSaqqx+caV0c15SbHl9/+xqF5WA1symPd3DWM=
+ 
+ __EOF_KUBE_ENV
+ 
+diff --git a/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_launch_template_nodes.minimal-ipv6.example.com_user_data b/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_launch_template_nodes.minimal-ipv6.example.com_user_data
+index aab0338391..fd9b19c2f9 100644
+--- a/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_launch_template_nodes.minimal-ipv6.example.com_user_data
++++ b/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_launch_template_nodes.minimal-ipv6.example.com_user_data
+@@ -153,7 +153,7 @@ ConfigServer:
+   - https://kops-controller.internal.minimal-ipv6.example.com:3988/
+ InstanceGroupName: nodes
+ InstanceGroupRole: Node
+-NodeupConfigHash: v5f3fdfGKoObcimpgX3OWSOCcfXvo1j0yAWONGF2g8o=
++NodeupConfigHash: 7xEqooXP6NiadwfV+Jrfb1cai0qYh6k6UHTVAB1umqI=
+ 
+ __EOF_KUBE_ENV
+ 
+diff --git a/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_cluster-completed.spec_content b/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_cluster-completed.spec_content
+index ba50411927..fc10bc0a9d 100644
+--- a/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_cluster-completed.spec_content
++++ b/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_cluster-completed.spec_content
+@@ -32,6 +32,7 @@ spec:
+     logLevel: info
+     runc:
+       version: 1.2.4
++    sandboxImage: registry.k8s.io/pause:3.10.1
+     version: 1.7.25
+   dnsZone: Z1AFAKE1ZON3YO
+   etcdClusters:
+@@ -150,7 +151,6 @@ spec:
+     evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
+     kubeconfigPath: /var/lib/kubelet/kubeconfig
+     logLevel: 2
+-    podInfraContainerImage: registry.k8s.io/pause:3.9
+     podManifestPath: /etc/kubernetes/manifests
+     protectKernelDefaults: true
+     registerSchedulable: true
+@@ -171,7 +171,6 @@ spec:
+     evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
+     kubeconfigPath: /var/lib/kubelet/kubeconfig
+     logLevel: 2
+-    podInfraContainerImage: registry.k8s.io/pause:3.9
+     podManifestPath: /etc/kubernetes/manifests
+     protectKernelDefaults: true
+     registerSchedulable: true
+diff --git a/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_nodeupconfig-master-us-test-1a_content b/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+index dcef6a5afb..a7fd1fddb6 100644
+--- a/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
++++ b/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+@@ -292,7 +292,6 @@ KubeletConfig:
+     kops.k8s.io/kops-controller-pki: ""
+     node-role.kubernetes.io/control-plane: ""
+     node.kubernetes.io/exclude-from-external-load-balancers: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -314,6 +313,7 @@ containerdConfig:
+   logLevel: info
+   runc:
+     version: 1.2.4
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.7.25
+ etcdManifests:
+ - memfs://clusters.example.com/minimal-ipv6.example.com/manifests/etcd/main-master-us-test-1a.yaml
+diff --git a/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_nodeupconfig-nodes_content b/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_nodeupconfig-nodes_content
+index e65e650650..dc92e97d60 100644
+--- a/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_nodeupconfig-nodes_content
++++ b/tests/integration/update_cluster/shared_vpc_ipv6/data/aws_s3_object_nodeupconfig-nodes_content
+@@ -42,7 +42,6 @@ KubeletConfig:
+   logLevel: 2
+   nodeLabels:
+     node-role.kubernetes.io/node: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -57,6 +56,7 @@ containerdConfig:
+   logLevel: info
+   runc:
+     version: 1.2.4
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.7.25
+ usesLegacyGossip: false
+ usesNoneDNS: false
+diff --git a/tests/integration/update_cluster/unmanaged/data/aws_launch_template_master-us-test-1a.masters.unmanaged.example.com_user_data b/tests/integration/update_cluster/unmanaged/data/aws_launch_template_master-us-test-1a.masters.unmanaged.example.com_user_data
+index 7a52ce903c..914c6dd049 100644
+--- a/tests/integration/update_cluster/unmanaged/data/aws_launch_template_master-us-test-1a.masters.unmanaged.example.com_user_data
++++ b/tests/integration/update_cluster/unmanaged/data/aws_launch_template_master-us-test-1a.masters.unmanaged.example.com_user_data
+@@ -130,7 +130,7 @@ ClusterName: unmanaged.example.com
+ ConfigBase: memfs://clusters.example.com/unmanaged.example.com
+ InstanceGroupName: master-us-test-1a
+ InstanceGroupRole: ControlPlane
+-NodeupConfigHash: ib5wn0YYyY+OOBl49o3MSaZoHPgMSelqDhGZAdZVQo0=
++NodeupConfigHash: 1U6+01T3ZEWL7Nn/m1vFvLLtHC5XBI5cWC6JQOTHpN8=
+ 
+ __EOF_KUBE_ENV
+ 
+diff --git a/tests/integration/update_cluster/unmanaged/data/aws_launch_template_nodes.unmanaged.example.com_user_data b/tests/integration/update_cluster/unmanaged/data/aws_launch_template_nodes.unmanaged.example.com_user_data
+index 07e22cff80..519c9ed2eb 100644
+--- a/tests/integration/update_cluster/unmanaged/data/aws_launch_template_nodes.unmanaged.example.com_user_data
++++ b/tests/integration/update_cluster/unmanaged/data/aws_launch_template_nodes.unmanaged.example.com_user_data
+@@ -153,7 +153,7 @@ ConfigServer:
+   - https://kops-controller.internal.unmanaged.example.com:3988/
+ InstanceGroupName: nodes
+ InstanceGroupRole: Node
+-NodeupConfigHash: FOCmhByF3MAWGCsSVv9WLu2KH1JPz+DGjepFrhOZ2YM=
++NodeupConfigHash: h5eDuV83yiHGtQsvZlU2dqR97o9ZstnTxAoigNJUxbo=
+ 
+ __EOF_KUBE_ENV
+ 
+diff --git a/tests/integration/update_cluster/unmanaged/data/aws_s3_object_cluster-completed.spec_content b/tests/integration/update_cluster/unmanaged/data/aws_s3_object_cluster-completed.spec_content
+index 08ee1ec8d8..e4bc37f9fd 100644
+--- a/tests/integration/update_cluster/unmanaged/data/aws_s3_object_cluster-completed.spec_content
++++ b/tests/integration/update_cluster/unmanaged/data/aws_s3_object_cluster-completed.spec_content
+@@ -30,6 +30,7 @@ spec:
+     logLevel: info
+     runc:
+       version: 1.2.4
++    sandboxImage: registry.k8s.io/pause:3.10.1
+     version: 1.7.25
+   dnsZone: Z1AFAKE1ZON3YO
+   etcdClusters:
+@@ -145,7 +146,6 @@ spec:
+     evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
+     kubeconfigPath: /var/lib/kubelet/kubeconfig
+     logLevel: 2
+-    podInfraContainerImage: registry.k8s.io/pause:3.9
+     podManifestPath: /etc/kubernetes/manifests
+     protectKernelDefaults: true
+     registerSchedulable: true
+@@ -165,7 +165,6 @@ spec:
+     evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
+     kubeconfigPath: /var/lib/kubelet/kubeconfig
+     logLevel: 2
+-    podInfraContainerImage: registry.k8s.io/pause:3.9
+     podManifestPath: /etc/kubernetes/manifests
+     protectKernelDefaults: true
+     registerSchedulable: true
+diff --git a/tests/integration/update_cluster/unmanaged/data/aws_s3_object_nodeupconfig-master-us-test-1a_content b/tests/integration/update_cluster/unmanaged/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+index 64500d553c..e65b1b2953 100644
+--- a/tests/integration/update_cluster/unmanaged/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
++++ b/tests/integration/update_cluster/unmanaged/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+@@ -291,7 +291,6 @@ KubeletConfig:
+     kops.k8s.io/kops-controller-pki: ""
+     node-role.kubernetes.io/control-plane: ""
+     node.kubernetes.io/exclude-from-external-load-balancers: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -313,6 +312,7 @@ containerdConfig:
+   logLevel: info
+   runc:
+     version: 1.2.4
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.7.25
+ etcdManifests:
+ - memfs://clusters.example.com/unmanaged.example.com/manifests/etcd/main-master-us-test-1a.yaml
+diff --git a/tests/integration/update_cluster/unmanaged/data/aws_s3_object_nodeupconfig-nodes_content b/tests/integration/update_cluster/unmanaged/data/aws_s3_object_nodeupconfig-nodes_content
+index 664e92e7b9..a1c14b05e2 100644
+--- a/tests/integration/update_cluster/unmanaged/data/aws_s3_object_nodeupconfig-nodes_content
++++ b/tests/integration/update_cluster/unmanaged/data/aws_s3_object_nodeupconfig-nodes_content
+@@ -43,7 +43,6 @@ KubeletConfig:
+   logLevel: 2
+   nodeLabels:
+     node-role.kubernetes.io/node: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -58,6 +57,7 @@ containerdConfig:
+   logLevel: info
+   runc:
+     version: 1.2.4
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.7.25
+ usesLegacyGossip: false
+ usesNoneDNS: false
+diff --git a/tests/integration/update_cluster/vfs-said/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data b/tests/integration/update_cluster/vfs-said/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
+index f9e9d03953..cfb61715a4 100644
+--- a/tests/integration/update_cluster/vfs-said/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
++++ b/tests/integration/update_cluster/vfs-said/data/aws_launch_template_master-us-test-1a.masters.minimal.example.com_user_data
+@@ -130,7 +130,7 @@ ClusterName: minimal.example.com
+ ConfigBase: memfs://clusters.example.com/minimal.example.com
+ InstanceGroupName: master-us-test-1a
+ InstanceGroupRole: ControlPlane
+-NodeupConfigHash: hwe4qrB8lrpQUByJDxUeDm6WzYWNuE7nQHAfP5g5nQo=
++NodeupConfigHash: v1G8dUnySTcFSgsLymYfHH8ceR3deEJ+CDyFZklRX5g=
+ 
+ __EOF_KUBE_ENV
+ 
+diff --git a/tests/integration/update_cluster/vfs-said/data/aws_launch_template_nodes.minimal.example.com_user_data b/tests/integration/update_cluster/vfs-said/data/aws_launch_template_nodes.minimal.example.com_user_data
+index 4b6fe88318..13b9b6d58a 100644
+--- a/tests/integration/update_cluster/vfs-said/data/aws_launch_template_nodes.minimal.example.com_user_data
++++ b/tests/integration/update_cluster/vfs-said/data/aws_launch_template_nodes.minimal.example.com_user_data
+@@ -153,7 +153,7 @@ ConfigServer:
+   - https://kops-controller.internal.minimal.example.com:3988/
+ InstanceGroupName: nodes
+ InstanceGroupRole: Node
+-NodeupConfigHash: RwbCzWuKwqBp91KWu4IEZpgBJ0UVI0mpR+lv9mY5/nQ=
++NodeupConfigHash: MBILso1750yJWFfuk5/KINzohd8nOsHTvT6sHBIZjgU=
+ 
+ __EOF_KUBE_ENV
+ 
+diff --git a/tests/integration/update_cluster/vfs-said/data/aws_s3_object_cluster-completed.spec_content b/tests/integration/update_cluster/vfs-said/data/aws_s3_object_cluster-completed.spec_content
+index 20891f0ab9..4905dae89e 100644
+--- a/tests/integration/update_cluster/vfs-said/data/aws_s3_object_cluster-completed.spec_content
++++ b/tests/integration/update_cluster/vfs-said/data/aws_s3_object_cluster-completed.spec_content
+@@ -28,6 +28,7 @@ spec:
+     logLevel: info
+     runc:
+       version: 1.2.4
++    sandboxImage: registry.k8s.io/pause:3.10.1
+     version: 1.7.25
+   dnsZone: Z1AFAKE1ZON3YO
+   etcdClusters:
+@@ -143,7 +144,6 @@ spec:
+     evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
+     kubeconfigPath: /var/lib/kubelet/kubeconfig
+     logLevel: 2
+-    podInfraContainerImage: registry.k8s.io/pause:3.9
+     podManifestPath: /etc/kubernetes/manifests
+     protectKernelDefaults: true
+     registerSchedulable: true
+@@ -163,7 +163,6 @@ spec:
+     evictionHard: memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<10%,imagefs.inodesFree<5%
+     kubeconfigPath: /var/lib/kubelet/kubeconfig
+     logLevel: 2
+-    podInfraContainerImage: registry.k8s.io/pause:3.9
+     podManifestPath: /etc/kubernetes/manifests
+     protectKernelDefaults: true
+     registerSchedulable: true
+diff --git a/tests/integration/update_cluster/vfs-said/data/aws_s3_object_nodeupconfig-master-us-test-1a_content b/tests/integration/update_cluster/vfs-said/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+index 2bda32e2dd..03972c8795 100644
+--- a/tests/integration/update_cluster/vfs-said/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
++++ b/tests/integration/update_cluster/vfs-said/data/aws_s3_object_nodeupconfig-master-us-test-1a_content
+@@ -292,7 +292,6 @@ KubeletConfig:
+     kops.k8s.io/kops-controller-pki: ""
+     node-role.kubernetes.io/control-plane: ""
+     node.kubernetes.io/exclude-from-external-load-balancers: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -314,6 +313,7 @@ containerdConfig:
+   logLevel: info
+   runc:
+     version: 1.2.4
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.7.25
+ etcdManifests:
+ - memfs://clusters.example.com/minimal.example.com/manifests/etcd/main-master-us-test-1a.yaml
+diff --git a/tests/integration/update_cluster/vfs-said/data/aws_s3_object_nodeupconfig-nodes_content b/tests/integration/update_cluster/vfs-said/data/aws_s3_object_nodeupconfig-nodes_content
+index 2d88fa5a47..fe36f97d54 100644
+--- a/tests/integration/update_cluster/vfs-said/data/aws_s3_object_nodeupconfig-nodes_content
++++ b/tests/integration/update_cluster/vfs-said/data/aws_s3_object_nodeupconfig-nodes_content
+@@ -43,7 +43,6 @@ KubeletConfig:
+   logLevel: 2
+   nodeLabels:
+     node-role.kubernetes.io/node: ""
+-  podInfraContainerImage: registry.k8s.io/pause:3.9
+   podManifestPath: /etc/kubernetes/manifests
+   protectKernelDefaults: true
+   registerSchedulable: true
+@@ -58,6 +57,7 @@ containerdConfig:
+   logLevel: info
+   runc:
+     version: 1.2.4
++  sandboxImage: registry.k8s.io/pause:3.10.1
+   version: 1.7.25
+ usesLegacyGossip: false
+ usesNoneDNS: false
+-- 
+2.45.2
+


### PR DESCRIPTION
To fix kops that conflicts with the v1-35 binary, we need this patch to remove pod infra container field from the kubelet binary that kops does not recognize for v1-35.