### PR TITLE
fix go version directive for iptables-wrapper and update iptables builder image to go 1.25

### DIFF
--- a/eks-distro-base/Dockerfile.minimal-base-iptables
+++ b/eks-distro-base/Dockerfile.minimal-base-iptables
@@ -21,7 +21,7 @@
 ARG BUILDER_IMAGE
 ARG BASE_IMAGE
 
-FROM public.ecr.aws/eks-distro-build-tooling/golang:1.23 as iptables-wrapper-builder
+FROM public.ecr.aws/eks-distro-build-tooling/golang:1.25 as iptables-wrapper-builder
 
 COPY iptables-wrappers/ /iptables-wrappers
 RUN set -x && \

--- a/eks-distro-base/iptables-wrappers/go.mod
+++ b/eks-distro-base/iptables-wrappers/go.mod
@@ -1,3 +1,3 @@
 module github.com/kubernetes-sigs/iptables-wrappers
 
-go 1.25.3
+go 1.25

--- a/eks-distro-base/tests/Dockerfile
+++ b/eks-distro-base/tests/Dockerfile
@@ -40,7 +40,7 @@ RUN ["update-alternatives", "--set", "ip6tables", "/usr/sbin/ip6tables-nft"]
 
 CMD ["iptables"]
 
-FROM public.ecr.aws/eks-distro-build-tooling/golang:1.23-al${AL_TAG} as iptables-wrapper-tests-builder
+FROM public.ecr.aws/eks-distro-build-tooling/golang:1.25-al${AL_TAG} as iptables-wrapper-tests-builder
 
 COPY iptables-wrappers /iptables-wrappers
 RUN cd /iptables-wrappers && \


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
