### PR TITLE
Add least-privilege permissions to the last three workflows

### DIFF
--- a/.github/workflows/base-image-pr-notifier.yml
+++ b/.github/workflows/base-image-pr-notifier.yml
@@ -2,6 +2,7 @@ name: baseimage-pr-notifier
 on:
   pull_request_target:
     types: [opened]
+permissions: {}
 jobs:
   baseimage-pr-notifier:
     runs-on: ubuntu-latest

--- a/.github/workflows/docker-check.yml
+++ b/.github/workflows/docker-check.yml
@@ -1,9 +1,11 @@
 name: Docker Check
 on:
   pull_request:
-    paths: 
+    paths:
       - 'Docker*'
       - '**/*/Docker*'
+permissions:
+  contents: read
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/go-coverage.yml
+++ b/.github/workflows/go-coverage.yml
@@ -3,6 +3,8 @@ on:
   pull_request:
     paths:
       - 'tools/eksDistroBuildToolingOpsTools/**'
+permissions:
+  contents: read
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Three workflows in this repo still inherit the default `GITHUB_TOKEN` scopes because they don't declare a `permissions:` block. The other workflows here already do (see `golangci-lint.yml` and `label.yml`), so this PR just closes the gap.

Files touched:

- `.github/workflows/docker-check.yml` — `pull_request` triggered Dockerfile lint. Only checks out the tree and greps it. `contents: read`.
- `.github/workflows/go-coverage.yml` — `pull_request` triggered Go test + Codecov upload. Codecov action with default token, no GitHub API writes from the workflow itself. `contents: read`.
- `.github/workflows/base-image-pr-notifier.yml` — runs on `pull_request_target`, which makes its token a write token by default even on fork PRs. The workflow only POSTs to a Slack webhook; it makes no GitHub API calls. `permissions: {}` (deny everything) is the right fit.

No behavior change — only token scopes are tightened. YAML re-parsed with `yaml.safe_load` for each file.

Why this matters: `pull_request_target` on `base-image-pr-notifier.yml` is the headline. Even though the script today only touches Slack, a future maintainer adding a `gh` call or an `octokit` step would silently inherit write access to the repo. Declaring `permissions: {}` now means any future PR that needs a scope has to add it explicitly and be reviewed.