### PR TITLE
ci: declare workflow-level contents: read on docker-check and go-coverage

### DIFF
--- a/.github/workflows/docker-check.yml
+++ b/.github/workflows/docker-check.yml
@@ -4,6 +4,9 @@ on:
     paths: 
       - 'Docker*'
       - '**/*/Docker*'
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/go-coverage.yml
+++ b/.github/workflows/go-coverage.yml
@@ -3,6 +3,9 @@ on:
   pull_request:
     paths:
       - 'tools/eksDistroBuildToolingOpsTools/**'
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Pins the default `GITHUB_TOKEN` to `contents: read` at the workflow level. The workflow runs checks only; no GitHub API writes.

Same post-CVE-2025-30066 (`tj-actions/changed-files`) supply-chain hardening pattern. YAML validated locally with `yaml.safe_load`.