### PR TITLE
Add upstream image check for helm chart images

### DIFF
--- a/pr-scripts/create_pr.sh
+++ b/pr-scripts/create_pr.sh
@@ -35,6 +35,8 @@ MINIMAL_IMAGE_REBUILD_PJ_NAME="quarterly-minimal-image-rebuild"
 
 GOLANG_RELEASE_PERIODIC="check-upstream-golang-release"
 
+HELM_CHART_IMAGES_PERIODIC="check-upstream-helm-chart-images"
+
 CHANGED_FILE="tag file(s)"
 CHANGED_COMPONENT="base image"
 if [[ $REPO =~ "prow-jobs" ]]; then
@@ -53,6 +55,10 @@ if [[ $JOB_NAME =~ $GOLANG_RELEASE_PERIODIC ]]; then
   CHANGED_FILE="builder-base and eks-distro-base"
   CHANGED_COMPONENT="golang"
 fi
+if [[ $JOB_NAME =~ $HELM_CHART_IMAGES_PERIODIC ]]; then
+  CHANGED_FILE="helm chart IMAGE_TAG files"
+  CHANGED_COMPONENT="helm chart images"
+fi
 
 if [ $REPO_OWNER = "aws" ]; then
   ORIGIN_ORG="eks-distro-pr-bot"
@@ -70,6 +76,8 @@ else
     PR_BODY_FILE=${SCRIPT_ROOT}/../pr-scripts/prow_cp_pr_body
   elif [[ $JOB_NAME =~ $MINIMAL_IMAGE_REBUILD_PJ_NAME ]]; then
     PR_BODY_FILE=${SCRIPT_ROOT}/../pr-scripts/rebuild-minimal-images-pr-body
+  elif [[ $JOB_NAME =~ $HELM_CHART_IMAGES_PERIODIC ]]; then
+    PR_BODY_FILE=${SCRIPT_ROOT}/../pr-scripts/helm_chart_image_pr_body
   else
     PR_BODY_FILE=${SCRIPT_ROOT}/../pr-scripts/eks_distro_base_other_repo_pr_body
     if [ $REPO = "eks-distro-build-tooling" ]; then
@@ -137,6 +145,13 @@ if [[ $JOB_NAME =~ $GOLANG_RELEASE_PERIODIC ]]; then
   git add ./eks-distro-base/make-tests/make-dry-run
   # TODO: remove after verifying what changes are unstaged
   git diff --name-only
+fi
+
+if [[ $JOB_NAME =~ $HELM_CHART_IMAGES_PERIODIC ]]; then
+  cp -f ${SCRIPT_ROOT}/../projects/kubernetes/test-infra/IMAGE_TAG ./projects/kubernetes/test-infra/IMAGE_TAG
+  cp -f ${SCRIPT_ROOT}/../projects/gomods/athens/IMAGE_TAG ./projects/gomods/athens/IMAGE_TAG
+  cp -f ${SCRIPT_ROOT}/../projects/kubernetes-sigs/external-dns/IMAGE_TAG ./projects/kubernetes-sigs/external-dns/IMAGE_TAG
+  git add ./projects/kubernetes/test-infra/IMAGE_TAG ./projects/gomods/athens/IMAGE_TAG ./projects/kubernetes-sigs/external-dns/IMAGE_TAG
 fi
 
 FILES_ADDED=$(git diff --staged --name-only)

--- a/pr-scripts/helm_chart_image_pr_body
+++ b/pr-scripts/helm_chart_image_pr_body
@@ -1,0 +1,1 @@
+This PR updates the helm chart image IMAGE_TAG files to the latest upstream image releases. Merging it triggers the corresponding image build postsubmits to rebuild and publish the mirrored images.

--- a/projects/gomods/athens/Makefile
+++ b/projects/gomods/athens/Makefile
@@ -37,6 +37,10 @@ images: buildkit-check
 		--local context=. \
 		--output type=image,oci-mediatypes=true,"name=$(IMAGE)",push=true
 
+.PHONY: check-athens-release
+check-athens-release:
+	$(MAKE_ROOT)/check_upstream_athens_image.sh
+
 .PHONY: build
 build: local-images
 

--- a/projects/gomods/athens/check_upstream_athens_image.sh
+++ b/projects/gomods/athens/check_upstream_athens_image.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+set -o pipefail
+set -x
+
+SCRIPT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+IMAGE_TAG_FILE="${SCRIPT_ROOT}/IMAGE_TAG"
+
+UPSTREAM_IMAGE="docker.io/gomods/athens"
+
+LATEST_TAG=$(skopeo list-tags "docker://${UPSTREAM_IMAGE}" \
+  | jq -r '.Tags[]' \
+  | grep -E '^v?[0-9]+\.[0-9]+\.[0-9]+$' \
+  | sort -V \
+  | tail -n1)
+
+if [ -z "$LATEST_TAG" ]; then
+  echo "Failed to determine latest upstream Athens image tag"
+  exit 1
+fi
+
+CURRENT_TAG=$(cat "$IMAGE_TAG_FILE")
+if [ "$LATEST_TAG" != "$CURRENT_TAG" ]; then
+  echo "Updating Athens IMAGE_TAG: ${CURRENT_TAG} -> ${LATEST_TAG}"
+  printf '%s\n' "$LATEST_TAG" > "$IMAGE_TAG_FILE"
+else
+  echo "Athens IMAGE_TAG already at latest: ${CURRENT_TAG}"
+fi

