### PR TITLE
Removed setup-permissions target from go-runner make file

### DIFF
--- a/projects/go-runner/Makefile
+++ b/projects/go-runner/Makefile
@@ -90,11 +90,6 @@ fix-licenses:
 	build/generate_attribution.sh $(PROJECT_DIRECTORY)/$(RELEASE_BRANCH) $(GO_VERSION)
 
 
-.PHONY: setup-permissions
-setup-permissions:
-	aws ecr get-login-password --region $(AWS_REGION) | docker login --username AWS --password-stdin $(IMAGE_REPO)
-
-
 .PHONY: images
 images: buildkit-check
 	$(BASE_DIRECTORY)/scripts/buildkit.sh \
@@ -130,7 +125,7 @@ buildkit-check:
 
 
 .PHONY: release
-release: setup-permissions process-go-versions clean
+release: process-go-versions clean
 
 
 .PHONY: clean


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

setup-permissions failed on Prow
```
aws ecr get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/eks-distro-build-tooling
time="2026-02-25T23:58:57Z" level=info msg="Error logging in to endpoint, trying next endpoint" error="login attempt to https://public.ecr.aws/v2/ failed with status: 403 Forbidden"
login attempt to https://public.ecr.aws/v2/ failed with status: 403 Forbidden
make: *** [setup-permissions] Error 1
```
Failed job logs [here](https://prow.eks.amazonaws.com/view/s3/prowdataclusterstack-316434458-prowbucket7c73355c-1n9f9v93wpjcm/logs/go-runner-images-postsubmit-al-2/2026808993866846208)

Reason:
Framework mounted credentials helper to the container - job yaml [here](https://prow.eks.amazonaws.com/rerun?mode=latest&prowjob=d95a0a20-12a5-11f1-8e12-b62ff9bc3c72), and current role doesn't have permissions for get-login-password.
```
      - mountPath: /root/.docker/config.json
        name: docker-registry-config
        subPath: config.json
```

Fix:
Removed explicit docker login target.

Testing:
Job succeeded after removing `setup-permissions` target from release  - [here](https://prow.eks.amazonaws.com/view/s3/prowdataclusterstack-316434458-prowbucket7c73355c-1n9f9v93wpjcm/logs/go-runner-images-postsubmit-al-2/2027056771008303104)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
