### PR TITLE
Use IMAGE_VERSION for authenticator CRD image tag

### DIFF
--- a/release/pkg/assets_authenticator.go
+++ b/release/pkg/assets_authenticator.go
@@ -30,6 +30,13 @@ func (r *ReleaseConfig) GetAuthenticatorComponent(spec distrov1alpha1.ReleaseSpe
 	if err != nil {
 		return nil, errors.Cause(err)
 	}
+	// imageVersion is the clean upstream tag the container image was pushed with.
+	// Decoupled components write a sibling IMAGE_VERSION file; others do not, so
+	// fall back to gitTag (their image tag equals gitTag).
+	imageVersion := gitTag
+	if v, err := readTag(filepath.Join(r.BuildRepoSource, projectSource, spec.Channel, "IMAGE_VERSION")); err == nil && v != "" {
+		imageVersion = v
+	}
 	assets := []distrov1alpha1.Asset{}
 	osArchMap := map[string][]string{
 		"linux":   []string{"arm64", "amd64"},
@@ -83,7 +90,7 @@ func (r *ReleaseConfig) GetAuthenticatorComponent(spec distrov1alpha1.ReleaseSpe
 			URI: fmt.Sprintf("%s/kubernetes-sigs/%s:%s-eks-%s-%d",
 				r.ContainerImageRepository,
 				binary,
-				gitTag,
+				imageVersion,
 				spec.Channel,
 				spec.Number,
 			),


### PR DESCRIPTION
Decoupled aws-iam-authenticator publishes its container image under the clean upstream tag (IMAGE_VERSION, e.g. v0.7.18-cvefix-eks-1-31-54) while GIT_TAG holds the combined runtime version (0.0.66-v0.7.18-cvefix) used for source and S3 artifact paths. copy_internal_build_artifacts.sh writes a sibling IMAGE_VERSION file for this purpose, but the release tool still built the image URI from GIT_TAG, so the generated CRD referenced an image tag that was never pushed and UpdateImageDigests failed with ImageNotFoundException.
https://prow.eks.amazonaws.com/view/s3/prowdataclusterstack-316434458-prowbucket7c73355c-1n9f9v93wpjcm/logs/dev-release-1-31-postsubmit/2089396095963631616


Read the sibling IMAGE_VERSION file for the image asset URI, falling back to GIT_TAG when absent so non-decoupled components are unchanged. Tarball URIs keep GIT_TAG since their S3 paths use the combined version.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
