### PR TITLE
Fixed missing Dockerfile bug on docker buildx builds

### DIFF
--- a/scripts/buildkit.sh
+++ b/scripts/buildkit.sh
@@ -45,6 +45,8 @@ if [ "${USE_BUILDX:-}" == "true" ]; then
                 shift
                 if [[ $1 = context* ]]; then
                     ARGS+="${1/context=/} "        
+                elif [[ $1 = dockerfile* ]]; then
+                    ARGS+="-f ${1/dockerfile=/}/Dockerfile "
                 fi
                 shift
                 ;;

--- a/scripts/buildkit.sh
+++ b/scripts/buildkit.sh
@@ -46,7 +46,10 @@ if [ "${USE_BUILDX:-}" == "true" ]; then
                 if [[ $1 = context* ]]; then
                     ARGS+="${1/context=/} "        
                 elif [[ $1 = dockerfile* ]]; then
-                    ARGS+="-f ${1/dockerfile=/}/Dockerfile "
+                    # Only add if --file not already set via --opt filename
+                    if [[ "$ARGS" != *"--file"* ]]; then
+                        ARGS+="--file ${1/dockerfile=/}/Dockerfile "
+                    fi
                 fi
                 shift
                 ;;


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
AL2 images with periodic builds use docker buildx for generating images. buildkit.sh converts arguments to docker buildx format, however it misses dockerfile argument.

Failed job [link](https://prow.eks.amazonaws.com/view/s3/prowdataclusterstack-316434458-prowbucket7c73355c-1n9f9v93wpjcm/logs/go-runner-images-periodic-al-2/2056510209211240448)
```
/home/prow/go/src/github.com/aws/eks-distro-build-tooling/scripts/buildkit.sh \
	build \
	--frontend dockerfile.v0 \
	--opt platform=linux/amd64,linux/arm64 \
	--opt build-arg:GO_VERSION=1.25 \
	--opt build-arg:BASE_IMAGE=public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base:2026-04-02-1775156511.2 \
	--local dockerfile=/home/prow/go/src/github.com/aws/eks-distro-build-tooling/projects/go-runner/docker/go-runner \
	--local context=/home/prow/go/src/github.com/aws/eks-distro-build-tooling/projects/go-runner/0.18.0/_output \
	--progress plain \
	--output type=image,oci-mediatypes=true,\"name=public.ecr.aws/eks-distro-build-tooling/go-runner:v0.18.0-go-1.25.10.2,public.ecr.aws/eks-distro-build-tooling/go-runner:v0.18.0-go-1.25-latest.al2\",push=true

Building with with docker buildx

Building attempt: 1
#0 building with "eks-d-builders" instance using remote driver

#1 [internal] load build definition from Dockerfile
#1 transferring dockerfile: 2B done
#1 DONE 0.0s
ERROR: failed to solve: failed to read dockerfile: open Dockerfile: no such file or directory
make[2]: *** [images] Error 1
```
Fix: Translated `--local dockerfile=/<directory path>` to docker buildx format `-f /<directory path>/Dockerfile`.

Testing: 
Successful build [link](https://prow.eks.amazonaws.com/view/s3/prowdataclusterstack-316434458-prowbucket7c73355c-1n9f9v93wpjcm/logs/go-runner-images-periodic-al-2/2056794182382522368)
```
/home/prow/go/src/github.com/aws/eks-distro-build-tooling/scripts/buildkit.sh \
	build \
	--frontend dockerfile.v0 \
	--opt platform=linux/amd64,linux/arm64 \
	--opt build-arg:GO_VERSION=1.26 \
	--opt build-arg:BASE_IMAGE=public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base:2026-04-02-1775156511.2 \
	--local dockerfile=/home/prow/go/src/github.com/aws/eks-distro-build-tooling/projects/go-runner/docker/go-runner \
	--local context=/home/prow/go/src/github.com/aws/eks-distro-build-tooling/projects/go-runner/0.18.0/_output \
	--progress plain \
	--output type=image,oci-mediatypes=true,\"name=public.ecr.aws/eks-distro-build-tooling/go-runner:v0.18.0-go-1.26.3.2,public.ecr.aws/eks-distro-build-tooling/go-runner:v0.18.0-go-1.26-latest.al2\",push=true

Building with with docker buildx

Building attempt: 1
#0 building with "eks-d-builders" instance using remote driver

#1 [internal] load build definition from Dockerfile
#1 transferring dockerfile: 950B done
#1 DONE 0.0s

#2 [linux/amd64 internal] load metadata for public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base:2026-04-02-1775156511.2

```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
