### PR TITLE
Fix curl endpoint for AL2 python-3.7 download

### DIFF
--- a/eks-distro-base/query_yum_for_python_version.sh
+++ b/eks-distro-base/query_yum_for_python_version.sh
@@ -23,11 +23,11 @@ AL_TAG="$2"
 
 
 if [ "$AL_TAG" = "2023" ]; then
-    MIRROR=$(curl -s https://cdn.amazonlinux.com/al2023/core/mirrors/latest/debuginfo/x86_64/mirror.list)
-    VERSION=$(curl -s ${MIRROR}repodata/primary.xml.gz | gunzip | sed -rn "s/^.*python${PYTHON_VERSION}-debuginfo-(.*)\-[0-9].amzn.*$/\1/p" | sed '/-/!{s/$/_/}' | sort -V | sed 's/_$//' | tail -1)
+    MIRROR=$(curl -s https://cdn.amazonlinux.com/al2023/core/mirrors/latest/debuginfo/x86_64/mirror.list | sed 's:/$::')
+    VERSION=$(curl -sS ${MIRROR}/repodata/primary.xml.gz | gunzip | sed -rn "s/^.*python${PYTHON_VERSION}-debuginfo-(.*)\-[0-9].amzn.*$/\1/p" | sed '/-/!{s/$/_/}' | sort -V | sed 's/_$//' | tail -1)
 else
-    MIRROR=$(curl -s http://amazonlinux.default.amazonaws.com/2/core/latest/debuginfo/x86_64/mirror.list)
-    VERSION=$(curl -s $MIRROR/repodata/primary.xml.gz | gunzip | sed -rn "s/^.*python3-debuginfo-(.*)\-[0-9].amzn.*$/\1/p" | sed '/-/!{s/$/_/}' | sort -V | sed 's/_$//' | tail -1)
+    MIRROR=$(curl -s http://amazonlinux.default.amazonaws.com/2/core/latest/debuginfo/x86_64/mirror.list | sed 's:/$::')
+    VERSION=$(curl -sS $MIRROR/repodata/primary.xml.gz | gunzip | sed -rn "s/^.*python3-debuginfo-(.*)\-[0-9].amzn.*$/\1/p" | sed '/-/!{s/$/_/}' | sort -V | sed 's/_$//' | tail -1)
 fi
 
 if [ -f /etc/os-release ] && grep "Amazon Linux 2" /etc/os-release; then


### PR DESCRIPTION
*Issue #, if available:*
eks-distro-base-tooling-periodic-al-2 is failing with "gzip: stdin: not in gzip format" while building eks-distro-minimal-base-python-3.7. 

*Description of changes:*
1. Yum looks to be constructing Curl Url's wrongly with extra slash causing AccessDenied exception from cloudfront (backed by Server S3). MIRROR endpoint for AL2023 and AL2 are inconsistent with "/" at end. 
2. Fixed by normalizing MIRROR URLs to remove trailing slashes, then explicitly adding the separator when building the repodata path. Also added -sS flag to curl for silent mode with error reporting.

% curl -s https://cdn.amazonlinux.com/2/core/2.0/debuginfo/x86_64/cb76372c7dd7f0831630d6065a92440477bc5d2290f30454701f425445700db8//repodata/primary.xml.gz
<?xml version="1.0" encoding="UTF-8"?>
<Error><Code>AccessDenied</Code><Message>Access Denied</Message><RequestId>Q44A3ZCEFQ6KGV85</RequestId><HostId>xJR2javs4J0DX0HUN1hQEoGSnF3jOgv98Ijc7lw3pHWWdXuexfyjYZgTLsuXiZzzPPDlPO+kIlY=</HostId></Error>%

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
