### PR TITLE
Add golang 1.26 to builder-base

### DIFF
--- a/builder-base/Dockerfile
+++ b/builder-base/Dockerfile
@@ -441,6 +441,24 @@ RUN --mount=type=cache,target=/var/cache/yum,sharing=locked \
     /install_golang.sh $GOLANG_VERSION_125 && \
     /remove_yum_packages.sh
 
+FROM ${BUILDER_IMAGE} as golang-1.26
+ARG TARGETARCH
+ARG GOLANG_VERSION_126
+ARG GOLANG_RPM_SOURCE_DIR
+WORKDIR /workdir
+ENV GOPATH /go
+ENV PATH="/go/bin/:$PATH"
+
+COPY --link --from=upx  /upx /
+COPY ./scripts/install_base_yum_packages.sh ./scripts/remove_yum_packages.sh ./scripts/common_vars.sh \
+    ./scripts/install_golang.sh /
+COPY $GOLANG_RPM_SOURCE_DIR/linux/arm64/go1.26*.tar.gz /tmp/linux/arm64/
+COPY $GOLANG_RPM_SOURCE_DIR/linux/amd64/go1.26*.tar.gz /tmp/linux/amd64/
+RUN --mount=type=cache,target=/var/cache/yum,sharing=locked \
+    /install_base_yum_packages.sh && \
+    /install_golang.sh $GOLANG_VERSION_126 && \
+    /remove_yum_packages.sh
+
 FROM ${BUILDER_IMAGE} as skopeo
 ARG TARGETARCH
 ARG GOPROXY
@@ -625,6 +643,22 @@ RUN --mount=type=cache,target=/root/.cache/go-build,sharing=locked \
     --mount=type=secret,id=netrc,target=/root/.netrc \
     /install_go_licenses.sh
 
+FROM ${BUILDER_IMAGE} as go-licenses-1.26
+ARG TARGETARCH
+ARG GOPROXY
+ARG GO_LICENSES_VERSION
+ENV GO_LICENSES_VERSION=$GO_LICENSES_VERSION
+WORKDIR /workdir
+ENV GOPATH /go
+ENV PATH="/go/bin/:$PATH"
+COPY --link --from=upx  /upx /
+COPY --link --from=golang-1.26 /golang-1.26 /
+COPY ./scripts/common_vars.sh \
+    ./scripts/install_go_licenses.sh /
+RUN --mount=type=cache,target=/root/.cache/go-build,sharing=locked \
+    --mount=type=secret,id=netrc,target=/root/.netrc \
+    /install_go_licenses.sh
+
 FROM ${BUILDER_IMAGE} as go-vuln-check
 ARG TARGETARCH
 ARG GOPROXY
@@ -684,6 +718,8 @@ COPY --link --from=golang-1.24 /golang-1.24 /
 COPY --link --from=go-licenses-1.24 /go-licenses-1.24 /
 COPY --link --from=golang-1.25 /golang-1.25 /
 COPY --link --from=go-licenses-1.25 /go-licenses-1.25 /
+COPY --link --from=golang-1.26 /golang-1.26 /
+COPY --link --from=go-licenses-1.26 /go-licenses-1.26 /
 # add the default golang verison last so its /usr/bin/go
 # takes precendent
 COPY --link --from=golang-1.20 /golang-1.20 /

--- a/builder-base/scripts/install_golang.sh
+++ b/builder-base/scripts/install_golang.sh
@@ -64,7 +64,11 @@ function build::go::extract {
 
   # go stopped building addr2line, doc, objdump, pprof, and trace by default starting with 1.25 so building them here
   if [[ "$major_version" -eq 1 && "$minor_version" -ge 25 ]]; then
-      local binaries=("addr2line" "doc" "objdump" "pprof" "trace")
+      local binaries=("addr2line" "objdump" "pprof" "trace")
+      # cmd/doc was removed in Go 1.26: https://go.dev/doc/go1.26#tools
+      if [[ "$minor_version" -lt 26 ]]; then
+          binaries+=("doc")
+      fi
       pushd /tmp/go-extracted/go/
       for binary in "${binaries[@]}"; do
         bin/go build -o "pkg/tool/linux_$TARGETARCH/$binary" "./src/cmd/$binary"
@@ -147,4 +151,9 @@ mv ${GOPATH} ${NEWROOT}/${GOPATH}
 #   process, then using the compressed version will require more RAM and/or
 #   swap space.  So, shell programs (bash, csh, etc.)  and ``make''
 #   might not be good candidates for compression.
-time upx --best --no-lzma ${NEWROOT}/root/sdk/go${VERSION%-*}/bin/go ${NEWROOT}/root/sdk/go${VERSION%-*}/pkg/tool/linux_$TARGETARCH/{addr2line,asm,cgo,cover,doc,objdump,pprof,trace,vet}
+UPX_TOOLS=(addr2line asm cgo cover objdump pprof trace vet)
+MINOR=$(echo "${VERSION%-*}" | cut -d. -f2)
+if [[ "$MINOR" -lt 26 ]]; then
+  UPX_TOOLS+=(doc)
+fi
+time upx --best --no-lzma ${NEWROOT}/root/sdk/go${VERSION%-*}/bin/go $(printf "${NEWROOT}/root/sdk/go${VERSION%-*}/pkg/tool/linux_$TARGETARCH/%s " "${UPX_TOOLS[@]}")

--- a/builder-base/scripts/validate_components.sh
+++ b/builder-base/scripts/validate_components.sh
@@ -77,6 +77,8 @@ if [ "${FINAL_STAGE_BASE}" = "full-copy-stage" ]; then
   /go/go1.24/bin/go-licenses --help
   /go/bin/go1.25 version
   /go/go1.25/bin/go-licenses --help
+  /go/bin/go1.26 version
+  /go/go1.26/bin/go-licenses --help
 
   gcc --version
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Adding support for golang 1.26 for builder base image which will result in new gorunner images on 1.26.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
