### PR TITLE
Update base image PR notifier to send per-repo Slack message

### DIFF
--- a/.github/workflows/base-image-pr-notifier.yml
+++ b/.github/workflows/base-image-pr-notifier.yml
@@ -10,10 +10,16 @@ jobs:
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
           PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
         run: |
           if [[ "$PR_AUTHOR" == "eks-distro-pr-bot" && ( "$PR_TITLE" == *"Update base image"* || "$PR_TITLE" == *"Update builder-base image"* || "$PR_TITLE" == *"Update golang"* || "$PR_TITLE" == *"Update GIT_TAG and GOLANG_VERSION"* || "$PR_TITLE" == *"Update helm chart images"* ) ]]; then
-            curl -X POST $SLACK_WEBHOOK
+            payload=$(jq -n \
+              --arg repo "$GITHUB_REPOSITORY" \
+              --arg pr_title "$PR_TITLE" \
+              --arg pr_url "$PR_URL" \
+              '{repo: $repo, pr_title: $pr_title, pr_url: $pr_url}')
+            curl -X POST -H 'Content-Type: application/json' --data "$payload" "$SLACK_WEBHOOK"
             echo "Base image update detected - Slack notification sent"
           else
             echo "Not a base image update PR - Skipping notification"


### PR DESCRIPTION
Replaces the empty webhook POST with a JSON payload (repo, pr_title, pr_url) so the new Slack channel's Workflow Builder workflow renders a per-repo message linking to the actual PR.