--- a/projects/kubernetes-sigs/external-dns/Makefile
+++ b/projects/kubernetes-sigs/external-dns/Makefile
@@ -38,6 +38,10 @@ images: buildkit-check
 		--local context=. \
 		--output type=image,oci-mediatypes=true,"name=$(IMAGE)",push=true
 
+.PHONY: check-external-dns-release
+check-external-dns-release:
+	$(MAKE_ROOT)/check_upstream_external_dns_image.sh
+
 .PHONY: build
 build: local-images
 

--- a/projects/kubernetes-sigs/external-dns/check_upstream_external_dns_image.sh
+++ b/projects/kubernetes-sigs/external-dns/check_upstream_external_dns_image.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+set -o pipefail
+set -x
+
+SCRIPT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+IMAGE_TAG_FILE="${SCRIPT_ROOT}/IMAGE_TAG"
+
+UPSTREAM_IMAGE="registry.k8s.io/external-dns/external-dns"
+
+LATEST_TAG=$(skopeo list-tags "docker://${UPSTREAM_IMAGE}" \
+  | jq -r '.Tags[]' \
+  | grep -E '^v?[0-9]+\.[0-9]+\.[0-9]+$' \
+  | sort -V \
+  | tail -n1)
+
+if [ -z "$LATEST_TAG" ]; then
+  echo "Failed to determine latest upstream external-dns image tag"
+  exit 1
+fi
+
+CURRENT_TAG=$(cat "$IMAGE_TAG_FILE")
+if [ "$LATEST_TAG" != "$CURRENT_TAG" ]; then
+  echo "Updating external-dns IMAGE_TAG: ${CURRENT_TAG} -> ${LATEST_TAG}"
+  printf '%s\n' "$LATEST_TAG" > "$IMAGE_TAG_FILE"
+else
+  echo "external-dns IMAGE_TAG already at latest: ${CURRENT_TAG}"
+fi

--- a/projects/kubernetes/test-infra/Makefile
+++ b/projects/kubernetes/test-infra/Makefile
@@ -40,6 +40,10 @@ local-images: buildkit-check $(LOCAL_IMAGE_TARGETS)
 .PHONY: images
 images: buildkit-check $(IMAGE_TARGETS)	
 
+.PHONY: check-prow-release
+check-prow-release:
+	$(MAKE_ROOT)/check_upstream_prow_image.sh
+
 .PHONY: update-helm-chart
 update-helm-chart:
 	./update_helm_images.sh "$(foreach image,$(IMAGE_NAMES),$(IMAGE_REPO)/$(image):$(IMAGE_TAG))" "$(VALUES_YAML_PATHS)"

--- a/projects/kubernetes/test-infra/check_upstream_prow_image.sh
+++ b/projects/kubernetes/test-infra/check_upstream_prow_image.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+set -o pipefail
+set -x
+
+SCRIPT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+IMAGE_TAG_FILE="${SCRIPT_ROOT}/IMAGE_TAG"
+
+# All Prow components are published with the same tag, so deck is used as the reference.
+UPSTREAM_IMAGE="us-docker.pkg.dev/k8s-infra-prow/images/deck"
+
+LATEST_TAG=$(skopeo list-tags "docker://${UPSTREAM_IMAGE}" \
+  | jq -r '.Tags[]' \
+  | grep -E '^v20[0-9]{6}-[0-9a-f]+$' \
+  | sort \
+  | tail -n1)
+
+if [ -z "$LATEST_TAG" ]; then
+  echo "Failed to determine latest upstream Prow image tag"
+  exit 1
+fi
+
+CURRENT_TAG=$(cat "$IMAGE_TAG_FILE")
+if [ "$LATEST_TAG" != "$CURRENT_TAG" ]; then
+  echo "Updating Prow IMAGE_TAG: ${CURRENT_TAG} -> ${LATEST_TAG}"
+  printf '%s\n' "$LATEST_TAG" > "$IMAGE_TAG_FILE"
+else
+  echo "Prow IMAGE_TAG already at latest: ${CURRENT_TAG}"
+fi


### PR DESCRIPTION
## Summary
Adds the build-tooling side of a bi-weekly automation that detects newer upstream Prow and Athens images and opens a PR to bump the IMAGE_TAG pins, modeled on the existing `check-upstream-golang-release` flow.

- `projects/kubernetes/test-infra/check_upstream_prow_image.sh` + `check-prow-release` make target: queries `us-docker.pkg.dev/k8s-infra-prow/images/deck` via skopeo, picks the newest `vYYYYMMDD-sha` tag, updates IMAGE_TAG.
- `projects/gomods/athens/check_upstream_athens_image.sh` + `check-athens-release` make target: queries `docker.io/gomods/athens`, picks the newest semver tag, updates IMAGE_TAG.
- `pr-scripts/create_pr.sh`: handles the new `check-upstream-prow-athens-images` periodic (PR title/body and staging the two IMAGE_TAG files).

The periodic job itself is added in aws/eks-distro-prow-jobs. Merging a generated bump PR triggers the existing prow-deck-tooling and athens-tooling postsubmits to rebuild and publish the images.

## Testing
Validated the tag-selection logic returns `v20260617-37d12bec7` (prow) and `v0.18.0` (athens). Shell scripts pass `bash -n`.