### PR TITLE
Trigger AL2 iptables base image rebuild for Go 1.25.9 CVE fixes

### DIFF
--- a/EKS_DISTRO_TAG_FILE.yaml
+++ b/EKS_DISTRO_TAG_FILE.yaml
@@ -3,7 +3,7 @@ al2:
   eks-distro-minimal-base: 2026-04-02-1775156511.2
   eks-distro-minimal-base-nonroot: 2026-04-02-1775156511.2
   eks-distro-minimal-base-glibc: 2026-04-02-1775156511.2
-  eks-distro-minimal-base-iptables: 2026-04-02-1775156511.2
+  eks-distro-minimal-base-iptables: null
   eks-distro-minimal-base-docker-client: 2026-04-14-1776193302.2
   eks-distro-minimal-base-csi: 2026-04-14-1776193302.2
   eks-distro-minimal-base-csi-ebs: 2026-04-02-1775156511.2


### PR DESCRIPTION
AL2 rebuild to 1.25.9

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
