### PR TITLE
Fix base image pr notifier env

### DIFF
--- a/.github/workflows/base-image-pr-notifier.yml
+++ b/.github/workflows/base-image-pr-notifier.yml
@@ -9,9 +9,10 @@ jobs:
       - name: Check PR title and notify Slack
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
         run: |
-          if [[ "$PR_TITLE" == *"Update base image"* || "$PR_TITLE" == *"Update builder-base image"* || "$PR_TITLE" == *"Update golang"* || "$PR_TITLE" == *"Update GIT_TAG and GOLANG_VERSION"* ]]; then
+          if [[ "$PR_AUTHOR" == "eks-distro-pr-bot" && ( "$PR_TITLE" == *"Update base image"* || "$PR_TITLE" == *"Update builder-base image"* || "$PR_TITLE" == *"Update golang"* || "$PR_TITLE" == *"Update GIT_TAG and GOLANG_VERSION"* ) ]]; then
             curl -X POST $SLACK_WEBHOOK
             echo "Base image update detected - Slack notification sent"
           else

--- a/.github/workflows/base-image-pr-notifier.yml
+++ b/.github/workflows/base-image-pr-notifier.yml
@@ -11,7 +11,7 @@ jobs:
           PR_TITLE: ${{ github.event.pull_request.title }}
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
         run: |
-          if [[ "$PR_TITLE" == *"Update base image"* ]]; then
+          if [[ "$PR_TITLE" == *"Update base image"* || "$PR_TITLE" == *"Update builder-base image"* || "$PR_TITLE" == *"Update golang"* || "$PR_TITLE" == *"Update GIT_TAG and GOLANG_VERSION"* ]]; then
             curl -X POST $SLACK_WEBHOOK
             echo "Base image update detected - Slack notification sent"
           else

--- a/.github/workflows/base-image-pr-notifier.yml
+++ b/.github/workflows/base-image-pr-notifier.yml
@@ -9,6 +9,7 @@ jobs:
       - name: Check PR title and notify Slack
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
         run: |
           if [[ "$PR_TITLE" == *"Update base image"* ]]; then
             curl -X POST $SLACK_WEBHOOK
@@ -17,5 +18,3 @@ jobs:
             echo "Not a base image update PR - Skipping notification"
           fi
           exit 0
-        env:
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fixes slack notification for eks-distro-pr-bot open PRs

We have been seeing this error in Github actions for the last 8 months.
```
 Invalid workflow file: .github/workflows/base-image-pr-notifier.yml#L1
(Line: 20, Col: 9): 'env' is already defined
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
